### PR TITLE
Fix missing space in conversations index heading

### DIFF
--- a/docusaurus/docs/conversations/index.mdx
+++ b/docusaurus/docs/conversations/index.mdx
@@ -51,7 +51,7 @@ Through Conversations, your customers can:
 - **Access conversation history** for continuity and context in all interactions
 - **Receive notifications** and updates through their preferred communication channels
 
-## What'sincluded
+## What's included
 
 ### **Core features**
 - **[Conversations in Partner Center](./conversations-in-partner-center.mdx)** - Complete messaging platform setup and usage


### PR DESCRIPTION
## Summary
- Fixed `What'sincluded` → `What's included` in the Conversations index page heading

## Test plan
- [ ] Verify the heading renders correctly on the live site at `/conversations`

🤖 Generated with [Claude Code](https://claude.com/claude-code)