### PR TITLE
docs(my-meetings): remove broken image references to unblock build

### DIFF
--- a/docusaurus/docs/crm/my-meetings/book-a-meeting-from-crm-contacts.mdx
+++ b/docusaurus/docs/crm/my-meetings/book-a-meeting-from-crm-contacts.mdx
@@ -20,13 +20,7 @@ This feature **sends the contact an email** so they can choose their own time sl
 1. Navigate to `CRM` > `Contacts`.
 2. Open the contact's profile.
 3. Click the **Book a meeting** button near the top of the contact profile.
-
-   ![Book a meeting button on CRM contact profile](./img/crm/my-meetings/book-a-meeting-crm-contact.png)
-
 4. In the dialog that appears, select the **event type** you want to use for this meeting. The event type determines the booking link that is sent and the email subject and description.
-
-   ![Select event type for meeting request](./img/crm/my-meetings/meeting-request-event-select.png)
-
 5. Click **Send**.
 
 The contact receives an email containing your booking link. They click the link, choose an available date and time, and confirm the booking. The meeting is then added to your calendar automatically.

--- a/docusaurus/docs/crm/my-meetings/groups-and-service-menus.mdx
+++ b/docusaurus/docs/crm/my-meetings/groups-and-service-menus.mdx
@@ -25,23 +25,13 @@ Groups and Service Menus are shared across your organization. Any team member ca
 ### Create a Group
 
 1. Navigate to `My Meetings` > `Settings` > **Groups** tab.
-
-   ![Settings page showing Groups tab](./img/crm/my-meetings/groups-settings-tab.png)
-
 2. Click **+ New group**.
-
-   ![New group creation form](./img/crm/my-meetings/create-group.png)
-
 3. Fill in the group details:
    - **Name** — A descriptive name that invitees will see (e.g., "Jeff's Sales Meetings").
    - **Link** — A URL slug is generated automatically. You can customize it.
    - **Description** (optional) — Briefly describe the purpose of the group.
    - **Color** — Pick a color to identify the group.
-
 4. Under **Event types**, add the event types you want in the group. You can mix personal and team event types.
-
-   ![Adding event types to a group](./img/crm/my-meetings/group-event-types.png)
-
 5. Click **Create new group**.
 
 ### Share a Group link
@@ -68,23 +58,13 @@ The **General Personal Event Link** and **General Team Event Link** groups are c
 ### Create a Service Menu
 
 1. Navigate to `My Meetings` > `Settings` > **Service menu** tab.
-
-   ![Settings page showing Service menu tab](./img/crm/my-meetings/service-menu-settings.png)
-
 2. Click **+ New service menu**.
-
-   ![New service menu creation form](./img/crm/my-meetings/create-service-menu.png)
-
 3. Fill in the service menu details:
    - **Name** — A descriptive name (e.g., "Cory's Cut and Shave").
    - **Link** — A URL slug is generated automatically.
    - **Description** (optional) — Describe what customers will find here.
    - **Color** — Pick a color.
-
 4. Under **Groups & event types**, add one or more Groups and/or individual Event Types.
-
-   ![Adding groups and event types to a service menu](./img/crm/my-meetings/service-menu-groups.png)
-
 5. Click **Create service menu**.
 
 ### Share or embed a Service Menu

--- a/docusaurus/docs/crm/my-meetings/index.mdx
+++ b/docusaurus/docs/crm/my-meetings/index.mdx
@@ -93,10 +93,6 @@ Click **Create event type** to set up a new type of meeting. Fill in the event t
 
 ![New event type details](./img/crm/my-meetings/new-event-type-details.png)
 
-![In Person — host sets the location](./img/crm/my-meetings/in-person-location-type.png)
-
-![In Person — invitee sets the location](./img/crm/my-meetings/in-person-invitee-location.png)
-
 You can also configure additional options for each event type. Settings configured here override your user-level defaults for this event type only:
 
 - **General availability** - Override your default availability for this specific event type.
@@ -107,11 +103,7 @@ You can also configure additional options for each event type. Settings configur
 - **Advance notice** - Override the minimum lead time required to prevent last-minute bookings.
 - **Add to my website** - Get an embed code to add your booking form directly to a website as an inline widget. Copy and paste the code into your site's HTML wherever you want the booking form to appear.
 
-  ![Add to my website embed code](./img/crm/my-meetings/add-to-website.png)
-
 - **Limit future meetings** - Control how far into the future meetings can be scheduled. Set limits by days, weeks, months, or choose a custom date range. When the limit is reached, no time slots are shown beyond that point.
-
-  ![Limit future meetings booking horizon](./img/crm/my-meetings/booking-horizon.png)
 
 ![New event type options](./img/crm/my-meetings/new-event-type-options.png)
 

--- a/docusaurus/docs/crm/my-meetings/setting-up-calendar-integration.mdx
+++ b/docusaurus/docs/crm/my-meetings/setting-up-calendar-integration.mdx
@@ -32,8 +32,6 @@ When you first visit **My Meetings**, the setup wizard walks you through four st
 - **Google Calendar** — Click **Sign in with Google** and grant the required permissions.
 - **Microsoft 365 / Outlook.com** — Select **Microsoft 365 / Outlook.com**, then click **Sign in with Microsoft** and grant the required permissions.
 
-![Calendar connection step showing Google and Microsoft options](./img/crm/my-meetings/outlook-calendar-connect.png)
-
 ### Option B — From Meeting Settings
 
 1. Navigate to **My Meetings** from the main menu.


### PR DESCRIPTION
## Summary
- 13 image references in `docs/crm/my-meetings/` point to PNGs that were never committed in #440, causing Cloud Build to fail on every master commit since 2026-04-09
- Removes the broken `<img>` tags across 4 files and tightens the numbered lists they left gaps in
- Unblocks deployment so recent merges (including #451) can go out
- Images can be restored in a follow-up once the original author provides them

## Files changed
- `docs/crm/my-meetings/book-a-meeting-from-crm-contacts.mdx` — 2 images
- `docs/crm/my-meetings/groups-and-service-menus.mdx` — 6 images
- `docs/crm/my-meetings/index.mdx` — 4 images
- `docs/crm/my-meetings/setting-up-calendar-integration.mdx` — 1 image

## Test plan
- [x] `npm run build` passes locally (was failing before this change)
- [ ] Cloud Build check passes on this PR
- [ ] Verify the four pages still read cleanly without the screenshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)