### PR TITLE
docs: add A2P SMS rejection FAQ to US SMS registration

### DIFF
--- a/docusaurus/docs/business-app/conversations/sms/us-businesses-sms-registration.mdx
+++ b/docusaurus/docs/business-app/conversations/sms/us-businesses-sms-registration.mdx
@@ -72,11 +72,11 @@ Certain industries are blocked from SMS registration by US phone carriers, regar
 - Gambling (unless specifically licensed and pre-approved by carriers)
 - Multi-level marketing (MLM) programs
 
-If the business falls into one of these categories, SMS registration is not currently available.
+If the business falls into one of these categories, SMS registration is not available.
 
 **The business information doesn't match IRS records**
 
-The registration system verifies the legal business name, EIN, and address against government databases. If anything doesn't match exactly — including punctuation, abbreviations, or the registered address — the registration will be rejected. The business should use their IRS CP 575 confirmation letter to verify the exact name and address on file before submitting.
+The registration system verifies the legal business name, EIN, and address against government databases. If anything doesn't match exactly, including punctuation, abbreviations, or the registered address, the registration will be rejected. The business should use their IRS CP 575 confirmation letter to verify the exact name and address on file before submitting.
 
 **The website's privacy policy has a problem**
 
@@ -84,7 +84,7 @@ The privacy policy must be live, publicly accessible, and clearly state that the
 
 - No privacy policy exists on the website
 - The privacy policy link is broken or the page is not accessible
-- The privacy policy includes language that allows sharing or selling contact information with third parties or marketing partners
+- The privacy policy includes language that allows sharing or selling contact information with third parties or other companies
 - The privacy policy does not mention SMS messaging or how phone numbers are used
 
 **The website is missing SMS opt-in consent**
@@ -104,10 +104,10 @@ The terms and conditions must include all of the following:
 
 If the brand registration was approved but the campaign was rejected, the most common causes are:
 
-- The use case description is too vague — "communicate with customers" is not sufficient; carriers need specifics like "send appointment reminders to customers who opted in through an online booking form"
+- The use case description is too vague: "communicate with customers" is not sufficient. Carriers need specifics like "send appointment reminders to customers who opted in through an online booking form."
 - Sample messages don't include the business name
 - Sample messages don't include opt-out instructions (e.g., "Reply STOP to unsubscribe")
-- Sample messages include a public URL shortener like bit.ly or tinyurl.com — these are blocked by carriers
+- Sample messages include a public URL shortener like bit.ly or tinyurl.com. These are blocked by carriers.
 
 If the registration is rejected, the business should correct the issue and resubmit once the form shows a failed status.
 </details>

--- a/docusaurus/docs/business-app/conversations/sms/us-businesses-sms-registration.mdx
+++ b/docusaurus/docs/business-app/conversations/sms/us-businesses-sms-registration.mdx
@@ -56,6 +56,63 @@ The most common reason for a business's application being rejected is because th
 </details>
 
 <details>
+<summary><strong>Why was the registration rejected?</strong></summary>
+
+Registration rejections fall into a few common categories. Here are the most frequent reasons and what to do about each one.
+
+**The business type is not eligible**
+
+Certain industries are blocked from SMS registration by US phone carriers, regardless of whether the business is legal in the state where it operates. Businesses that sell or promote any of the following are not eligible to register:
+
+- Cannabis, CBD, hemp, or kratom products
+- Tobacco, e-cigarettes, or vaping products
+- Firearms or ammunition
+- Alcohol (direct consumer marketing)
+- Payday loans, high-interest lending, or debt settlement services
+- Gambling (unless specifically licensed and pre-approved by carriers)
+- Multi-level marketing (MLM) programs
+
+If the business falls into one of these categories, SMS registration is not currently available.
+
+**The business information doesn't match IRS records**
+
+The registration system verifies the legal business name, EIN, and address against government databases. If anything doesn't match exactly — including punctuation, abbreviations, or the registered address — the registration will be rejected. The business should use their IRS CP 575 confirmation letter to verify the exact name and address on file before submitting.
+
+**The website's privacy policy has a problem**
+
+The privacy policy must be live, publicly accessible, and clearly state that the business does not sell or share customer phone numbers with third parties. Common issues that cause rejection:
+
+- No privacy policy exists on the website
+- The privacy policy link is broken or the page is not accessible
+- The privacy policy includes language that allows sharing or selling contact information with third parties or marketing partners
+- The privacy policy does not mention SMS messaging or how phone numbers are used
+
+**The website is missing SMS opt-in consent**
+
+If customers can enter their phone number anywhere on the website, that form must include a checkbox where the customer actively agrees to receive text messages from the business. A phone number field without explicit SMS consent language is a common rejection reason.
+
+**The terms and conditions are missing required messaging language**
+
+The terms and conditions must include all of the following:
+
+- How often customers will receive messages (e.g., "Message frequency varies")
+- "Message and data rates may apply"
+- How customers can opt out (e.g., "Reply STOP to unsubscribe")
+- How customers can get help (e.g., "Reply HELP for assistance")
+
+**The campaign description or sample messages were rejected**
+
+If the brand registration was approved but the campaign was rejected, the most common causes are:
+
+- The use case description is too vague — "communicate with customers" is not sufficient; carriers need specifics like "send appointment reminders to customers who opted in through an online booking form"
+- Sample messages don't include the business name
+- Sample messages don't include opt-out instructions (e.g., "Reply STOP to unsubscribe")
+- Sample messages include a public URL shortener like bit.ly or tinyurl.com — these are blocked by carriers
+
+If the registration is rejected, the business should correct the issue and resubmit once the form shows a failed status.
+</details>
+
+<details>
 <summary><strong>How does a business find their business registration number a.k.a. EIN / Tax ID?</strong></summary>
 
 An EIN is a nine-digit number the IRS uses to identify a business for tax purposes, much like a Social Security number identifies an individual business. In the US, the Internal Revenue Service (IRS) issues a CP 575 EIN Confirmation Letter to confirm the unique Employer Identification Number (EIN) issued to a new business. The EIN provided in a CP 575 letter is required to file your company's taxes, open a business bank account, and apply for a business credit card, loan, or payroll processing. If a business does not know their EIN, they can apply for an EIN by submitting IRS Form SS-4 online.


### PR DESCRIPTION
## What changed

Adds a new **"Why was the registration rejected?"** FAQ accordion to the US SMS Registration article.

**File:** `docusaurus/docs/business-app/conversations/sms/us-businesses-sms-registration.mdx`

## New FAQ content

The new accordion covers 6 rejection categories:

1. **Ineligible business type** — cannabis/CBD, tobacco/vaping, firearms, alcohol, payday loans, MLM, gambling
2. **IRS info mismatch** — legal name, EIN, or address doesn't exactly match CP 575 records
3. **Privacy policy issues** — missing, broken link, allows third-party data sharing, doesn't mention SMS
4. **Missing SMS opt-in consent** — phone number fields on website lack explicit SMS checkbox
5. **Terms & conditions gaps** — missing STOP/HELP instructions, message frequency, or rate disclosure
6. **Campaign/sample message problems** — vague use case, missing business name or STOP language, public URL shorteners blocked