### PR TITLE
docs: rename Users tab permission to User Management (WARP-2314)

### DIFF
--- a/docusaurus/docs/accounts/manage-users/index.mdx
+++ b/docusaurus/docs/accounts/manage-users/index.mdx
@@ -88,7 +88,7 @@ To remove a user, click the three-dot menu next to the user, then select **Delet
 
 ## SMB self-service user management
 
-Business App users who have the **Users** tab permission enabled can manage users directly from Business App, without requiring Partner Center access. From **Administration** → **Users**, they can:
+Business App users who have the **User Management** tab permission enabled can manage users directly from Business App, without requiring Partner Center access. From **Administration** → **Users**, they can:
 
 - View all users on the account
 - Invite new team members
@@ -98,7 +98,7 @@ Business App users who have the **Users** tab permission enabled can manage user
 When a user is added or removed — whether by a partner or by an SMB user — the event is automatically logged in the CRM activity feed on both the company record and the contact record. The log includes who performed the action and which account it was for.
 
 :::tip
-To control whether an SMB user can manage other users, enable or disable the **Users** tab in that user's permissions. Users without this tab cannot see the Users page or make changes.
+To control whether an SMB user can manage other users, enable or disable the **User Management** tab in that user's permissions. Users without this tab cannot see the Users page or make changes.
 :::
 
 ## Managing the user lifecycle
@@ -157,13 +157,13 @@ Deactivate or delete the user account to prevent unauthorized access. Consider w
 <details>
 <summary>Can users change their own permission levels?</summary>
 
-Users who have the **Users** tab enabled in their permissions can edit permissions for themselves and other users on the same account. However, they cannot remove their own user account or revoke their own access to the Users tab. Partners can also manage permissions from Partner Center.
+Users who have the **User Management** tab enabled in their permissions can edit permissions for themselves and other users on the same account. However, they cannot remove their own user account or revoke their own access to the Users tab. Partners can also manage permissions from Partner Center.
 </details>
 
 <details>
 <summary>Can SMB users manage other users without Partner Center?</summary>
 
-Yes. If the **Users** tab is enabled in a user's permissions, they can invite, edit permissions for, and remove other users directly from Business App under **Administration** → **Users**.
+Yes. If the **User Management** tab is enabled in a user's permissions, they can invite, edit permissions for, and remove other users directly from Business App under **Administration** → **Users**.
 </details>
 
 <details>


### PR DESCRIPTION
## Motivation

Companion to vendasta/galaxy#31515 — the "Users" permission is being renamed to "User Management" in both BizApp and Partner Center.

## Summary

- Update 4 references to "Users" tab permission → "User Management" in manage-users docs
- Only changes references to the BizApp tab **permission name**, not UI navigation labels

[WARP-2314]

## Test Plan

- [ ] Docs build passes
- [ ] Verify updated text reads naturally in context

@vendasta/warped-tour 
@vendasta/comm-prod 
@David-of-Growth 

[WARP-2314]: https://vendasta.jira.com/browse/WARP-2314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ