### PR TITLE
Fix broken links in Conversations AI page

### DIFF
--- a/docusaurus/docs/business-app/conversations/conversations-ai/index.mdx
+++ b/docusaurus/docs/business-app/conversations/conversations-ai/index.mdx
@@ -22,8 +22,8 @@ Together, these components create an intelligent receptionist that knows your cl
 ## What's Included
 
 ### Setup & Training Resources
-- **[AI Website Knowledge Training](./ai-website-knowledge-training.mdx)** - Train your AI on website content and business information
-- **[Customizing Your Chatbot Behavior](./customizing-your-chatbot-behavior.mdx)** - Configure AI personality and response style
+- **[AI Website Knowledge Training](https://docs.businessapp.io/business-app/conversations/conversations-ai/ai-website-knowledge-training)** - Train your AI on website content and business information
+- **[Customizing Your Chatbot Behavior](https://docs.businessapp.io/business-app/conversations/conversations-ai/customizing-your-chatbot-behavior)** - Configure AI personality and response style
 
 ### Implementation Guides
 - **[AI-Assisted Web Chat Widget Overview](./ai-assisted-web-chat-widget-overview.mdx)** - Set up intelligent web chat for your client's website
@@ -31,7 +31,7 @@ Together, these components create an intelligent receptionist that knows your cl
 - **[Understanding Lead Capture Notifications](./understanding-lead-capture-notifications.mdx)** - Learn when leads are captured and how notifications work
 
 ### Resources & Tools
-- **[White-labeled Video for AI-Assisted WebChat Lead Capture](./white-labelled-video-for-ai-assisted-webchat-lead-capture-unified-inbox.mdx)** - Marketing materials for client presentations
+- **[White-labeled Video for AI-Assisted WebChat Lead Capture](https://docs.businessapp.io/business-app/conversations/conversations-ai/ai-assisted-web-chat-lead-capture-video)** - Marketing materials for client presentations
 
 ## AI Receptionist Capabilities
 


### PR DESCRIPTION
## Summary
- Fixed 3 broken links in the "What's Included" section of the Conversations AI page
- AI Website Knowledge Training, Customizing Your Chatbot Behavior, and White-labeled Video links now point to `docs.businessapp.io` where the content was migrated

## Test plan
- [ ] Verify the 3 updated links resolve correctly
- [ ] Run `npm run build` to confirm no broken link errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)