### PR TITLE
docs(crm-ai): document CRM AI Pro meeting recording limits and pricing

### DIFF
--- a/docusaurus/docs/ai/ai-workforce/ai-sales-assistant.mdx
+++ b/docusaurus/docs/ai/ai-workforce/ai-sales-assistant.mdx
@@ -114,17 +114,42 @@ CRM AI is available in three editions:
 | AI Sales Assistant | N/A | Included | Included |
 | Auto CRM updates | N/A | Included | Included |
 | Chat with CRM data | N/A | Included | Included |
-| [Conversation intelligence](/crm/my-meetings/meeting-details-page) | N/A | N/A | Included |
+| [Conversation intelligence](/crm/my-meetings/meeting-details-page) | N/A | N/A | 750 minutes/month. Overages: ~$0.04/min (applies after bonus period ends). |
 | Sales coaching and conversation scoring | N/A | N/A | Included |
 | Sales frameworks (BANT, MEDDPICC, SANDLER) | N/A | N/A | Included |
 
 The **Free** edition includes core CRM features with every Business App. **Standard** adds AI Sales Assistant capabilities and custom objects. **Pro** adds conversation intelligence and sales coaching.
 
 :::note
+CRM AI Pro includes 750 minutes of meeting recording per month. Enjoy unlimited recording as a bonus until mid-2026, after which overages will be billed at approximately $0.04 per minute.
+:::
+
+:::note
 Vendasta partners receive a discount on CRM AI retail pricing. Contact your account team or visit the Marketplace for current pricing.
 :::
 
 ## FAQs
+
+<details>
+<summary>Is CRM AI priced per seat?</summary>
+
+No, what sets Vendasta CRM AI apart from traditional CRMs is that it's priced per organization. Since AI helps you scale without adding headcount, our pricing gives you unlimited seats on all plans. CRM AI Pro includes 750 minutes of meeting recording and conversation intelligence. Enjoy unlimited recording as a bonus until mid-2026, after which overages will be billed at approximately $0.04 per minute.
+
+</details>
+
+<details>
+<summary>What is Conversation Intelligence and how does it work?</summary>
+
+CRM AI Conversation Intelligence is a core feature that records, transcribes, and analyzes your virtual sales meetings. It currently supports English-language transcription for platforms like Google Meet and Microsoft Teams, generating automated meeting summaries and bulleted action items that are stored directly in your CRM record for easy follow-up. CRM AI Pro includes 750 minutes of meeting recording. Enjoy unlimited recording as a bonus until mid-2026, after which overages will be billed at approximately $0.04 per minute.
+
+</details>
+
+<details>
+<summary>Are there any limits to meeting recording?</summary>
+
+CRM AI Pro includes 750 minutes of meeting recording. Enjoy unlimited recording as a bonus until mid-2026, after which overages will be billed at approximately $0.04 per minute.
+
+</details>
 
 <details>
 <summary>Where do I access the AI Sales Assistant?</summary>

--- a/docusaurus/docs/crm/index.mdx
+++ b/docusaurus/docs/crm/index.mdx
@@ -173,6 +173,13 @@ You can view a record's source to understand how it was created or see its prope
 ## Frequently Asked Questions
 
 <details>
+<summary>Are there any limits to meeting recording?</summary>
+
+CRM AI Pro includes 750 minutes of meeting recording. Enjoy unlimited recording as a bonus until mid-2026, after which overages will be billed at approximately $0.04 per minute.
+
+</details>
+
+<details>
 <summary>Who can see these new tabs in Partner Center? Can I change this?</summary>
 
 Yes, you can control who can see the new tabs in `Partner Center` for users with admin roles, here's how:

--- a/docusaurus/docs/crm/my-meetings/meeting-details-page.mdx
+++ b/docusaurus/docs/crm/my-meetings/meeting-details-page.mdx
@@ -217,6 +217,15 @@ By using the Meeting Details page effectively, you can turn recorded meetings in
 
 ## Frequently asked questions
 
+### Plan limits and pricing
+
+<details>
+  <summary><strong>Are there any limits to meeting recording?</strong></summary>
+
+  CRM AI Pro includes 750 minutes of meeting recording. Enjoy unlimited recording as a bonus until mid-2026, after which overages will be billed at approximately $0.04 per minute.
+
+</details>
+
 ### Interaction metrics
 
 <details>


### PR DESCRIPTION
## Summary
- Document the new CRM AI Pro meeting recording allowance (750 min/mo), unlimited recording bonus through mid-2026, and ~$0.04/min overage rate across the three surfaces in this repo that discuss CRM AI Pro / Conversation Intelligence.
- Aligns with the Product Asset Update tasks from the CRM AI Pro monetization rollout (equivalent to tasks #4 "Add FAQ to Meeting Details page" and #5 "Add FAQ to CRM page", plus covering the editions/pricing cell and the related CRM AI priced-per-seat and Conversation Intelligence FAQs).

### Changes
- **`docs/crm/my-meetings/meeting-details-page.mdx`** — new "Plan limits and pricing" FAQ subsection with *Are there any limits to meeting recording?*
- **`docs/crm/index.mdx`** — same FAQ added to the CRM overview's Frequently Asked Questions section
- **`docs/ai/ai-workforce/ai-sales-assistant.mdx`**
  - Updated CRM AI editions table: Conversation intelligence Pro cell now reads `750 minutes/month. Overages: ~$0.04/min (applies after bonus period ends).`
  - Added `:::note` under the table restating the bonus window and overage rate
  - Added three FAQs at the top of the FAQs section: *Is CRM AI priced per seat?*, *What is Conversation Intelligence and how does it work?*, *Are there any limits to meeting recording?*

## Test plan
- [ ] `cd docusaurus && npm run build` succeeds
- [ ] `npm run start` — visually verify new FAQ sections render correctly on `/crm`, `/crm/my-meetings/meeting-details-page`, and `/ai/ai-workforce/ai-sales-assistant`
- [ ] Confirm editions table renders cleanly with the longer Pro cell value

🤖 Generated with [Claude Code](https://claude.com/claude-code)