### PR TITLE
add Google Tag Manager with Cookiebot

### DIFF
--- a/docusaurus/docusaurus.config.ts
+++ b/docusaurus/docusaurus.config.ts
@@ -23,6 +23,29 @@ const config: Config = {
   onBrokenLinks: 'warn',
   onBrokenMarkdownLinks: 'warn',
 
+  // Add external scripts
+  scripts: [
+    {
+      src: 'https://consent.cookiebot.com/uc.js',
+      'data-cbid': '18defc9c-f3d9-498d-b1d8-469fdf619133',
+      'data-blockingmode': 'auto',
+      async: false,
+    },
+    // Google Tag Manager
+    {
+      innerHTML: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-M8CQT5');`,
+    },
+  ],
+
+  // Add head tags
+  headTags: [
+    // Google Tag Manager (noscript) fallback will be handled in a custom component
+  ],
+
   // Enable faster builds with Rspack bundler and persistent cache
   future: {
     experimental_faster: {
@@ -154,6 +177,14 @@ const config: Config = {
             {
               label: 'Privacy Policy',
               href: 'https://www.vendasta.com/privacy/',
+            },
+            {
+              label: 'Cookie Policy',
+              to: '/legal/cookie-policy',
+            },
+            {
+              type: 'html',
+              value: '<a href="javascript:void(0)" onclick="Cookiebot.show()">Cookie Settings</a>',
             },
             {
               label: 'GDPR',

--- a/docusaurus/docusaurus.config.ts
+++ b/docusaurus/docusaurus.config.ts
@@ -4,6 +4,8 @@ import type * as Preset from '@docusaurus/preset-classic';
 
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 
+const cookiebotDomainGroupId = process.env.COOKIEBOT_DOMAIN_GROUP_ID;
+
 const config: Config = {
   title: 'Vendasta Documentation',
   tagline: 'Your comprehensive guide to Vendasta\'s platform and tools.',
@@ -25,6 +27,21 @@ const config: Config = {
 
   // Add head tags
   headTags: [
+    ...(cookiebotDomainGroupId
+      ? [
+          {
+            tagName: 'script',
+            attributes: {
+              id: 'Cookiebot',
+              src: 'https://consent.cookiebot.com/uc.js',
+              'data-cbid': cookiebotDomainGroupId,
+              'data-blockingmode': 'auto',
+              type: 'text/javascript',
+              async: 'true',
+            },
+          },
+        ]
+      : []),
     // Google Tag Manager script
     {
       tagName: 'script',

--- a/docusaurus/docusaurus.config.ts
+++ b/docusaurus/docusaurus.config.ts
@@ -4,8 +4,6 @@ import type * as Preset from '@docusaurus/preset-classic';
 
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 
-const cookiebotDomainGroupId = process.env.COOKIEBOT_DOMAIN_GROUP_ID;
-
 const config: Config = {
   title: 'Vendasta Documentation',
   tagline: 'Your comprehensive guide to Vendasta\'s platform and tools.',
@@ -27,21 +25,6 @@ const config: Config = {
 
   // Add head tags
   headTags: [
-    ...(cookiebotDomainGroupId
-      ? [
-          {
-            tagName: 'script',
-            attributes: {
-              id: 'Cookiebot',
-              src: 'https://consent.cookiebot.com/uc.js',
-              'data-cbid': cookiebotDomainGroupId,
-              'data-blockingmode': 'auto',
-              type: 'text/javascript',
-              async: 'true',
-            },
-          },
-        ]
-      : []),
     // Google Tag Manager script
     {
       tagName: 'script',
@@ -193,7 +176,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
               to: '/legal/cookie-policy',
             },
             {
-              html: '<a href="javascript:void(0)" onclick="Cookiebot.show()">Cookie Settings</a>',
+              html: '<a href="#cookie-settings" data-cookie-settings-link>Cookie Settings</a>',
             },
             {
               label: 'GDPR',

--- a/docusaurus/docusaurus.config.ts
+++ b/docusaurus/docusaurus.config.ts
@@ -23,21 +23,20 @@ const config: Config = {
   onBrokenLinks: 'warn',
   onBrokenMarkdownLinks: 'warn',
 
-  // Add external scripts
-  scripts: [
-    // Google Tag Manager - placed in <head>
+  // Add head tags
+  headTags: [
+    // Google Tag Manager script
     {
+      tagName: 'script',
+      attributes: {
+        type: 'text/javascript',
+      },
       innerHTML: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
 })(window,document,'script','dataLayer','GTM-M8CQT5');`,
     },
-  ],
-
-  // Add head tags
-  headTags: [
-    // Google Tag Manager (noscript) fallback will be handled in a custom component
   ],
 
   // Enable faster builds with Rspack bundler and persistent cache
@@ -177,8 +176,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
               to: '/legal/cookie-policy',
             },
             {
-              type: 'html',
-              value: '<a href="javascript:void(0)" onclick="Cookiebot.show()">Cookie Settings</a>',
+              html: '<a href="javascript:void(0)" onclick="Cookiebot.show()">Cookie Settings</a>',
             },
             {
               label: 'GDPR',

--- a/docusaurus/docusaurus.config.ts
+++ b/docusaurus/docusaurus.config.ts
@@ -25,13 +25,7 @@ const config: Config = {
 
   // Add external scripts
   scripts: [
-    {
-      src: 'https://consent.cookiebot.com/uc.js',
-      'data-cbid': '18defc9c-f3d9-498d-b1d8-469fdf619133',
-      'data-blockingmode': 'auto',
-      async: false,
-    },
-    // Google Tag Manager
+    // Google Tag Manager - placed in <head>
     {
       innerHTML: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],

--- a/docusaurus/src/pages/legal/cookie-policy.mdx
+++ b/docusaurus/src/pages/legal/cookie-policy.mdx
@@ -13,13 +13,13 @@ Cookies are small text files that are placed on your computer or mobile device w
 
 ## How We Use Cookies
 
-We use cookies for various purposes including:
+We use cookies to:
 
-- **Essential Cookies**: These cookies are necessary for the website to function properly. They enable core functionality such as security, network management, and accessibility.
+- **Make our website work properly** - Essential cookies that help our documentation site function correctly
+- **Understand how you use our site** - Analytics cookies that help us improve your experience  
+- **Remember your preferences** - So you don't have to set your cookie choices every time you visit
 
-- **Analytics Cookies**: These cookies help us understand how visitors interact with our website by collecting and reporting information anonymously.
-
-- **Performance Cookies**: These cookies help us improve our website's performance and user experience.
+We only use analytics and tracking cookies if you give us permission. You can change your mind at any time.
 
 ## Cookie Declaration
 
@@ -32,9 +32,13 @@ Below you will find detailed information about the cookies used on this website:
   async
 ></script>
 
-## Managing Your Cookie Preferences
+## Your Choice
 
-You can manage your cookie preferences at any time by clicking the "Cookie Settings" link in the footer of this website, or by clicking the button below:
+You control your cookie preferences:
+
+- **Change your settings anytime** - Click "Cookie Settings" in the footer
+- **Accept or decline** - Choose which cookies you're comfortable with
+- **No impact on functionality** - Essential cookies will always work to keep the site running
 
 <button 
   type="button" 
@@ -43,14 +47,14 @@ You can manage your cookie preferences at any time by clicking the "Cookie Setti
     backgroundColor: '#007bff',
     color: 'white',
     border: 'none',
-    padding: '10px 20px',
+    padding: '12px 24px',
     borderRadius: '5px',
     cursor: 'pointer',
     fontSize: '16px',
-    marginTop: '10px'
+    marginTop: '15px'
   }}
 >
-  Manage Cookie Preferences
+  Update Cookie Settings
 </button>
 
 ## Contact Us

--- a/docusaurus/src/pages/legal/cookie-policy.mdx
+++ b/docusaurus/src/pages/legal/cookie-policy.mdx
@@ -1,0 +1,67 @@
+---
+title: Cookie Policy
+description: Cookie Policy for Vendasta Partner Center Documentation
+---
+
+# Cookie Policy
+
+This Cookie Policy explains how Vendasta Technologies Inc. ("we", "us", or "our") uses cookies and similar technologies when you visit our Partner Center Documentation website (the "Service").
+
+## What Are Cookies
+
+Cookies are small text files that are placed on your computer or mobile device when you visit a website. They are widely used to make websites work more efficiently and to provide information to website owners.
+
+## How We Use Cookies
+
+We use cookies for various purposes including:
+
+- **Essential Cookies**: These cookies are necessary for the website to function properly. They enable core functionality such as security, network management, and accessibility.
+
+- **Analytics Cookies**: These cookies help us understand how visitors interact with our website by collecting and reporting information anonymously.
+
+- **Performance Cookies**: These cookies help us improve our website's performance and user experience.
+
+## Cookie Declaration
+
+Below you will find detailed information about the cookies used on this website:
+
+<script 
+  id="CookieDeclaration" 
+  src="https://consent.cookiebot.com/18defc9c-f3d9-498d-b1d8-469fdf619133/cd.js" 
+  type="text/javascript" 
+  async
+></script>
+
+## Managing Your Cookie Preferences
+
+You can manage your cookie preferences at any time by clicking the "Cookie Settings" link in the footer of this website, or by clicking the button below:
+
+<button 
+  type="button" 
+  onclick="Cookiebot.show()" 
+  style={{
+    backgroundColor: '#007bff',
+    color: 'white',
+    border: 'none',
+    padding: '10px 20px',
+    borderRadius: '5px',
+    cursor: 'pointer',
+    fontSize: '16px',
+    marginTop: '10px'
+  }}
+>
+  Manage Cookie Preferences
+</button>
+
+## Contact Us
+
+If you have any questions about this Cookie Policy, please contact us at:
+
+- **Email**: privacy@vendasta.com
+- **Website**: [www.vendasta.com/privacy/](https://www.vendasta.com/privacy/)
+
+## Updates to This Policy
+
+We may update this Cookie Policy from time to time. Any changes will be posted on this page with an updated revision date.
+
+*Last updated: September 23, 2025*

--- a/docusaurus/src/pages/legal/cookie-policy.mdx
+++ b/docusaurus/src/pages/legal/cookie-policy.mdx
@@ -5,21 +5,19 @@ description: Cookie Policy for Vendasta Partner Center Documentation
 
 # Cookie Policy
 
-This Cookie Policy explains how Vendasta Technologies Inc. ("we", "us", or "our") uses cookies and similar technologies when you visit our Partner Center Documentation website (the "Service").
+This documentation site follows [Vendasta's comprehensive Cookie Policy](https://www.vendasta.com/privacy/).
 
-## What Are Cookies
+## Documentation Site Overview
 
-Cookies are small text files that are placed on your computer or mobile device when you visit a website. They are widely used to make websites work more efficiently and to provide information to website owners.
+This documentation site uses cookies to:
 
-## How We Use Cookies
+- **Make the site work properly** - Essential cookies for functionality
+- **Improve your experience** - Analytics to help us make better documentation
+- **Remember your preferences** - So you don't have to reset cookie choices each visit
 
-We use cookies to:
+We only use analytics cookies with your permission. Essential cookies are always active to keep the site working.
 
-- **Make our website work properly** - Essential cookies that help our documentation site function correctly
-- **Understand how you use our site** - Analytics cookies that help us improve your experience  
-- **Remember your preferences** - So you don't have to set your cookie choices every time you visit
-
-We only use analytics and tracking cookies if you give us permission. You can change your mind at any time.
+**For complete details**, see our [full Cookie Policy](https://www.vendasta.com/privacy/).
 
 ## Cookie Declaration
 
@@ -37,25 +35,12 @@ Below you will find detailed information about the cookies used on this website:
 You control your cookie preferences:
 
 - **Change your settings anytime** - Click "Cookie Settings" in the footer
-- **Accept or decline** - Choose which cookies you're comfortable with
+- **Accept or decline** - Choose which cookies you're comfortable with  
 - **No impact on functionality** - Essential cookies will always work to keep the site running
 
-<button 
-  type="button" 
-  onclick="Cookiebot.show()" 
-  style={{
-    backgroundColor: '#007bff',
-    color: 'white',
-    border: 'none',
-    padding: '12px 24px',
-    borderRadius: '5px',
-    cursor: 'pointer',
-    fontSize: '16px',
-    marginTop: '15px'
-  }}
->
-  Update Cookie Settings
-</button>
+:::tip Manage Your Preferences
+You can update your cookie preferences anytime by clicking **"Cookie Settings"** in the footer of any page.
+:::
 
 ## Contact Us
 

--- a/docusaurus/src/pages/legal/privacy-preferences.mdx
+++ b/docusaurus/src/pages/legal/privacy-preferences.mdx
@@ -1,0 +1,55 @@
+---
+title: Privacy Preferences
+description: Manage your privacy and cookie preferences for Vendasta Partner Center Documentation
+---
+
+# Privacy Preferences
+
+This page allows you to manage your privacy and cookie preferences for the Vendasta Partner Center Documentation website.
+
+## Cookie Consent Management
+
+Use the button below to review and update your cookie consent preferences:
+
+<button 
+  type="button" 
+  onclick="Cookiebot.show()" 
+  style={{
+    backgroundColor: '#007bff',
+    color: 'white',
+    border: 'none',
+    padding: '15px 30px',
+    borderRadius: '5px',
+    cursor: 'pointer',
+    fontSize: '18px',
+    marginTop: '20px',
+    marginBottom: '20px'
+  }}
+>
+  Manage Cookie Preferences
+</button>
+
+## Your Rights
+
+Under applicable data protection laws, you have the following rights:
+
+- **Right to Access**: You can request information about the personal data we process about you
+- **Right to Rectification**: You can request correction of inaccurate personal data
+- **Right to Erasure**: You can request deletion of your personal data in certain circumstances
+- **Right to Restrict Processing**: You can request that we limit how we use your personal data
+- **Right to Data Portability**: You can request a copy of your personal data in a structured format
+- **Right to Object**: You can object to certain types of processing
+
+## Contact Information
+
+If you have questions about your privacy rights or how we handle your personal data, please contact us:
+
+- **Email**: privacy@vendasta.com
+- **Privacy Policy**: [www.vendasta.com/privacy/](https://www.vendasta.com/privacy/)
+- **GDPR Information**: [www.vendasta.com/gdpr/](https://www.vendasta.com/gdpr/)
+
+## Additional Resources
+
+- [Cookie Policy](/legal/cookie-policy) - Detailed information about cookies used on this site
+- [Terms of Service](https://www.vendasta.com/terms/) - Terms governing your use of Vendasta services
+- [Privacy Policy](https://www.vendasta.com/privacy/) - Our comprehensive privacy policy

--- a/docusaurus/src/theme/Root.tsx
+++ b/docusaurus/src/theme/Root.tsx
@@ -4,6 +4,24 @@ import {useLocation} from '@docusaurus/router';
 declare global {
   interface Window {
     dataLayer?: Array<Record<string, unknown>>;
+    Cookiebot?: {
+      show?: () => void;
+    };
+  }
+}
+
+const COOKIE_SETTINGS_SELECTOR = '[data-cookie-settings-link]';
+
+type CookieSettingsEvent = MouseEvent | React.MouseEvent<HTMLAnchorElement> | undefined;
+
+function openCookieSettings(event?: CookieSettingsEvent) {
+  event?.preventDefault();
+
+  if (typeof window !== 'undefined' && window.Cookiebot?.show) {
+    window.Cookiebot.show();
+  } else {
+    // eslint-disable-next-line no-console
+    console.warn('Cookiebot not available yet.');
   }
 }
 
@@ -30,6 +48,26 @@ export default function Root({children}: {children: React.ReactNode}): React.Rea
 
     // Update previous path for next navigation
     previousPathRef.current = page_path;
+  }, [location.pathname, location.search]);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return undefined;
+
+    const elements = Array.from(
+      document.querySelectorAll<HTMLAnchorElement>(COOKIE_SETTINGS_SELECTOR),
+    );
+
+    const listeners = elements.map((element) => {
+      const handler = (event: MouseEvent) => openCookieSettings(event);
+      element.addEventListener('click', handler);
+      return {element, handler};
+    });
+
+    return () => {
+      listeners.forEach(({element, handler}) => {
+        element.removeEventListener('click', handler);
+      });
+    };
   }, [location.pathname, location.search]);
   return (
     <>

--- a/docusaurus/src/theme/Root.tsx
+++ b/docusaurus/src/theme/Root.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export default function Root({children}: {children: React.ReactNode}): JSX.Element {
+  return (
+    <>
+      {/* Google Tag Manager (noscript) */}
+      <noscript>
+        <iframe 
+          src="https://www.googletagmanager.com/ns.html?id=GTM-M8CQT5"
+          height="0" 
+          width="0" 
+          style={{display: 'none', visibility: 'hidden'}}
+        />
+      </noscript>
+      {children}
+    </>
+  );
+}

--- a/docusaurus/src/theme/Root.tsx
+++ b/docusaurus/src/theme/Root.tsx
@@ -1,6 +1,36 @@
-import React from 'react';
+import React, {useEffect, useRef} from 'react';
+import {useLocation} from '@docusaurus/router';
+
+declare global {
+  interface Window {
+    dataLayer?: Array<Record<string, unknown>>;
+  }
+}
 
 export default function Root({children}: {children: React.ReactNode}): React.ReactElement {
+  const location = useLocation();
+  const previousPathRef = useRef<string>('');
+
+  // Push pageview event to dataLayer on initial load and on every route change
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    window.dataLayer = window.dataLayer || [];
+
+    const page_path = `${location.pathname}${location.search}`;
+    const payload = {
+      event: 'pageview',
+      page_path,
+      page_title: typeof document !== 'undefined' ? document.title : '',
+      page_location: typeof window !== 'undefined' ? window.location.href : '',
+      previous_path: previousPathRef.current,
+      referrer: typeof document !== 'undefined' ? document.referrer : '',
+    };
+
+    window.dataLayer.push(payload);
+
+    // Update previous path for next navigation
+    previousPathRef.current = page_path;
+  }, [location.pathname, location.search]);
   return (
     <>
       {/* Google Tag Manager (noscript) */}

--- a/docusaurus/src/theme/Root.tsx
+++ b/docusaurus/src/theme/Root.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export default function Root({children}: {children: React.ReactNode}): JSX.Element {
+export default function Root({children}: {children: React.ReactNode}): React.ReactElement {
   return (
     <>
       {/* Google Tag Manager (noscript) */}


### PR DESCRIPTION
We currently have *no* insight into how people are using the Vendasta documentation site.

This adds a GTM property (Vendasta Support) to our documentation so that we can track page views in Docusaurus in a GDPR compliant way. 

As an offshoot, this also creates a cookie policy and privacy-preferences page for compliance.