### PR TITLE
Reorder homepage sections: move Explore by Product above Quick Start …

### DIFF
--- a/docusaurus/docs/index.mdx
+++ b/docusaurus/docs/index.mdx
@@ -51,6 +51,32 @@ Your comprehensive resource for all Vendasta platform tools and features. Explor
   </div>
 </div>
 
+### Explore by Product
+
+<div className="explore-by-product-section">
+<Cards variant="plain" cols={3}>
+  <Card href="https://docs.steprep.com/" icon={useBaseUrl('/img/Reputation-Management.svg')} title="Reputation Management">
+    Partner with AI to monitor your listings, reviews, mentions, and social media presence.
+  </Card>
+
+  <Card href="https://docs.socialsmbs.com/" icon={useBaseUrl('/img/Social-Marketing.svg')} title="Social Marketing">
+    Respond to customer posts, uncover potential prospects, and discover relevant content.
+  </Card>
+
+  <Card href="https://docs.pdqs.mobi/overview" icon={useBaseUrl('/img/Local-SEO.svg')} title="LocalSEO">
+    Improve visibility online and within local maps and navigation apps.
+  </Card>
+
+  <Card href="https://docs.advertisingintelligence.io/" icon={useBaseUrl('/img/Advertising-Intelligence.svg')} title="Advertising Intelligence">
+    Bring clients' ad campaigns under one roof to see what's working across platforms.
+  </Card>
+
+  <Card href="https://docs.websitepro.hosting/" icon={useBaseUrl('/img/Wordpress-Hosting.png')} title="WordPress Hosting">
+    Launch, manage, and grow WordPress websites.
+  </Card>
+</Cards>
+</div>
+
 ### Quick Start Resources
 
 New to Vendasta? Here are your essential next steps:
@@ -117,31 +143,5 @@ New to Vendasta? Here are your essential next steps:
       </div>
     </div>
   </div>
-</div>
-
-### Explore by Product
-
-<div className="explore-by-product-section">
-<Cards variant="plain" cols={3}>
-  <Card href="https://docs.steprep.com/" icon={useBaseUrl('/img/Reputation-Management.svg')} title="Reputation Management">
-    Partner with AI to monitor your listings, reviews, mentions, and social media presence.
-  </Card>
-
-  <Card href="https://docs.socialsmbs.com/" icon={useBaseUrl('/img/Social-Marketing.svg')} title="Social Marketing">
-    Respond to customer posts, uncover potential prospects, and discover relevant content.
-  </Card>
-
-  <Card href="https://docs.pdqs.mobi/overview" icon={useBaseUrl('/img/Local-SEO.svg')} title="LocalSEO">
-    Improve visibility online and within local maps and navigation apps.
-  </Card>
-
-  <Card href="https://docs.advertisingintelligence.io/" icon={useBaseUrl('/img/Advertising-Intelligence.svg')} title="Advertising Intelligence">
-    Bring clients' ad campaigns under one roof to see what's working across platforms.
-  </Card>
-
-  <Card href="https://docs.websitepro.hosting/" icon={useBaseUrl('/img/Wordpress-Hosting.png')} title="WordPress Hosting">
-    Launch, manage, and grow WordPress websites.
-  </Card>
-</Cards>
 </div>
 

--- a/docusaurus/src/css/custom.css
+++ b/docusaurus/src/css/custom.css
@@ -474,8 +474,8 @@ h2 {
   font-size: 0.9rem;
 }
 
-/* Adjust spacing before Explore by Product to match intro text spacing */
+/* Adjust spacing for Explore by Product section in its new position */
 .explore-by-product-section {
-  margin-top: -0.25rem; /* slight reduction while maintaining some breathing room */
-  margin-bottom: var(--ifm-spacing-vertical);
+  margin-top: 2rem; /* consistent spacing after top cards section */
+  margin-bottom: 2rem; /* consistent spacing before Quick Start Resources */
 }


### PR DESCRIPTION
…Resources

- Moved 'Explore by Product' section to appear directly after the top three cards
- Positioned it above 'Quick Start Resources' section for better user flow
- Updated CSS spacing to maintain consistent padding between sections
- Preserved all existing styling including drop shadows and responsive grid layout