### PR TITLE
docs: extract automation history into its own page

### DIFF
--- a/docusaurus/docs/automations/automation-history.mdx
+++ b/docusaurus/docs/automations/automation-history.mdx
@@ -1,0 +1,31 @@
+---
+title: Automation History
+description: Track and review your automation execution history to analyze performance, ensure compliance, and troubleshoot issues.
+sidebar_position: 5
+---
+
+# Automation History
+
+The automation history feature allows you to track and review your automation execution history over time. This is essential for:
+
+- **Performance Analysis**: Understanding how your automations are performing
+- **Compliance**: Keeping records of automated actions
+- **Optimization**: Identifying patterns and areas for improvement
+- **Troubleshooting**: Investigating issues that occurred in the past
+
+## Accessing History Data
+
+You can access automation history through:
+
+1. **Individual Automation View**: Click on any automation to see its specific history
+2. **Global Activity View**: View activity across all automations from the main activity tab
+3. **Filtered Views**: Use filters to focus on specific time periods, automations, or statuses
+
+## What History Includes
+
+Your automation history tracks:
+- **Execution Times**: When each automation run started and completed
+- **Trigger Details**: What caused each automation to start
+- **Step-by-Step Progress**: Which steps completed successfully and which failed
+- **Data Changes**: What data was modified by each step
+- **Error Logs**: Detailed information about any failures

--- a/docusaurus/docs/automations/managing-your-automations.mdx
+++ b/docusaurus/docs/automations/managing-your-automations.mdx
@@ -59,31 +59,7 @@ This allows you to fix issues and continue automations without having to restart
 
 ## Automation History
 
-### Viewing Automation History
-
-The automation history feature allows you to track and review your automation execution history over time. This is essential for:
-
-- **Performance Analysis**: Understanding how your automations are performing
-- **Compliance**: Keeping records of automated actions
-- **Optimization**: Identifying patterns and areas for improvement
-- **Troubleshooting**: Investigating issues that occurred in the past
-
-### Accessing History Data
-
-You can access automation history through:
-
-1. **Individual Automation View**: Click on any automation to see its specific history
-2. **Global Activity View**: View activity across all automations from the main activity tab
-3. **Filtered Views**: Use filters to focus on specific time periods, automations, or statuses
-
-### What History Includes
-
-Your automation history tracks:
-- **Execution Times**: When each automation run started and completed
-- **Trigger Details**: What caused each automation to start
-- **Step-by-Step Progress**: Which steps completed successfully and which failed
-- **Data Changes**: What data was modified by each step
-- **Error Logs**: Detailed information about any failures
+For details on tracking and reviewing your automation execution history, see [Automation History](./automation-history.mdx).
 
 ## Performance Monitoring
 


### PR DESCRIPTION
## Summary
- Created a new `automation-history.mdx` page under automations
- Replaced the Automation History section in `managing-your-automations.mdx` with a link to the new page

## Test plan
- [ ] Verify the new page renders at `/automations/automation-history`
- [ ] Verify the link from managing-your-automations works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)