### PR TITLE
Fix broken links in conversations settings page

### DIFF
--- a/docusaurus/docs/business-app/administration/conversations-settings/index.mdx
+++ b/docusaurus/docs/business-app/administration/conversations-settings/index.mdx
@@ -19,9 +19,9 @@ Configure which messaging channels are available in Business App and access each
 
 ## Related setup guides
 - [Conversations overview](../../conversations/index.mdx)
-- [Web Chat Setup & Usage](/business-app/conversations/web-chat/)
-- [Facebook Messenger Integration](/business-app/conversations/facebook/)
-- [Instagram Messages](/business-app/conversations/instagram/)
-- [WhatsApp for Inbox](/business-app/conversations/whatsapp/whatsapp-for-inbox.mdx)
+- [Web Chat Setup & Usage](https://docs.businessapp.io/business-app/conversations/web-chat)
+- [Facebook Messenger Integration](https://docs.businessapp.io/business-app/conversations/facebook-messenger)
+- [Instagram Messages](https://docs.businessapp.io/business-app/conversations/instagram-messenger)
+- [WhatsApp for Inbox](https://docs.businessapp.io/business-app/conversations/whatsapp-for-inbox)
 - [Messaging Templates](/conversations/messaging-templates.mdx)
-- [Missed Call Text Back](./missed-call-text-back.mdx)
+- [Missed Call Text Back](../ai-workforce-communication-automation)


### PR DESCRIPTION
## Summary
- Fixed 5 broken links in the "Related setup guides" section of the Conversations Settings page
- Web Chat, Facebook Messenger, Instagram, and WhatsApp links now point to `docs.businessapp.io` where the content was migrated
- Missed Call Text Back link now points to the existing `ai-workforce-communication-automation` page

## Test plan
- [ ] Verify the 5 updated links resolve correctly
- [ ] Run `npm run build` to confirm no broken link errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)