### PR TITLE
docs(crm): document CRM AI field updates and Field Change History

### DIFF
--- a/docusaurus/docs/ai/ai-workforce/ai-sales-assistant.mdx
+++ b/docusaurus/docs/ai/ai-workforce/ai-sales-assistant.mdx
@@ -26,7 +26,7 @@ The AI Sales Assistant addresses these challenges by automating CRM updates and 
 
 ## What's included with the AI Sales Assistant
 
-- **Automated CRM updates:** Automatically update CRM contact and company records after customer meetings and calls, based on meeting participants and conversation content captured through meetings and sales activities
+- **Automated CRM updates:** Automatically update CRM contact, company, opportunity, and custom object records after customer meetings and calls, based on meeting participants and conversation content captured through meetings and sales activities
 - **Conversational CRM insights:** Ask natural-language questions to get specific, company-level insights from your CRM data and meeting content — no need to run reports or search through records manually
 - **Activity creation:** Create sales activities directly from the AI Sales Assistant based on meeting outcomes and CRM data, helping you stay on top of follow-ups and next steps
 
@@ -77,16 +77,23 @@ You can customize the prompt used by this capability to adjust how the AI Sales 
 
 #### Auto update CRM records
 
-The **Auto update CRM records** capability allows the AI Sales Assistant to automatically update your CRM contact and company records after each customer meeting or call.
+The **Auto update CRM records** capability allows the AI Sales Assistant to automatically update your CRM records after each customer meeting or call, including contacts, companies, opportunities, and custom object fields.
 
 - Extracts key details from meeting content captured through Conversation Intelligence
-- Updates CRM records based on meeting participants and conversation outcomes
+- Updates contact and company records based on meeting participants and conversation outcomes
+- Updates opportunity fields such as price and pipeline stage based on sales activity
+- Updates custom object fields (for example, vehicle year and model) based on conversation content
 - Creates activities based on action items and follow-ups identified during meetings
-- Keeps your CRM accurate and current without manual data entry
+- Respects field restrictions — will not update a field with a value outside defined options
 
-:::note
-Review the default update settings to ensure they align with your sales process. You can adjust which fields are updated and how the AI Sales Assistant interprets meeting data.
-:::
+**Overwrite settings:** For each field, you can configure how the AI handles existing values:
+
+- **Always overwrite:** The AI updates the field regardless of whether it already has a value
+- **Overwrite if empty:** The AI only fills in the field if it is currently empty
+
+To configure overwrite preferences, go to **Business App** > **CRM** > **AI Sales Assistant** > **Configure**. In the **Update CRM** capability, set the overwrite preference for each field.
+
+**Automation time trigger:** You can also use an automation time trigger to prompt the AI Sales Assistant to find and act on data updates on a schedule — without waiting for a meeting to trigger it.
 
 ### Step 3: Add knowledge sources
 
@@ -175,7 +182,14 @@ No. You can enable or configure each capability independently. For example, you 
 <details>
 <summary>How does the AI Sales Assistant update my CRM?</summary>
 
-After a meeting is recorded and analyzed, the AI Sales Assistant extracts relevant details from the conversation — such as participant information, discussion outcomes, and action items — and updates the corresponding CRM contact and company records automatically.
+After a meeting is recorded and analyzed, the AI Sales Assistant extracts relevant details from the conversation — such as participant information, discussion outcomes, and action items — and updates the corresponding CRM records automatically. This includes contact and company records, as well as opportunity fields (such as price and pipeline stage) and custom object fields (such as vehicle year and model). You control which fields the AI can update and whether it should always overwrite existing values or only fill in empty ones.
+
+</details>
+
+<details>
+<summary>Can I control which fields the AI Sales Assistant updates?</summary>
+
+Yes. In the **Update CRM** capability configuration, you can select which fields the AI is allowed to update and set the overwrite preference for each one — either **always overwrite** or **overwrite if empty**. The AI also respects any field restrictions you have defined, so it will never set a field to an invalid value.
 
 </details>
 

--- a/docusaurus/docs/crm/custom-objects.mdx
+++ b/docusaurus/docs/crm/custom-objects.mdx
@@ -23,6 +23,7 @@ Custom objects now support the full CRM toolkit:
 - **Automations**: trigger workflows on object create, update, list entry, or list exit — and update custom object fields from automation actions
 - **Smart lists**: segment custom object records with the same filter power as contacts and companies
 - **API support**: programmatically create, update, and sync custom object records from external systems
+- **AI Sales Assistant**: automatically update custom object fields based on sales conversations — for example, vehicle year and model updated after a meeting (requires CRM AI)
 
 ## Why use custom objects?
 
@@ -111,6 +112,22 @@ A partner creates a **Demo** object linked to opportunities with fields like:
 - Who researched
 
 Automations can then update demo records or move opportunities forward based on booking events.
+
+## Auto-update custom object fields with AI
+
+With a CRM AI subscription, the AI Sales Assistant can automatically update custom object fields based on what happens in your sales conversations — no manual entry required.
+
+For example, an automotive business can have the AI populate **vehicle year** and **model** fields after a meeting where the customer discussed their vehicle. You choose which fields the AI can update and whether it should always overwrite existing values or only fill in empty ones.
+
+To configure AI updates for custom object fields:
+
+1. Go to **Business App** > **CRM** > **AI Sales Assistant** > **Configure**
+2. In the **Update CRM** capability, find your custom object fields
+3. Set the overwrite preference for each field (**always overwrite** or **overwrite if empty**)
+
+The AI respects any field restrictions you have set — it will never populate a field with a value outside its defined options.
+
+See [AI Sales Assistant](/ai/ai-workforce/ai-sales-assistant) for full setup details.
 
 ## API support
 

--- a/docusaurus/docs/crm/index.mdx
+++ b/docusaurus/docs/crm/index.mdx
@@ -24,6 +24,7 @@ Transform your sales process with powerful relationship management tools that ke
 - **[Custom Objects](./custom-objects.mdx)**: Create custom modules to track industry-specific data like equipment, properties, or vehicles
 - **[My Meetings](./my-meetings/index.mdx)**: Schedule and manage appointments with prospects, with conversation intelligence and AI-generated summaries
 - **[Activity Feed](./activity-feed/index.mdx)**: Track all interactions and engagement history
+- **Field Change History**: View a complete audit trail of every field update — what changed, the previous and new values, and who or what made the update (available on Starter subscription and above)
 - **[Sales Teams](./sales-teams/index.mdx)**: Organize and manage your sales team performance
 - **[Leaderboard](./leaderboard/index.mdx)**: Monitor sales performance and team rankings
 
@@ -161,7 +162,7 @@ You can view a record's source to understand how it was created or see its prope
 - **`Legacy Customer List`:** Created from the legacy customer list in the `Business App` (only for Contact records), `Customer Voice`, `Website Pro`, or `Marketplace` product integration.
 - **`Bulk Import`:** Added through the bulk import process via CSV upload.
 - **`Web Chat`:** Created via the AI lead capture widget.
-- **`Form`:** Created when a user fills out a form built with the form builder.
+- **`Form`:** Created when a user fills out a form built with the form builder. Form submissions automatically overwrite the corresponding CRM fields with the submitted values.
 - **`Facebook Messenger`:** Created from conversations initiated through `Facebook Messenger`.
 - **`Google Business Messages`:** Created from conversations on `Google Business Messages`.
 - **`Instagram Messaging`:** Created from `Instagram` direct messaging.
@@ -170,6 +171,19 @@ You can view a record's source to understand how it was created or see its prope
 - **`GingrApp`:** Created through the `Gingr` integration.
 - **`Jobber`:** Created through the `Jobber` integration.
 - **`HubSpot`:** Created or updated through the `HubSpot` integration via two-way sync of Contact and Company records.
+
+## Field Change History
+
+Every field update in your CRM is logged in **Field Change History**. Whether a field was updated by a form submission, the AI Sales Assistant, a teammate, or the system, you can see exactly what the previous value was, what it changed to, and who or what made the update.
+
+To view Field Change History for any record:
+
+1. Go to **Business App** > **CRM**
+2. Open any contact, company, or opportunity record
+3. Click the **History icon** in the top right corner
+4. Review the log of changes, including the previous value, new value, and the source of each update
+
+Field Change History is available to all users on a Starter subscription or above.
 
 ## Frequently Asked Questions
 


### PR DESCRIPTION
- Expand AI Sales Assistant docs to cover opportunity and custom object field updates, overwrite settings (always overwrite / overwrite if empty), field restriction behavior, and the new automation time trigger
- Add Field Change History section to CRM overview with access instructions and subscription requirement
- Note that form submissions automatically overwrite CRM fields in Record sources
- Add AI Sales Assistant to custom objects What's new list and add a dedicated auto-update section