### PR TITLE
modified nginx to do redirects server-side as we edit our documentation

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -9,6 +9,16 @@ server {
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
     gzip_min_length 1000;
 
+    # Redirect /docs/* to /* (remove /docs prefix)
+    location ~ ^/docs(/.*)$ {
+        return 301 $1;
+    }
+
+    # Redirect /docs to / (root)
+    location = /docs {
+        return 301 /;
+    }
+
     # Main handler - serve files or fallback to index.html for SPA routing
     location / {
         try_files $uri /index.html;

--- a/nginx.conf
+++ b/nginx.conf
@@ -11,12 +11,12 @@ server {
 
     # Redirect /docs/* to /* (remove /docs prefix)
     location ~ ^/docs(/.*)$ {
-        return 301 $1;
+        return 302 $1;
     }
 
     # Redirect /docs to / (root)
     location = /docs {
-        return 301 /;
+        return 302 /;
     }
 
     # Main handler - serve files or fallback to index.html for SPA routing


### PR DESCRIPTION
We've got a lot of broken links in the platform.

At the same time, we are likely to do some adjustments of how things are structured in the near future.

For the interim, I want to do server-side redirects for all URLs with /docs/ and just strip /docs/ from the path.