### PR TITLE
Fix homepage card navigation links

### DIFF
--- a/docusaurus/docs/index.mdx
+++ b/docusaurus/docs/index.mdx
@@ -12,7 +12,7 @@ Your comprehensive resource for all Vendasta platform tools and features. Explor
 <div className="container">
   <div className="row">
     <div className="col col--4">
-      <Link className="card-link" to="/getting-started/">
+      <Link className="card-link" to="category/getting-started">
         <div className="card">
           <div className="card__header">
             <h3>Getting Started</h3>
@@ -24,7 +24,7 @@ Your comprehensive resource for all Vendasta platform tools and features. Explor
       </Link>
     </div>
     <div className="col col--4">
-      <Link className="card-link" to="/partner-center/">
+      <Link className="card-link" to="partner-center/">
         <div className="card">
           <div className="card__header">
             <h3>Partner Center</h3>
@@ -36,7 +36,7 @@ Your comprehensive resource for all Vendasta platform tools and features. Explor
       </Link>
     </div>
     <div className="col col--4">
-      <Link className="card-link" to="/business-app/">
+      <Link className="card-link" to="business-app/">
         <div className="card">
           <div className="card__header">
             <h3>Business App</h3>
@@ -50,7 +50,7 @@ Your comprehensive resource for all Vendasta platform tools and features. Explor
   </div>
   <div className="row">
     <div className="col col--4">
-      <Link className="card-link" to="/crm/">
+      <Link className="card-link" to="category/crm">
         <div className="card">
           <div className="card__header">
             <h3>CRM</h3>
@@ -62,7 +62,7 @@ Your comprehensive resource for all Vendasta platform tools and features. Explor
       </Link>
     </div>
     <div className="col col--4">
-      <Link className="card-link" to="/marketplace/">
+      <Link className="card-link" to="category/marketplace">
         <div className="card">
           <div className="card__header">
             <h3>Marketplace</h3>
@@ -74,7 +74,7 @@ Your comprehensive resource for all Vendasta platform tools and features. Explor
       </Link>
     </div>
     <div className="col col--4">
-      <Link className="card-link" to="/marketing/">
+      <Link className="card-link" to="marketing/">
         <div className="card">
           <div className="card__header">
             <h3>Marketing</h3>
@@ -88,7 +88,7 @@ Your comprehensive resource for all Vendasta platform tools and features. Explor
   </div>
   <div className="row">
     <div className="col col--4">
-      <Link className="card-link" to="/fulfillment/">
+      <Link className="card-link" to="category/fulfillment">
         <div className="card">
           <div className="card__header">
             <h3>Fulfillment</h3>
@@ -100,7 +100,7 @@ Your comprehensive resource for all Vendasta platform tools and features. Explor
       </Link>
     </div>
     <div className="col col--4">
-      <Link className="card-link" to="/commerce/">
+      <Link className="card-link" to="category/commerce">
         <div className="card">
           <div className="card__header">
             <h3>Commerce</h3>
@@ -112,7 +112,7 @@ Your comprehensive resource for all Vendasta platform tools and features. Explor
       </Link>
     </div>
     <div className="col col--4">
-      <Link className="card-link" to="/administration/">
+      <Link className="card-link" to="administration/">
         <div className="card">
           <div className="card__header">
             <h3>Administration</h3>
@@ -126,7 +126,7 @@ Your comprehensive resource for all Vendasta platform tools and features. Explor
   </div>
   <div className="row">
     <div className="col col--4">
-      <Link className="card-link" to="/automations/">
+      <Link className="card-link" to="automations/">
         <div className="card">
           <div className="card__header">
             <h3>Automations</h3>
@@ -138,7 +138,7 @@ Your comprehensive resource for all Vendasta platform tools and features. Explor
       </Link>
     </div>
     <div className="col col--4">
-      <Link className="card-link" to="/reports/">
+      <Link className="card-link" to="reports/">
         <div className="card">
           <div className="card__header">
             <h3>Reports</h3>
@@ -150,7 +150,7 @@ Your comprehensive resource for all Vendasta platform tools and features. Explor
       </Link>
     </div>
     <div className="col col--4">
-      <Link className="card-link" to="/vendasta-products/">
+      <Link className="card-link" to="category/vendasta-products">
         <div className="card">
           <div className="card__header">
             <h3>Vendasta Products</h3>
@@ -168,7 +168,7 @@ Your comprehensive resource for all Vendasta platform tools and features. Explor
 
 New to Vendasta? Here are your essential next steps:
 
-- **[Getting Started Guides](/getting-started/)** - Essential guides to help you get up and running
+- **[Getting Started Guides](category/getting-started)** - Essential guides to help you get up and running
 - **[Partner Center Access](https://partners.vendasta.com/dashboard)** - Log in to your Partner Center dashboard
 - **[Vendasta Academy](https://academy.vendasta.com/)** - Take courses to master the platform
 


### PR DESCRIPTION
- Update category-based sections to use 'category/' prefix for auto-generated indexes
- Keep manual index sections using direct paths
- Ensure all 12 cards navigate correctly to appropriate page types
- Fix Quick Start Resources links to use category paths
- Tested all links: 100% working

Category links (auto-generated): Getting Started, CRM, Marketplace, Fulfillment, Commerce, Vendasta Products
Manual links (custom pages): Partner Center, Business App, Marketing, Administration, Automations, Reports