### PR TITLE
Fix typos across documentation

### DIFF
--- a/docusaurus/docs/ai/ai-workforce/ai-chat-receptionist/connect-the-ai-receptionist-with-shopify.md
+++ b/docusaurus/docs/ai/ai-workforce/ai-chat-receptionist/connect-the-ai-receptionist-with-shopify.md
@@ -91,7 +91,7 @@ Use the values below (replacing any placeholders) to create your version of this
 | `query` | `Body` | `string` | `Generate a full GraphQL query string using Shopify Storefront API with this format: query { products(first: 5, query: "KEYWORD") { edges { node { title handle availableForSale priceRange { minVariantPrice { amount currencyCode } } descriptionHtml } } } }, replacing KEYWORD with the user's term. Do not return just a keyword—return the entire query string exactly as shown.` |
 
 :::info
-If an API call is failing, compare the API call created by your AI Employeee with this example succesful GraphQL body. You can inspect AI Employee raw API calls in the `Conversations` tab.
+If an API call is failing, compare the API call created by your AI Employee with this example successful GraphQL body. You can inspect AI Employee raw API calls in the `Conversations` tab.
 
 <details>
 <summary>Example AI Receptionist generated GraphQL body</summary>
@@ -121,7 +121,7 @@ In this step, you’ll write the AI Receptionist’s prompt. These are the instr
 
 You can copy and paste this whole example prompt below, but you will first have to:
 -  swap out the `Category`  placeholders with a few examples of product categories in your Shopify store 
-- swap out the `Item` placeholders with examples of products that belong to the prodcut categores in your Shopify store
+- swap out the `Item` placeholders with examples of products that belong to the product categories in your Shopify store
 
 ### Example AI Receptionist Shopify prompt
 

--- a/docusaurus/docs/crm/contacts/send-yesware-campaigns-from-contacts.mdx
+++ b/docusaurus/docs/crm/contacts/send-yesware-campaigns-from-contacts.mdx
@@ -50,7 +50,7 @@ Yesware campaigns are sent out directly via the user’s Gmail or Outlook inboxe
 
 ## How to launch Yesware campaigns using Vendasta's Automations
 
-Automations give you another way to launch Yesware campaigns beyond the Contacts table. Any existing Yesware campaign can be be triggered by an automation using the `Send a Yesware campaign for the contact` step.
+Automations give you another way to launch Yesware campaigns beyond the Contacts table. Any existing Yesware campaign can be triggered by an automation using the `Send a Yesware campaign for the contact` step.
 
 Example triggers include:
 - When a contact is added to a specific list; 

--- a/docusaurus/docs/index.mdx
+++ b/docusaurus/docs/index.mdx
@@ -32,7 +32,7 @@ Your comprehensive resource for all Vendasta platform tools and features. Explor
             <h3>Business App</h3>
           </div>
           <div className="card__body">
-            <p>Your client dashboard for businesseses to manage and grow their business.</p>
+            <p>Your client dashboard for businesses to manage and grow their business.</p>
           </div>
         </div>
       </Link>

--- a/docusaurus/docs/vendasta-services/listings-claims-optimization/google-business-profile-optimization.md
+++ b/docusaurus/docs/vendasta-services/listings-claims-optimization/google-business-profile-optimization.md
@@ -20,7 +20,7 @@ The team will review the order and start the process within 2 business days. Ini
 
 Our team will work to claim and verify the listing using the information you provided. This step can take two weeks or more to complete, depending on Google's requirements and how quickly requested information is provided.
 
-You may be required to comply with one of of Google’s allowed verification methods, which can include:
+You may be required to comply with one of Google's allowed verification methods, which can include:
 * **Video Verification:** Providing a video of the physical location, equipment, or assets used by the business. In some cases, this may be a live video call.
 * **Phone Call/Text Message:** Google sends an automated call or text with a PIN to the business phone number.
 * **Postcard:** A physical postcard with a PIN is mailed to the business's physical address, which can take two weeks or more. P.O. boxes cannot be used.

--- a/docusaurus/docs/vendasta-services/listings-claims-optimization/local-listings-management.md
+++ b/docusaurus/docs/vendasta-services/listings-claims-optimization/local-listings-management.md
@@ -4,7 +4,7 @@ sidebar_label: "Local Listings Management"
 description: "An overview of the fully managed Local Listings Management service, detailing the process for claiming, optimizing, and monitoring your business listings on Google, Apple, and Bing."
 ---
 
-This guide outlines the process and expectations for the Local Listings Management service. This is a a fully managed solution where a team of specialists will claim, optimize, and monitor your business listings on Google Business Profile, Apple Business Connect, and Bing Places.
+This guide outlines the process and expectations for the Local Listings Management service. This is a fully managed solution where a team of specialists will claim, optimize, and monitor your business listings on Google Business Profile, Apple Business Connect, and Bing Places.
 
 ## The setup process
 

--- a/docusaurus/docs/vendasta-services/sales-marketing-assets/marketing-information-by-product.md
+++ b/docusaurus/docs/vendasta-services/sales-marketing-assets/marketing-information-by-product.md
@@ -6,7 +6,7 @@ description: "We have a host of information and marketing assets available in th
 
 We have a host of information and marketing assets available in the Marketplace. Go to *Screenshots and Files* at the top of each page to find valuable resources. For quick access and easy reference, here is a list of the main product pages here:
 
-*   [Local Listings Mangement](https://partners.vendasta.com/marketplace/products/MP-5DVQX5R8JBTD2RHWZLZ5BD56RTHJPW84)
+*   [Local Listings Management](https://partners.vendasta.com/marketplace/products/MP-5DVQX5R8JBTD2RHWZLZ5BD56RTHJPW84)
     
 *   [Social Media Management Standard](https://partners.vendasta.com/marketplace/products/MP-GKVMGQFB5HBKXNNKDX7SFVQPK7364FB7)
     


### PR DESCRIPTION
## Summary
- Fixed 8 typos across 6 documentation files
- Corrected misspellings: `businesseses`, `Employeee`, `succesful`, `prodcut categores`, `Mangement`
- Removed duplicate words: `one of of`, `can be be`, `a a`

## Files Changed
| File | Typo | Fix |
|------|------|-----|
| index.mdx | `businesseses` | `businesses` |
| connect-the-ai-receptionist-with-shopify.md | `Employeee` | `Employee` |
| connect-the-ai-receptionist-with-shopify.md | `succesful` | `successful` |
| connect-the-ai-receptionist-with-shopify.md | `prodcut categores` | `product categories` |
| google-business-profile-optimization.md | `one of of` | `one of` |
| send-yesware-campaigns-from-contacts.mdx | `can be be` | `can be` |
| local-listings-management.md | `a a` | `a` |
| marketing-information-by-product.md | `Mangement` | `Management` |

## Test plan
- [ ] Verify documentation renders correctly after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)