### PR TITLE
docs(business-app): restructure administration pages

### DIFF
--- a/docusaurus/docs/business-app/administration/ai-workforce-communication-automation.mdx
+++ b/docusaurus/docs/business-app/administration/ai-workforce-communication-automation.mdx
@@ -55,6 +55,8 @@ When businesses are busy or unavailable, customers still expect prompt responses
 
 ### How to Set Up AI Voice Receptionist
 
+<img src={require('./img/business-app/voice-receptionist/ai-voice-receptionist-diagram1.jpg').default} alt="AI Voice Receptionist overview diagram" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
+
 1. **Enable the AI Voice Receptionist**
    - Navigate to **Business App > AI Workforce > AI Voice Receptionist > Configure**
    - Check "Phone call: Answer with Voice AI" and click Save
@@ -84,6 +86,8 @@ When businesses are busy or unavailable, customers still expect prompt responses
 
 ### How to Set Up Missed-Call Text Back
 
+<img src={require('./img/business-app/missed-call-text-back/image1.jpg').default} alt="Missed-call text back feature overview" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
+
 1. **Access Settings**
    - Navigate to **Business App > Administration > Inbox Settings > Phone & SMS > Settings**
 
@@ -105,7 +109,11 @@ When businesses are busy or unavailable, customers still expect prompt responses
      - Opt-out option (e.g., "Reply STOP to opt out")
    - Example: "Hi, this is [Business Name]. We noticed you tried to call but couldn't reach us. How can we assist you? Reply to this message and we'll get back to you shortly. Reply STOP to opt out."
 
+<img src={require('./img/business-app/missed-call-text-back/image2.jpg').default} alt="Missed-call text back settings" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
+
 ### How to Set Up AI-Powered SMS Responses
+
+<img src={require('./img/business-app/ai-sms-receptionist.png').default} alt="AI SMS receptionist settings" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
 
 1. **Navigate to Inbox Settings**
    - In Business App, go to **Administration > Inbox Settings**
@@ -221,13 +229,3 @@ If you receive an "unexpected error occurred" message when updating email inform
 Yes, you can disable AI responses for specific customers or conversations. Go to the conversation, click the three-dot menu, and select "Disable AI Responses."
 </details>
 
-## Screenshots
-
-![AI Voice Receptionist Diagram](./img/business-app/voice-receptionist/ai-voice-receptionist-diagram1.jpg)
-
-![Missed-Call Text Back Feature](./img/business-app/missed-call-text-back/image1.jpg)
-
-![AI SMS Receptionist Settings](./img/business-app/ai-sms-receptionist.png)
-
-
-![Missed-Call Text Back Settings](./img/business-app/missed-call-text-back/image2.jpg)

--- a/docusaurus/docs/business-app/administration/business-connections-integrations.mdx
+++ b/docusaurus/docs/business-app/administration/business-connections-integrations.mdx
@@ -43,6 +43,8 @@ Connecting your business accounts is one of the most critical steps to maximize 
 
 ### How to Access the Connections Interface
 
+<img src={require('./img/business-app/business-app-connections.png').default} alt="Business App Connections interface" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
+
 1. **Navigate to Connections**
    - In Business App, go to **Administration > Connections**
    - Toggle between **Browse** and **Manage** tabs as needed
@@ -71,6 +73,8 @@ Connecting your business accounts is one of the most critical steps to maximize 
 
 ### How to Set Up QuickBooks Integration
 
+<img src={require('./img/business-app/quickbooks/quickbooks-card.jpg').default} alt="QuickBooks integration card" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
+
 1. **Find QuickBooks Integration**
    - Navigate to **Browse** tab in Connections
    - Locate QuickBooks integration card
@@ -80,6 +84,8 @@ Connecting your business accounts is one of the most critical steps to maximize 
    - Click **Connect** button on marketing page
    - Complete pre-connect form with business information
    - Submit form to proceed to QuickBooks authorization
+
+<img src={require('./img/business-app/quickbooks/browse-tab.jpg').default} alt="QuickBooks browse tab connection process" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
 
 3. **Complete QuickBooks Authorization**
    - Enter QuickBooks credentials on sign-in page
@@ -95,6 +101,8 @@ Connecting your business accounts is one of the most critical steps to maximize 
 **Important Note**: Users must log in to Business App directly to connect QuickBooks. Partners cannot impersonate users for this connection. Only the connecting user can see and interact with QuickBooks data.
 
 ### How to Set Up SSO-Based Integrations
+
+<img src={require('./img/business-app/sso-integrations/sso-setup.jpg').default} alt="SSO integration setup process" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
 
 1. **Browse Available SSO Integrations**
    - Review applications on Connections page
@@ -117,7 +125,11 @@ Connecting your business accounts is one of the most critical steps to maximize 
    - Connection cards display for each integrated application
    - Marketing pages show "Connected" tag for active integrations
 
+<img src={require('./img/business-app/sso-integrations/connection-settings.jpg').default} alt="SSO connection settings page" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
+
 ### How to Set Up API-Key Based Integrations
+
+<img src={require('./img/api-key-based-integrations/connection-settings.png').default} alt="API-key integration connection settings" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
 
 1. **Find API-Key Integrations**
    - Look for integration cards marked "API-Key Based"
@@ -137,6 +149,8 @@ Connecting your business accounts is one of the most critical steps to maximize 
    - **Pending**: Connection in progress
 
 ### How to Configure Data Sync and Automated Review Requests
+
+<img src={require('./img/business-app/data-sync-review-requests/connection-card.jpg').default} alt="Data sync connection card" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
 
 1. **Access Connection Settings**
    - Navigate to **Manage** tab in Connections
@@ -163,6 +177,8 @@ Connecting your business accounts is one of the most critical steps to maximize 
 
 ### How to Set Up Google Analytics Connection
 
+<img src={require('./img/business-app/google-analytics/ga4-connection-1.jpg').default} alt="GA4 connection process" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
+
 1. **Access Google Analytics Integration**
    - Navigate to **Settings > Connections**
    - Click GA4 connection card
@@ -174,6 +190,8 @@ Connecting your business accounts is one of the most critical steps to maximize 
    - Select appropriate GA4 property for connection
 
 ### How to Set Up Vendor Managed Integrations
+
+<img src={require('./img/business-app/vendor-integrations/notification-email.png').default} alt="Vendor integration notification email" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
 
 1. **Access Vendor Integration Portal**
    - Navigate to **Business App Administration**
@@ -281,22 +299,3 @@ First, check the connection status in the **Manage** tab. Try disconnecting and 
 Most integrations are included with Business App, but some may require specific subscriptions (like Reputation AI Premium for automated review requests). Check the integration marketing page for pricing details.
 </details>
 
-## Screenshots
-
-![Business App Connections Interface](./img/business-app/business-app-connections.png)
-
-![QuickBooks Integration Card](./img/business-app/quickbooks/quickbooks-card.jpg)
-
-![QuickBooks Connection Process](./img/business-app/quickbooks/browse-tab.jpg)
-
-![SSO Setup Process](./img/business-app/sso-integrations/sso-setup.jpg)
-
-![Connection Settings Page](./img/business-app/sso-integrations/connection-settings.jpg)
-
-![API-Key Integration Settings](./img/api-key-based-integrations/connection-settings.png)
-
-![Data Sync Connection Card](./img/business-app/data-sync-review-requests/connection-card.jpg)
-
-![GA4 Connection Process](./img/business-app/google-analytics/ga4-connection-1.jpg)
-
-![Vendor Integration Notification](./img/business-app/vendor-integrations/notification-email.png)

--- a/docusaurus/docs/business-app/administration/business-profile-analytics-connections.mdx
+++ b/docusaurus/docs/business-app/administration/business-profile-analytics-connections.mdx
@@ -49,6 +49,8 @@ Accurate business profile information and proper analytics connections are funda
 
 ### How to Manage Your Business Profile
 
+<img src={require('./img/business-app/profile/business-profile.jpg').default} alt="Business Profile in Business App" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
+
 1. **Access Business Profile**
    - Log in to Business App
    - Navigate to **My Business > Business Profile**
@@ -73,6 +75,8 @@ Accurate business profile information and proper analytics connections are funda
 
 #### If Google Business Profile is Connected to Business App
 
+<img src={require('./img/business-app/google-business-profile/verified-tag.jpg').default} alt="Google Business Profile verified tag in Business App" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
+
 1. **Check Verification Status in Business App**
    - Navigate to your connected Google Business Profile
    - Look for verification indicators:
@@ -95,12 +99,18 @@ Accurate business profile information and proper analytics connections are funda
    - **Red shield** = Profile still needs verification
    - Follow Google's verification process if unverified
 
+<img src={require('./img/business-app/google-business-profile/blue-checkmark.jpg').default} alt="Blue checkmark indicating verified Google Business Profile" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
+
+<img src={require('./img/business-app/google-business-profile/red-shield.jpg').default} alt="Red shield indicating unverified Google Business Profile" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
+
 3. **Complete Verification Process**
    - Follow Google's verification requirements
    - Options may include phone verification, postcard verification, or instant verification
    - [Complete verification using Google's official guide](https://support.google.com/business/answer/7107242?hl=en)
 
 ### How to Connect Google Analytics
+
+<img src={require('./img/business-app/google-analytics/ga4-connection-1.jpg').default} alt="GA4 connection card in Business App" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
 
 1. **Access Google Analytics Connection**
    - Navigate to **Business App > Settings > Connections**
@@ -110,6 +120,8 @@ Accurate business profile information and proper analytics connections are funda
    - Click on GA4 connection card
    - Marketing page opens with integration details
    - Click **Add Connection** to begin setup process
+
+<img src={require('./img/business-app/google-analytics/ga4-connection-2.jpg').default} alt="GA4 marketing page with Add Connection button" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
 
 3. **Complete Google Analytics Authorization**
    - Sign in to your Google account when prompted
@@ -255,16 +267,3 @@ Update your information in the Business Profile section of Business App. This sh
 Connecting Google Analytics and Google Business Profile to Business App is typically included with your subscription. However, you must have active Google accounts for these services.
 </details>
 
-## Screenshots
-
-![Business Profile in Business App](./img/business-app/profile/business-profile.jpg)
-
-![Google Business Profile Verified Tag](./img/business-app/google-business-profile/verified-tag.jpg)
-
-![Blue Checkmark Verification](./img/business-app/google-business-profile/blue-checkmark.jpg)
-
-![Red Shield Unverified](./img/business-app/google-business-profile/red-shield.jpg)
-
-![GA4 Connection Card](./img/business-app/google-analytics/ga4-connection-1.jpg)
-
-![GA4 Marketing Page](./img/business-app/google-analytics/ga4-connection-2.jpg)

--- a/docusaurus/docs/business-app/administration/custom-content-advanced-configuration.mdx
+++ b/docusaurus/docs/business-app/administration/custom-content-advanced-configuration.mdx
@@ -49,11 +49,15 @@ Advanced configuration options allow businesses to customize Business App to mat
 
 ### How to Configure Guides in Business App
 
+<img src={require('./img/business-app/guides/guides-location.jpg').default} alt="Guides location in Business App navigation" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
+
 1. **Enable Guides Section**
    - Navigate to **Partner Center > Administration > Customize Business App**
    - Select the **Guides** tab
    - Check **'Show this page'** to enable Guides for Business App users
    - Click **Save** to apply changes
+
+<img src={require('./img/business-app/guides/enable-guides.jpg').default} alt="Enabling Guides in Business App settings" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
 
 2. **Choose Content Source**
    - **Option 1**: Use Vendasta's pre-written white-label content (default)
@@ -63,6 +67,8 @@ Advanced configuration options allow businesses to customize Business App to mat
    - Navigate to **Business App > Administration > Guides**
    - Browse available guides and educational content
    - Access industry-specific information and best practices
+
+<img src={require('./img/business-app/guides/guides-section.jpg').default} alt="Guides section in Business App" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
 
 ### How to Set Up WordPress Blog Integration
 
@@ -74,6 +80,8 @@ Advanced configuration options allow businesses to customize Business App to mat
    - Check **Use your own WordPress blog**
    - Enter your **WordPress blog URL**
    - **Important**: Use the actual blog URL (e.g., `https://www.yoursite.com/blog`), not your homepage URL
+
+<img src={require('./img/business-app/guides/wordpress-blog-url.jpg').default} alt="WordPress blog URL configuration" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
 
 3. **Configure Content Filtering** (Optional)
    - Enter WordPress **tag IDs** to filter content
@@ -106,6 +114,8 @@ Advanced configuration options allow businesses to customize Business App to mat
    - Click on the tag you want to use for filtering
    - In the browser URL, find the number after **tag_ID=**
    - Example: In `https://website.com/wp-admin/term.php?taxonomy=post_tag&tag_ID=4&post_type=post`, the tag ID is **4**
+
+<img src={require('./img/business-app/guides/wordpress-tag-id.jpg').default} alt="WordPress tag ID in browser URL" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
 
 5. **Use Multiple Tag IDs**
    - Enter multiple tag IDs separated by commas
@@ -268,14 +278,3 @@ WordPress content typically updates in Business App within a few hours of publis
 The best way to preview is to test the integration in Business App after configuration. Ensure your WordPress content is mobile-friendly and displays well in the Business App interface.
 </details>
 
-## Screenshots
-
-![Guides Location in Business App](./img/business-app/guides/guides-location.jpg)
-
-![Enabling Guides in Business App](./img/business-app/guides/enable-guides.jpg)
-
-![WordPress Blog URL Configuration](./img/business-app/guides/wordpress-blog-url.jpg)
-
-![WordPress Tag ID Example](./img/business-app/guides/wordpress-tag-id.jpg)
-
-![Guides Section in Business App](./img/business-app/guides/guides-section.jpg)

--- a/docusaurus/docs/business-app/administration/financial-management-client-billing.mdx
+++ b/docusaurus/docs/business-app/administration/financial-management-client-billing.mdx
@@ -54,6 +54,8 @@ Effective financial management tools are essential for maintaining healthy clien
 
 ### How to Access and Use Order Management
 
+<img src={require('./img/business-app/orders/order-details.jpg').default} alt="Business App Orders interface" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
+
 1. **Access Orders Interface**
    - Log in to Business App
    - Navigate to **Orders** section
@@ -71,7 +73,11 @@ Effective financial management tools are essential for maintaining healthy clien
    - Use CSV data for accounting or reporting purposes
    - Maintain offline records of order history
 
+<img src={require('./img/business-app/orders/csv-download.jpg').default} alt="CSV download option in Orders" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
+
 ### How to Manage Invoices
+
+<img src={require('./img/business-app/invoices.png').default} alt="Business App Invoices tab" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
 
 1. **Access Invoice Interface**
    - Navigate to **Business App > Invoices** tab
@@ -104,6 +110,8 @@ Effective financial management tools are essential for maintaining healthy clien
 
 ### How to Manage Payment Methods
 
+<img src={require('./img/business-app/credit-card/add-payment-method-1.jpg').default} alt="Add payment method screen" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
+
 1. **Access Payment Settings**
    - Navigate to **Business App > Settings > Billing Settings**
    - Click **Add Payment Method** to add new payment options
@@ -114,6 +122,8 @@ Effective financial management tools are essential for maintaining healthy clien
    - Verify and save payment method
    - Set as default payment method if desired
 
+<img src={require('./img/business-app/credit-card/add-payment-method-2.jpg').default} alt="Payment method details form" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
+
 3. **Update Payment Methods**
    - Access existing payment methods in billing settings
    - Update expiration dates, billing addresses, or card numbers
@@ -121,6 +131,8 @@ Effective financial management tools are essential for maintaining healthy clien
    - Manage multiple payment methods as needed
 
 ### How to Set Up QuickBooks Integration
+
+<img src={require('./img/business-app/quickbooks/quickbooks-connection-card.jpg').default} alt="QuickBooks connection card" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
 
 1. **Navigate to QuickBooks Connection**
    - Go to **Business App > Settings > Connections**
@@ -133,11 +145,17 @@ Effective financial management tools are essential for maintaining healthy clien
    - Enter QuickBooks credentials on sign-in page
    - Grant permission for Business App to connect
 
+<img src={require('./img/business-app/quickbooks/quickbooks-login.jpg').default} alt="QuickBooks login screen" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
+
+<img src={require('./img/business-app/quickbooks/quickbooks-connect-permission.jpg').default} alt="QuickBooks permission screen" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
+
 3. **Manage QuickBooks Connection**
    - View connection status in **Manage** tab
    - Access QuickBooks Online directly from Business App navigation
    - Monitor data synchronization between systems
    - Troubleshoot connection issues if needed
+
+<img src={require('./img/business-app/quickbooks/established-connection.jpg').default} alt="QuickBooks established connection" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
 
 **Important Requirements**:
 - User must log in to Business App directly (cannot be impersonated)
@@ -250,22 +268,3 @@ Clients can update billing information by accessing **Settings > Billing Setting
 If the QuickBooks connection is disrupted, clients will need to re-authorize the connection through the Connections page. Data synchronization will resume once the connection is re-established.
 </details>
 
-## Screenshots
-
-![Business App Orders Interface](./img/business-app/orders/order-details.jpg)
-
-![CSV Download Option](./img/business-app/orders/csv-download.jpg)
-
-![Business App Invoices Tab](./img/business-app/invoices.png)
-
-![Add Payment Method Screen](./img/business-app/credit-card/add-payment-method-1.jpg)
-
-![Payment Method Details](./img/business-app/credit-card/add-payment-method-2.jpg)
-
-![QuickBooks Connection Card](./img/business-app/quickbooks/quickbooks-connection-card.jpg)
-
-![QuickBooks Login Screen](./img/business-app/quickbooks/quickbooks-login.jpg)
-
-![QuickBooks Permission Screen](./img/business-app/quickbooks/quickbooks-connect-permission.jpg)
-
-![QuickBooks Established Connection](./img/business-app/quickbooks/established-connection.jpg)

--- a/docusaurus/docs/business-app/administration/index.mdx
+++ b/docusaurus/docs/business-app/administration/index.mdx
@@ -5,40 +5,30 @@ sidebar_label: Administration
 sidebar_position: 0
 ---
 
-import DocCardList from '@theme/DocCardList';
-
 # Business App Administration
 
-The **Business App Administration** section provides comprehensive management tools for configuring and optimizing your Business App experience. This centralized hub gives you control over AI-powered communication features, third-party integrations, financial management, and advanced customization options.
+## What can you manage in the Administration section?
 
-## Core Administration Areas
+The **Business App Administration** section provides comprehensive management tools for configuring and optimizing your Business App experience. Your dashboard relies on key configurations that determine how leads are captured, communications are handled, and automations are triggered. Everything in Administration works together to ensure that:
 
-The Administration section is organized into five main areas, each designed to handle specific aspects of your Business App management:
+- Your tools are connected and synced correctly
+- AI and messaging features are properly configured
+- Workflows and communication channels are set up in a way that streamlines your operations
 
-### [AI Workforce & Communication Automation](./ai-workforce-communication-automation.mdx)
-Configure AI-powered communication tools including AI Voice Receptionist, missed-call text back, and automated SMS responses for 24/7 customer support and lead capture.
+Keeping these foundational settings aligned improves daily operations and makes your system easier to manage over time.
 
-### [Business Connections & Third-Party Integrations](./business-connections-integrations.mdx)
-Connect Google Business Profile, QuickBooks, social media accounts, and other third-party services with automated data sync and review request workflows.
+## Core areas
 
-### [Financial Management & Client Billing](./financial-management-client-billing.mdx)
-Manage orders, invoices, payment methods, and QuickBooks integration for streamlined financial operations and client self-service capabilities.
+- [AI Workforce & Communication Automation](./ai-workforce-communication-automation.mdx) — Configure AI-powered communication tools including AI Voice Receptionist, missed-call text back, and automated SMS responses for 24/7 customer support and lead capture.
+- [Business Connections & Third-Party Integrations](./business-connections-integrations.mdx) — Connect Google Business Profile, QuickBooks, social media accounts, and other third-party services with automated data sync and review request workflows.
+- [Financial Management & Client Billing](./financial-management-client-billing.mdx) — Manage orders, invoices, payment methods, and QuickBooks integration for streamlined financial operations and client self-service capabilities.
+- [Business Profile & Analytics Connections](./business-profile-analytics-connections.mdx) — Maintain business profile information, verify Google Business Profile listings, and connect Google Analytics for comprehensive business data tracking.
+- [Custom Content & Advanced Configuration](./custom-content-advanced-configuration.mdx) — Configure custom guides, WordPress integration, and advanced workflow triggers for specialized business requirements and custom content management.
 
-### [Business Profile & Analytics Connections](./business-profile-analytics-connections.mdx)
-Maintain business profile information, verify Google Business Profile listings, and connect Google Analytics for comprehensive business data tracking.
+## Getting started
 
-### [Custom Content & Advanced Configuration](./custom-content-advanced-configuration.mdx)
-Configure custom guides, WordPress integration, and advanced workflow triggers for specialized business requirements and custom content management.
-
-## Getting Started
-
-1. **Start with [AI Workforce & Communication Automation](./ai-workforce-communication-automation.mdx)** to set up 24/7 customer communication tools
-2. **Set up [Business Connections & Third-Party Integrations](./business-connections-integrations.mdx)** to connect your essential business tools
-3. **Organize [Financial Management & Client Billing](./financial-management-client-billing.mdx)** for streamlined client financial interactions
-4. **Maintain [Business Profile & Analytics Connections](./business-profile-analytics-connections.mdx)** for consistent business information
-5. **Explore [Custom Content & Advanced Configuration](./custom-content-advanced-configuration.mdx)** for specialized customization needs
-
-Each section contains detailed guides and step-by-step instructions to help you configure your Business App according to your specific business requirements.
-
-<DocCardList />
-- [Let clients review their orders and contract details](/business-app/administration/orders).
+1. Start with [AI Workforce & Communication Automation](./ai-workforce-communication-automation.mdx) to set up 24/7 customer communication tools.
+2. Set up [Business Connections & Third-Party Integrations](./business-connections-integrations.mdx) to connect your essential business tools.
+3. Organize [Financial Management & Client Billing](./financial-management-client-billing.mdx) for streamlined client financial interactions.
+4. Maintain [Business Profile & Analytics Connections](./business-profile-analytics-connections.mdx) for consistent business information.
+5. Explore [Custom Content & Advanced Configuration](./custom-content-advanced-configuration.mdx) for specialized customization needs.


### PR DESCRIPTION
## Summary

- Reformatted the Administration index page to match the structure of docs.businessapp.io — replaced the verbose section descriptions and redundant getting started list with a "What can you manage?" intro, bullet list of core areas with em-dash descriptions, and a clean numbered getting started section
- Moved all screenshots out of bottom-of-page "Screenshots" sections and into their relevant setup sections across all 5 administration pages, using the Docusaurus `<img>` format with standard border/shadow styling

## Test plan

- [ ] Review index page at `/business-app/administration`
- [ ] Review each of the 5 administration sub-pages to confirm screenshots appear inline with their relevant steps
- [ ] Confirm no broken image references

🤖 Generated with [Claude Code](https://claude.com/claude-code)