### PR TITLE
docs: add external link sharing article

### DIFF
--- a/docusaurus/docs/crm/my-meetings/external-link-sharing.mdx
+++ b/docusaurus/docs/crm/my-meetings/external-link-sharing.mdx
@@ -1,0 +1,170 @@
+---
+title: Share meeting recordings externally
+sidebar_label: External Link Sharing
+description: Share a public link to a meeting recording with people outside your organization using external link sharing.
+tags: [meetings, sharing, recordings, external]
+keywords: [external link sharing, public meeting link, share recording, public video link]
+---
+
+## Overview
+
+External link sharing lets you generate a public link to a meeting recording that anyone can view, even if they are not part of your organization. This is useful when you need to share a recorded meeting with a client, prospect, or external stakeholder without requiring them to log in.
+
+:::note
+Conversation intelligence features (meeting recording, AI summaries, sales coaching, and conversation scoring) are available with CRM AI Pro. See [CRM AI editions](/ai/ai-workforce/ai-sales-assistant#crm-ai-editions) for details.
+:::
+
+## Demo
+
+<div style={{position: "relative", paddingBottom: "56.25%", height: 0}}>
+  <iframe
+    src="https://drive.google.com/file/d/1Lu3hg2B0I1xwED-1WkdIRn7I-jiqf-fB/preview"
+    frameBorder="0"
+    allowFullScreen
+    style={{position: "absolute", top: 0, left: 0, width: "100%", height: "100%"}}>
+  </iframe>
+</div>
+
+## What is external link sharing?
+
+External link sharing creates a public URL for a specific meeting recording. Anyone with the link can watch the video without needing an account or login. The link only provides access to the recording itself, not to the AI summary, transcript, sales coaching, or any other meeting details.
+
+This is different from the internal **Share** button on the Meeting Details page, which controls visibility within your organization. External link sharing is designed for audiences outside your company.
+
+## Why use external link sharing?
+
+- Share a recorded demo or presentation with a prospect after a call
+- Send a meeting recap to a client who could not attend
+- Provide a recording to an external collaborator for review
+- Share a training or onboarding session with partners
+
+## Who can enable or disable external sharing?
+
+Only authorized users can enable or disable external sharing for a meeting. You are authorized if you are one of the following:
+
+- The **host** of the meeting
+- The **creator** of the meeting record
+- An **authorized user** added to the meeting
+
+You also need write access to the meeting in the CRM.
+
+:::warning
+The meeting must have a recording before external sharing can be enabled. If the meeting has not been recorded, the option to share externally will not be available.
+:::
+
+## How to share a meeting recording externally
+
+1. Open the CRM.
+2. In the left-hand menu, select **CRM**, then select **My Meetings**.
+3. Open the **Recordings** tab and locate the meeting you want to share.
+4. Click the meeting to open the **Meeting Details** page.
+5. Select the **External share** option.
+6. Enable **Public access** to generate a shareable link.
+7. Copy the link and send it to anyone you want to share the recording with.
+
+The link is ready to use immediately. Recipients can watch the recording by opening the link in any browser.
+
+## How to disable external sharing
+
+1. Open the meeting from **My Meetings** and go to the **Meeting Details** page.
+2. Select the **External share** option.
+3. Disable **Public access**.
+
+Once disabled, the public link stops working. Anyone who tries to open the link will see a not-found page.
+
+:::tip
+Disabling and re-enabling external sharing for the same meeting produces the same link. You do not need to redistribute a new URL if you temporarily disable sharing and then turn it back on.
+:::
+
+## What external viewers can see
+
+External viewers who open the public link can watch the meeting video recording. All other meeting data remains private to your organization.
+
+| Feature | Status |
+|---------|--------|
+| Meeting video recording | Available |
+| AI-generated summary | Coming soon |
+| Transcript | Coming soon |
+| Sales coaching and scores | Coming soon |
+| Action items and topics | Coming soon |
+| Guest and participant details | Coming soon |
+
+## How external links work
+
+- Each meeting gets a unique public link the first time external sharing is enabled.
+- The link stays the same even if sharing is disabled and re-enabled later.
+- The link does not expire automatically.
+- No login or account is required to view the recording.
+- The public link is independent from the internal visibility setting. Changing the internal visibility (Private, All, or Anyone with the link) does not affect the external link, and vice versa.
+
+## Best practices
+
+- **Share selectively**
+  Only enable external sharing for meetings where the recording content is appropriate for an outside audience.
+
+- **Disable sharing when no longer needed**
+  If the external audience no longer needs access, disable public access to prevent further viewing.
+
+- **Communicate context**
+  When sending the link, include a brief note explaining what the recording covers so the recipient knows what to expect.
+
+- **Check recording quality**
+  Review the recording before sharing to confirm it captured the meeting clearly and does not contain sensitive information you did not intend to share.
+
+## Frequently asked questions
+
+<details>
+<summary>Can anyone in my organization enable external sharing?</summary>
+
+No. Only the meeting host, creator, or an authorized user with write access can enable or disable external sharing.
+
+</details>
+
+<details>
+<summary>Does the external link expire?</summary>
+
+No. The link remains active as long as public access is enabled. If you disable public access, the link stops working but is not deleted. Re-enabling sharing restores the same link.
+
+</details>
+
+<details>
+<summary>Can I share the transcript or AI summary externally?</summary>
+
+No. External link sharing only provides access to the video recording. The transcript, AI summary, sales coaching, and all other meeting details remain internal.
+
+</details>
+
+<details>
+<summary>Does enabling external sharing affect internal visibility?</summary>
+
+No. External sharing and internal visibility are independent settings. Changing one does not affect the other. You can have a private internal meeting with a publicly shared recording, or vice versa.
+
+</details>
+
+<details>
+<summary>What happens if I disable external sharing?</summary>
+
+The public link immediately stops working. Anyone who clicks the link will see a not-found page. If you re-enable sharing later, the same link becomes active again.
+
+</details>
+
+<details>
+<summary>Can I track who viewed the external link?</summary>
+
+View tracking is not currently available for external links.
+
+</details>
+
+<details>
+<summary>Can I password-protect an external link?</summary>
+
+Password protection is not currently available. Anyone with the link can view the recording while public access is enabled.
+
+</details>
+
+<details>
+<summary>Why don't I see the option to share externally?</summary>
+
+External sharing requires the meeting to have a recording. If the meeting was not recorded, or if the recording is still being processed, the external share option will not appear. You also need to be the host, creator, or an authorized user for that meeting.
+
+</details>


### PR DESCRIPTION
## Summary
- Adds a new support article for the external link sharing feature under **CRM → My Meetings**
- Covers how to enable/disable public sharing, who can share, what external viewers can see, and FAQs
- Follows existing partnercenter-docs conventions (frontmatter, callouts, collapsible FAQs)
- Includes an embedded demo video from Google Drive

## Test plan
- [ ] Preview the page locally at `/crm/my-meetings/external-link-sharing`
- [ ] Verify the demo video embed loads correctly
- [ ] Confirm sidebar navigation shows the new page under My Meetings
- [ ] Review content accuracy against the shipped feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)