### PR TITLE
SOC2: Add an automated check using Trivy security scan

### DIFF
--- a/.build/tfsec.yml
+++ b/.build/tfsec.yml
@@ -1,0 +1,39 @@
+steps:
+  # Run Trivy Config Scan (TFSec compatibility)
+  - id: 'tfsec-check'
+    name: 'gcr.io/repcore-prod/vendasta-terraform-trivy:1.0.0'
+    entrypoint: 'sh'
+    args:
+      - '-c'
+      - |
+        # Documentation
+        echo "################################################"
+        echo "######### tfsec/Trivy Filesystem Scan ##########"
+        echo "################################################"
+        echo "Performs static analysis for security misconfigurations."
+        echo "Official Documentation: https://github.com/aquasecurity/trivy"
+        echo "Guide: https://trivy.dev/latest/docs/"
+        
+        # Git setup
+        echo "### Git setup"
+        apk add --no-cache git
+        git remote set-url origin https://$$GITHUB_TOKEN@github.com/vendasta/partnercenter-docs.git
+        
+        # Current working branch setup
+        echo "### Current working branch setup"
+        git fetch --unshallow || true
+        git fetch origin master
+        git fetch origin "$BRANCH_NAME"
+        git checkout -b "$BRANCH_NAME" "origin/$BRANCH_NAME"
+
+        
+        # Run Trivy Filesystem Secret Scan (Only)
+        echo "### Running Trivy Config Scan"
+        trivy config --exit-code 1 --severity HIGH .
+    secretEnv:
+      - GITHUB_TOKEN
+availableSecrets:
+  secretManager:
+    - versionName: projects/repcore-prod/secrets/cloudbuild-github-token/versions/latest
+      env: GITHUB_TOKEN
+timeout: 900s

--- a/.build/tfsec.yml
+++ b/.build/tfsec.yml
@@ -27,9 +27,13 @@ steps:
         git checkout -b "$BRANCH_NAME" "origin/$BRANCH_NAME"
 
         
-        # Run Trivy Filesystem Secret Scan (Only)
+        # Run Trivy Configuration Scan (Only)
         echo "### Running Trivy Config Scan"
         trivy config --exit-code 1 --severity HIGH .
+
+        # Run Trivy Secret Scan (Only)
+        echo "### Running Trivy Config Scan"
+        trivy fs --scanners secret --exit-code 1 .
     secretEnv:
       - GITHUB_TOKEN
 availableSecrets:


### PR DESCRIPTION
## Summary
Adds Cloud Build configuration to run a [Trivy](https://github.com/aquasecurity/tfsec) scan on repository code and configuration files. The scan checks for security basic misconfigurations and potential secrets.
Setting this up to support SOC 2 compliance with regards to having [automated checks for code changes](https://delve.co/blog/github-your-soc-2-compliance-configuration-checklist).

Story: https://vendasta.jira.com/browse/VSRE-2311

## Details

- Runs Trivy filesystem for secret/key detection
- Outputs reports for audit evidence
- Configurable to fail only on CRITICAL findings

Cloud Build Trigger [here](https://console.cloud.google.com/cloud-build/triggers?project=repcore-prod&pageState=(%22triggers%22:(%22f%22:%22%255B%257B_22k_22_3A_22_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22partnercenter-docs_5C_22_22%257D%255D%22))).

## Impact
Improves automated security coverage and ensures code changes meet baseline SOC 2 requirements before merge.

@vendasta/sre 
