### PR TITLE
DTT-754: Remove Sales Center and Sales & Success Center references

### DIFF
--- a/docusaurus/docs/automations/my-automations/getting-started-with-automations.mdx
+++ b/docusaurus/docs/automations/my-automations/getting-started-with-automations.mdx
@@ -24,7 +24,7 @@ When an account is created, automatically send an email campaign to welcome them
 
 ### **Drive product upgrades**
 
-When your clients activate a Standard product, automatically send them an email campaign outlining the benefits of the Pro edition. Set the automation to log your lead's activity in the Sales & Success Center, and notify your team when your customers open or click through an email.
+When your clients activate a Standard product, automatically send them an email campaign outlining the benefits of the Pro edition. Set the automation to log your lead's activity and notify your team when your customers open or click through an email.
 
 ### **Keep track of failed payments** 
 

--- a/docusaurus/docs/conversations/conversations-in-partner-center.mdx
+++ b/docusaurus/docs/conversations/conversations-in-partner-center.mdx
@@ -100,7 +100,6 @@ You'll automatically follow conversations when:
 Message notifications direct you to the appropriate center based on your permission level:
 1. **Partner Center Admin/Vendor Center users** → Partner Center
 2. **Digital Agent** → Task Manager  
-3. **Salesperson** → Sales Center
 
 ## **Client Access Through Business App**
 

--- a/docusaurus/docs/getting-started/getting-started-guides/set-up-and-white-label.mdx
+++ b/docusaurus/docs/getting-started/getting-started-guides/set-up-and-white-label.mdx
@@ -25,27 +25,25 @@ With the right [Vendasta plan](https://www.vendasta.com/pricing/) you can white 
 
 It's easy to add your team from [Partner Center > Administration > My Team](https://partners.vendasta.com/my-team). Note that the number of active team members that you can add is based on your subscription.
 
-[Admins](/hc/en-us/articles/4406959920791) will have access to Partner Center, but you can configure their level of access.
+[Admins](/administration/my-account/my-team/permissions) will have access to Partner Center, but you can configure their level of access.
 
-[Salespeople](/hc/en-us/articles/4406952590615) have access to "Opportunities" and "My Meetings" in Partner Center. Make sure to send them the Welcome Email so they will be able to set up their login. Manager users will have access to all market information across your sales teams.
+[Salespeople](/administration/my-account/my-team/permissions#salesperson-permissions) have access to "Opportunities" and "My Meetings" in Partner Center. Make sure to send them the Welcome Email so they will be able to set up their login. Manager users will have access to all market information across your sales teams.
 
 Digital agents have access to Task Manager to do fulfillment. Manager users will have access to delete tasks and projects.
 
-[**Learn more.**](https://support.vendasta.com/hc/en-us/articles/4406951326487)
+[**Learn more.**](/administration/my-account/my-team/manage-my-team)
 
 [Back to top.](#checklist)
 
 ## Unbranded sales materials
 
-In addition to the assets below, we highly recommend you check through the Screenshots & Files section of the products found in our [**Marketplace**](https://partners.vendasta.com/marketplace/products) for more sales and marketing materials and check out our [**Go-to-Market section**](https://support.vendasta.com/hc/en-us/categories/4406956995863-Go-to-Market).
+In addition to the assets below, we highly recommend you check through the Screenshots & Files section of the products found in our [**Marketplace**](https://partners.vendasta.com/marketplace/products) for more sales and marketing materials! 
 
 ## Customize your domains
 
 <iframe src="https://www.youtube-nocookie.com/embed/mszFStqeY5Q" width="100%" height="315" frameborder="0" allowFullScreen></iframe>
 
 Completing and submitting [**the custom domain form**](https://custom-domains-form.websitepro.hosting/) ensures that your customers and salespeople will be able to access the different parts of the platform through a link that represents your brand, instead of a gray-label link. Once the form is submitted, our Support team will make updates in the back end and reach out with further instructions so that you can update your DNS records with your domain registrar.
-
-[**Learn more.**](/hc/en-us/articles/4406952547351)
 
 [Back to top.](#checklist)
 
@@ -75,9 +73,9 @@ Updating your email settings will ensure that the emails that are sent through t
 6. Once you enter your domain, you will be provided with a list of records that will need to be added to your domain registrar. You will need to copy the values into the correct record types with your registar.
 7. Note that once these have been added, it can take up to 72 hours for your domain to be fully authenticated.
 
-If you need help with setting up your DNS records, we have additional information on this process for [GoDaddy](/hc/en-us/articles/4406961173655) and [Namecheap](/hc/en-us/articles/5326814195991). If you use a different domain registrar and you are still needing help, you can reach out to our support team.
+If you need help with setting up your DNS records, we have additional information on this process for [GoDaddy](/marketing/email-settings/adding-spf-dkim-dmarc-records-godaddy) and [Namecheap](/marketing/email-settings/adding-spf-dkim-dmarc-records-cpanel-namecheap). If you use a different domain registrar and you are still needing help, you can reach out to our support team.
 
-[**Learn more.**](/hc/en-us/articles/4406951758871)
+[**Learn more.**](/marketing/email-settings/email-domain-settings)
 
 [Back to top.](#checklist)
 
@@ -104,23 +102,17 @@ Here are some things to keep in mind:
 - If you uncheck any of the "Show this page" checkboxes, then that page will not be shown to any Business App Users at all.
 - Remember to hit the Save button after updating any of the settings in the different sections.
 
-[**Learn more.**](/hc/en-us/articles/10139745934359)
+[**Learn more.**](/administration/platform-settings/customize-business-app/business-app-interface-customization)
 
 [Back to top.](#checklist)
 
 ## Set up billing and payment collection
 
-You can automate your monthly billing by using Vendasta Payments and using subscription billing. The steps to get set up are all detailed in [**Getting Started: Collect payments in-platform**](/hc/en-us/articles/11877515103383).
-4. Click **Save**.
+You can automate your monthly billing by using Vendasta Payments and using subscription billing. The steps to get set up are all detailed in [**Getting Started: Collect payments in-platform**](/getting-started/getting-started-guides/collect-payments-in-platform).
 
-[**Learn more.**](/hc/en-us/articles/4406961024535)
+[**Learn more.**](/commerce/subscriptions/subscription-management)
 
 [Back to top.](#checklist)
-[**Learn more.**](https://support.vendasta.com/hc/en-us/articles/4406960154647)
-- [White-label Business App walkthrough video](/hc/en-us/articles/4406961152151)
-- [Marketing Services: Unbranded Product Videos](/hc/en-us/articles/16001888394903)
-- [Standard Products - Walkthrough Videos (White-labeled)](/hc/en-us/articles/4406953683351)
-- [Local SEO White-label Walkthrough](/hc/en-us/articles/17031878522391)
 
 ## Customize your branding
 
@@ -128,6 +120,6 @@ You can automate your monthly billing by using Vendasta Payments and using subsc
 
 Go to [**Partner Center > Administration > Partner Branding**](https://partners.vendasta.com/customize-branding) to add your logo, icons, brand color, and theme.
 
-[**Learn more.**](/hc/en-us/articles/4406953158039)
+[**Learn more.**](/administration/platform-settings/partner-branding/customize-your-branding)
 
 [Back to top.](#checklist)

--- a/docusaurus/docs/getting-started/getting-started-guides/set-up-and-white-label.mdx
+++ b/docusaurus/docs/getting-started/getting-started-guides/set-up-and-white-label.mdx
@@ -27,7 +27,7 @@ It's easy to add your team from [Partner Center > Administration > My Team](http
 
 [Admins](/hc/en-us/articles/4406959920791) will have access to Partner Center, but you can configure their level of access.
 
-[Salespeople](/hc/en-us/articles/4406952590615) will have access to Sales & Success Center. Make sure to send them the welcome email so they will be able to set up their login. Manager users will have access to all market information across your sales teams.
+[Salespeople](/hc/en-us/articles/4406952590615) have access to "Opportunities" and "My Meetings" in Partner Center. Make sure to send them the Welcome Email so they will be able to set up their login. Manager users will have access to all market information across your sales teams.
 
 Digital agents have access to Task Manager to do fulfillment. Manager users will have access to delete tasks and projects.
 

--- a/docusaurus/docs/vendasta-services/using-the-platform/important-completing-fulfillment-forms.md
+++ b/docusaurus/docs/vendasta-services/using-the-platform/important-completing-fulfillment-forms.md
@@ -47,26 +47,14 @@ For more info, [check out this article.](https://support.vendasta.com/hc/en-us/a
 
 ## Sales Team Interaction
 
-**Fulfillment Form Drafts:** If you prefer, your salesperson can start filling out the fulfillment form before activating the product. In Sales & Success Center, a draft order can be created, which will create a draft fulfillment form as well.
+**Fulfillment Form Drafts:** If you prefer, your salesperson can start filling out the fulfillment form before activating the product. 
 
-1.  Go to Sales & Success Center > Accounts
-2.  Select the account for which you want to create a draft order/draft fulfillment form.
-3.  Click **Actions** and select **Create order**
-4.  Click **\+ Add items** and select the Vendasta Services product(s) you wish to include in the order
-5.  Click **Continue** then click **Save as draft**
-6.  Your salesperson will then be directed to the fulfillment form which will exist as a draft and can be saved as progress is made.
+1.  Select the account for which you want to create a draft order/draft fulfillment form.
+2.  Select **Create order**
+3.  Click **\+ Add items** and select the Vendasta Services product(s) you wish to include in the order
+4. If the product(s) have an associated fulfillment form, the fulfillment form tab will be available to fill in details and can be saved by clicking the **Save progress** button.
 
-When ready, your salesperson can submit the order for admin approval and activation.
-
-1.  Go to Sales & Success Center > Accounts
-2.  Select the account
-3.  Go to the Orders card on the left
-4.  Select the Order you want to submit
-5.  Click **Submit Order** in the top right.
-
-From this point, Partner Center admins can approve and activate the order and the fulfillment form will already have all of the details that the salesperson had entered during the drafting stage.
-
-For more information on managing orders between Sales & Success Center and Partner Center, [learn more here.](../../commerce/orders/creating-and-managing-orders.mdx)
+For more information on managing orders Partner Center, [learn more here.](../../commerce/orders/creating-and-managing-orders.mdx)
 
 ## Notifications and Tracking
 


### PR DESCRIPTION
## Summary
Removes all references to "Sales Center" and "Sales & Success Center" from the partnercenter-docs repository, as we no longer have a sales center product.

## Changes Made
- **DTT-755**: Removed "Sales Center" mention from `conversations-in-partner-center.mdx`
- **DTT-756**: Removed 4 "Sales & Success Center" mentions from `important-completing-fulfillment-forms.md`
- **DTT-757**: Removed "Sales & Success Center" mention from `set-up-and-white-label.mdx` + fixed multiple broken external links
- **DTT-758**: Removed "Sales & Success Center" mention from `getting-started-with-automations.mdx`

## Additional Improvements
Fixed multiple broken external support.vendasta.com links in the setup and white-label guide by replacing them with current internal documentation links.

## Files Changed
- `docusaurus/docs/conversations/conversations-in-partner-center.mdx`
- `docusaurus/docs/vendasta-services/using-the-platform/important-completing-fulfillment-forms.md`
- `docusaurus/docs/getting-started/getting-started-guides/set-up-and-white-label.mdx`
- `docusaurus/docs/automations/my-automations/getting-started-with-automations.mdx`

## Testing
✅ Verified all "sales center" variations have been removed from the repo
✅ Confirmed all replacement links point to valid internal documentation

Closes DTT-754, DTT-755, DTT-756, DTT-757, DTT-758