### PR TITLE
Update footer to white background with company website links

### DIFF
--- a/docusaurus/docusaurus.config.ts
+++ b/docusaurus/docusaurus.config.ts
@@ -104,19 +104,65 @@ const config: Config = {
       ],
     },
     footer: {
-      style: 'dark',
+      style: 'light',
       links: [
         {
-          title: 'Docs',
+          title: 'RESOURCES',
           items: [
             {
-              label: 'Getting started',
-              to: '/category/getting-started',
+              label: 'Vendasta Website',
+              href: 'https://www.vendasta.com/ai/',
+            },
+            {
+              label: 'Blog',
+              href: 'https://www.vendasta.com/blog/',
+            },
+            {
+              label: 'Content Library',
+              href: 'https://www.vendasta.com/content-library/',
+            },
+            {
+              label: 'Community',
+              href: 'https://www.facebook.com/groups/vendasta',
+            },
+          ],
+        },
+        {
+          title: 'COMPANY',
+          items: [
+            {
+              label: 'About Us',
+              href: 'https://www.vendasta.com/company/',
+            },
+            {
+              label: 'Contact',
+              href: 'https://www.vendasta.com/contact/',
+            },
+            {
+              label: 'Newsroom',
+              href: 'https://www.vendasta.com/newsroom/',
+            },
+          ],
+        },
+        {
+          title: 'LEGAL',
+          items: [
+            {
+              label: 'Terms of Service',
+              href: 'https://www.vendasta.com/terms/',
+            },
+            {
+              label: 'Privacy Policy',
+              href: 'https://www.vendasta.com/privacy/',
+            },
+            {
+              label: 'GDPR',
+              href: 'https://www.vendasta.com/gdpr/',
             },
           ],
         },
       ],
-      copyright: `Copyright © ${new Date().getFullYear()}`,
+      copyright: `Copyright © ${new Date().getFullYear()} Vendasta Technologies Inc.`,
     },
     prism: {
       theme: prismThemes.github,


### PR DESCRIPTION
- Changed footer style from 'dark' to 'light' for white background
- Restructured footer into 3 clean columns with company branding:
  * RESOURCES: Vendasta Website, Blog, Content Library, Community
  * COMPANY: About Us, Contact, Newsroom
  * LEGAL: Terms of Service, Privacy Policy, GDPR
- All section titles in ALL CAPS for consistency with company branding
- All links point to main company website URLs
- Streamlined design appropriate for documentation site
- Updated copyright to include full company name