### PR TITLE
docs(ai-workforce): add AI Human Resources Coordinator Setup page

### DIFF
--- a/docusaurus/docs/vendasta-services/ai-workforce-setup/ai-human-resources-coordinator-setup.md
+++ b/docusaurus/docs/vendasta-services/ai-workforce-setup/ai-human-resources-coordinator-setup.md
@@ -1,0 +1,219 @@
+---
+title: "AI Human Resources Coordinator Setup: Service Expectations"
+sidebar_label: "AI Human Resources Coordinator Setup"
+description: "An overview of the AI Human Resources Coordinator Setup service, detailing the process from the fulfillment form through onboarding, HR Coordinator configuration, training, and the 30-day check-in."
+---
+
+:::info Requirements
+**Conversations AI** must be active on your account. See the full [requirements](#requirements) below.
+:::
+
+The AI Human Resources Coordinator Setup is a do-it-with-me service where our experts configure, train, and launch the AI Human Resources Coordinator for your business. Our team handles the technical setup, configures the PolicyScope framework, sets up your escalation contacts, uploads all HR policy documents and handbooks to the knowledge base, and connects optional capabilities such as appointment booking.
+
+## What's included?
+
+### AI Employee profile
+
+We create a custom AI Employee with a name and avatar that represents your HR team. Employees interact with a professional HR persona that is warm, accurate, and appropriately cautious with sensitive topics. The profile is configured within the **AI Workforce** section of Business App.
+
+### PolicyScope framework
+
+We configure the PolicyScope framework — a three-level routing system that governs how the AI handles every HR inquiry:
+
+* **Level 1 (General questions):** The AI answers directly from the knowledge base and links to the relevant policy document.
+* **Level 2 (Personal or sensitive questions):** The AI acknowledges the question, explains that it requires a human, and redirects warmly to your designated HR contact.
+* **Level 3 (Out of scope):** The AI declines the question politely and directs the employee to the appropriate department (IT, Finance, Legal, etc.).
+
+:::note
+The AI will never guess or fabricate answers to personal questions — it is designed to redirect before it over-reaches.
+:::
+
+### Escalation contact configuration
+
+We populate the Level 2 redirect language with your actual HR contact's name, role, phone, and email — so employees receive a clear, specific direction rather than a generic "speak to HR" message. Additional escalation contacts for Level 3 (IT, Finance, Legal) can be added at any time.
+
+### Knowledge base setup
+
+We upload every policy document, employee handbook, benefit guide, onboarding checklist, and FAQ provided during setup. This is the most critical step — the AI can only answer questions it has been given the information to answer.
+
+:::note
+The AI HR Coordinator is an internal tool and does not require a chat widget or website installation. No code will be added to your public website.
+:::
+
+### Optional: Appointment booking
+
+If your HR team uses a connected Google, Outlook, or Microsoft calendar in Business App, we can enable the AI to schedule meetings with HR team members directly in the conversation.
+
+### Optional: Google Drive sync
+
+If your HR policies are stored and maintained in Google Drive, we can configure an automated sync so that policy updates in your Drive folder are automatically reflected in the AI's knowledge base. This requires brief access to your Google Drive folder structure.
+
+## The setup process
+
+The process involves a fulfillment form, a series of calls, and configuration steps to get your AI Human Resources Coordinator running effectively.
+
+### 1. Fulfillment form
+
+To ensure a smooth and efficient setup, please fill out the fulfillment form with as much detail as possible. Include your escalation contact's full name, role, and contact information — this is required to configure the AI's handoff logic.
+
+* **Timeline:** We'll review the order and start the process within 2 business days.
+
+### 2. Onboarding call
+
+Our team will lead a structured onboarding call to understand your HR workflows, the types of questions employees most commonly ask, and how you'd like sensitive or personal inquiries handled. We'll configure the PolicyScope framework — a three-level routing system that answers general questions directly, redirects personal inquiries to your HR contact, and declines out-of-scope questions gracefully. We will come to the call with an initial setup ready to demo and refine together.
+
+* **Timeline:** An onboarding call can be booked in as little as 1 business day, depending on availability.
+
+:::note
+If you are unable to attend the onboarding call, our team will proceed with setup using the information provided in your fulfillment form and will follow up via email and phone to review and refine. If we are unable to reach you after our follow-up process, the project will be closed — but can be reopened at any time by reaching back out to us.
+:::
+
+### 3. HR Coordinator setup
+
+Using the information gathered during the onboarding call, we will configure your AI HR Coordinator with the PolicyScope framework, set up your escalation contacts, upload all HR policy documents and handbooks to the knowledge base, and connect optional capabilities such as appointment booking if required.
+
+* **Timeline:** Your AI Human Resources Coordinator will be complete in 1 business day, or 3 business days for setups with large or complex policy libraries.
+
+### 4. Training call
+
+This call will walk you through your AI HR Coordinator — how it handles general policy questions, how it redirects personal or sensitive inquiries, and where it declines out-of-scope requests. We'll test it live together and answer any questions your team has before go-live.
+
+* **Timeline:** This call can be booked in as little as 1 business day after HR Coordinator Setup completion, depending on availability.
+
+### 5. 30-day check-in
+
+This call will be used to review real employee interactions, assess whether the AI is routing questions correctly across all three PolicyScope levels, and refine the knowledge base or escalation contacts based on actual usage.
+
+:::note
+Prior to this call, our team will review 5–10 conversations to identify gaps in the knowledge base and highlight where the AI is performing well.
+:::
+
+* **Timeline:** This call will be booked 3–4 weeks after the completion of your HR Coordinator Setup.
+
+## Requirements
+
+To set your business up for success, the following requirements must be met to deliver this service efficiently.
+
+### Conversations AI
+
+**Conversations AI** must be active on your account. This is the platform requirement for deploying the AI Human Resources Coordinator.
+
+### Escalation contact information
+
+We require the full name, role/title, phone number, and email address of the HR team member who should receive escalated inquiries. This contact is embedded directly into the AI's Level 2 redirect response so employees always know exactly who to reach out to.
+
+:::note
+If there are multiple escalation contacts for different departments (e.g. IT for technical issues, Finance for payroll questions), please have those names and contact details ready as well.
+:::
+
+### HR policy documents and handbook
+
+All HR policies, employee handbooks, benefit guides, onboarding and offboarding documentation, and any other materials employees regularly ask about. These documents form the AI's entire knowledge base — the more complete and current they are, the more accurately the AI can respond.
+
+:::tip
+The AI HR Coordinator cannot answer questions about information it has not been given. We strongly recommend providing current, written versions of all policies before the setup call.
+:::
+
+### No website installation required
+
+The AI HR Coordinator is an internal tool — no chat widget or website embed code is required. There are no external accounts, social integrations, or customer-facing installations involved in this setup.
+
+## Frequently asked questions (FAQs)
+
+<details>
+
+<summary>What types of HR questions can the AI HR Coordinator answer?</summary>
+
+The AI HR Coordinator is designed to answer general, policy-based HR questions: how many PTO days employees receive, what the leave request process looks like, where to find the benefits guide, and similar inquiries that have a clear written answer in your HR documentation. It will also link directly to the relevant policy document wherever possible, so employees can read the full context themselves.
+
+</details>
+
+<details>
+
+<summary>What happens when an employee asks something personal or sensitive?</summary>
+
+When a question is personal — such as a salary inquiry, a performance concern, or a disciplinary matter — the AI will not attempt to answer. Instead, it acknowledges the question warmly, explains that this type of question requires a human, and provides your designated HR contact's name, role, and contact information directly in the response. Employees always leave the conversation knowing exactly who to speak with.
+
+</details>
+
+<details>
+
+<summary>Does the AI have access to individual employee data like salary or performance reviews?</summary>
+
+No. The AI HR Coordinator does not have access to individual employee records, payroll data, or performance management systems. It operates entirely from the policy documents and HR materials you provide during setup. Any question that requires access to individual data is automatically redirected to your HR contact.
+
+</details>
+
+<details>
+
+<summary>What documents do I need to provide for the knowledge base?</summary>
+
+At a minimum: your employee handbook, leave and time-off policies, benefits documentation, and answers to your most frequently asked HR questions. Onboarding and offboarding checklists, change request forms, and any departmental policies your employees regularly ask about are also valuable additions. The more specific and current your documentation, the better the AI performs.
+
+</details>
+
+<details>
+
+<summary>What is the PolicyScope framework?</summary>
+
+PolicyScope is the structured routing system we configure for your AI HR Coordinator. It governs how the AI handles every incoming question across three levels. Level 1 covers general, policy-based questions the AI can answer directly from your documentation. Level 2 covers personal or sensitive inquiries that require human judgment — the AI redirects warmly to your HR contact. Level 3 covers out-of-scope questions (IT, Finance, Legal, etc.) that the AI politely declines and routes to the right department.
+
+</details>
+
+<details>
+
+<summary>Can the AI take action — like submitting a form, sending an email, or opening a ticket?</summary>
+
+No. The AI HR Coordinator is an information and direction tool only. It will answer questions, link to documents, and redirect employees to the right person — but it cannot submit forms, send emails on behalf of employees, or create tickets in any system. If an action is required, the AI will clearly explain what the employee needs to do and who they need to contact.
+
+</details>
+
+<details>
+
+<summary>Can employees book a meeting with HR through the AI?</summary>
+
+Yes, if your HR team has a Google, Outlook, or Microsoft calendar connected in Business App. When this is set up, the AI can check availability and book a meeting directly in the conversation — presenting available times, confirming the selection, and sending a confirmation. Please let our team know during the onboarding call if you'd like to enable this capability.
+
+</details>
+
+<details>
+
+<summary>Does this require a chat widget on our website or company portal?</summary>
+
+No. The AI HR Coordinator is an internal tool — it does not require any website embed code, widget installation, or public-facing setup. There are no customer-facing components, no social media integrations, and no external accounts required as part of this setup.
+
+</details>
+
+<details>
+
+<summary>What happens when our HR policies change after setup?</summary>
+
+Whenever your policies are updated, you can send the revised documents to our team and we will update the knowledge base. If you have Google Drive sync configured, policy updates made in your designated Drive folder will be reflected automatically — no manual update required. We recommend reviewing the AI's knowledge base any time a significant policy changes.
+
+</details>
+
+<details>
+
+<summary>Can the AI sync automatically with our HR policy documents in Google Drive?</summary>
+
+Yes. If your HR policies are maintained in Google Drive, we can configure an automated sync that monitors your policy folder and updates the AI's knowledge base whenever documents are added or changed. This requires brief access to your Google Drive folder structure during setup. Please let our team know during the onboarding call if you would like this configured.
+
+</details>
+
+<details>
+
+<summary>What happens if I miss the onboarding call?</summary>
+
+If you are unable to attend the onboarding call, our team will proceed with setup using the information provided in your fulfillment form and demo the configuration when we connect. We will then follow up via email and phone to review, refine, and answer any questions you have.
+
+If we are unable to reach you after our follow-up process (4 emails and 4 phone calls), the project will be closed. However, the project can be reopened at any time by reaching back out to us — no need to start over from scratch.
+
+</details>
+
+<details>
+
+<summary>How is this different from just having a shared FAQ document or HR knowledge base page?</summary>
+
+A shared document or FAQ page requires employees to know it exists, find it, and search through it themselves. The AI HR Coordinator responds conversationally in real time — employees ask a question and get a direct answer, often with a link to the relevant policy, without needing to search. It is also available at any hour, reduces repetitive questions to your HR team, and consistently applies the same routing logic for sensitive or out-of-scope inquiries.
+
+</details>

--- a/docusaurus/docs/vendasta-services/ai-workforce-setup/index.mdx
+++ b/docusaurus/docs/vendasta-services/ai-workforce-setup/index.mdx
@@ -1,10 +1,10 @@
 ---
 id: ai-workforce-setup
 title: AI Workforce Setup
-description: "Done-for-you setup for AI Receptionist, AI Reputation Specialist, AI Data Analyst, and AI Support Agent: configuration, training calls, lead capture, review responses, data insights, customer support, and ongoing support."
+description: "Done-for-you setup for AI Receptionist, AI Reputation Specialist, AI Data Analyst, AI Support Agent, AI Inside Sales Representative, and AI Human Resources Coordinator: configuration, training calls, lead capture, review responses, data insights, customer support, and ongoing support."
 sidebar_position: 1
 tags: [vendasta-services, ai-workforce, ai-receptionist, ai-reputation-specialist, ai-data-analyst, ai-support-agent, setup]
-keywords: [AI Receptionist, AI Reputation Specialist, AI Data Analyst, AI Support Agent, setup, lead capture, review responses, data insights, customer support, HEARD framework, onboarding]
+keywords: [AI Receptionist, AI Reputation Specialist, AI Data Analyst, AI Support Agent, AI Inside Sales Representative, AI Human Resources Coordinator, setup, lead capture, review responses, data insights, customer support, HEARD framework, PolicyScope, onboarding]
 ---
 
 # AI Workforce Setup
@@ -18,6 +18,7 @@ Vendasta Services offers done-for-you AI workforce setup so you can get AI emplo
 | **AI Data Analyst** | Structured insights across CRM, reviews, and social data |
 | **AI Support Agent** | HEARD-framework customer support across web chat, SMS, and social channels |
 | **AI Inside Sales Representative** | Lead qualification, appointment booking, and sales-focused conversation handling |
+| **AI Human Resources Coordinator** | Policy-based HR question answering, sensitive inquiry routing, and escalation contact configuration |
 
 ## What is AI Workforce Setup?
 
@@ -64,6 +65,14 @@ Web chat lead capture, CRM pipeline, booking, service-area connections, and auto
 - **Process:** Fulfillment form → onboarding call → ISR setup (1 business day, or 3 for custom integrations/complex knowledge bases) → training call → 30-day check-in
 - **Requirements:** Connected Google, Outlook, or Microsoft calendar for appointment booking; A2P registration for U.S. businesses using SMS
 
+### AI Human Resources Coordinator Setup
+
+**Requires Conversations AI.** Internal HR assistant that answers policy questions, routes sensitive inquiries to the right contact, and declines out-of-scope requests.
+
+- **Includes:** AI Employee profile, PolicyScope framework (3-level routing), escalation contact configuration, knowledge base, optional appointment booking and Google Drive sync
+- **Process:** Fulfillment form → onboarding call → HR Coordinator setup (1 business day, or 3 for large or complex policy libraries) → training call → 30-day check-in
+- **Requirements:** Escalation contact information; HR policy documents and handbooks; no website installation required
+
 ## Documentation
 
 - [AI Receptionist Setup](./ai-receptionist-setup.md) – What’s included (CRM, booking, inventory, service area, automations), setup process (training call, configuration, walkthrough, 30-day check-in), FAQs
@@ -71,6 +80,7 @@ Web chat lead capture, CRM pipeline, booking, service-area connections, and auto
 - [AI Data Analyst Setup](./ai-data-analyst-setup.md) – AIR Analysis Framework, data source connections (CRM, Reviews/NPS, Social), requirements, setup process (fulfillment form, onboarding, configuration, training, 30-day check-in), FAQs
 - [AI Support Agent Setup](./ai-support-agent-setup.md) – HEARD Support Framework, escalation logic, channel setup (web chat, SMS, Facebook, Instagram, WhatsApp, email), chat widget installation, knowledge base, requirements (Conversations AI, website access, A2P), FAQs
 - [AI Inside Sales Representative Setup](./ai-inside-sales-representative-setup.md) – Sales role prompt, lead discovery and qualification logic, lead capture sequence, appointment booking, knowledge base, requirements (Conversations AI, connected calendar, services list, A2P), FAQs
+- [AI Human Resources Coordinator Setup](./ai-human-resources-coordinator-setup.md) – PolicyScope framework (3-level routing), escalation contact configuration, knowledge base, optional appointment booking and Google Drive sync, requirements (Conversations AI, escalation contacts, HR policy documents), FAQs
 - [AI Workforce Optimization Plan](./ai-workforce-optimization-plan.md) – Ongoing optimization subscription: unlimited changes, monthly check-ins, email access to experts, live training, what's included and out of scope, roles and responsibilities
 
 ## Frequently asked questions


### PR DESCRIPTION
## Summary
- Adds new AI Human Resources Coordinator Setup doc matching the style of existing AI workforce setup pages
- Covers PolicyScope framework (3-level routing), escalation contact configuration, knowledge base setup, optional appointment booking and Google Drive sync, requirements, and 12 FAQs
- Updates `index.mdx` to include the new service in the summary table, subsections, and documentation links

## Test plan
- [ ] Page renders correctly in Docusaurus
- [ ] All `:::info`, `:::note`, and `:::tip` callouts display properly
- [ ] FAQ `<details>` blocks expand correctly
- [ ] Links in index.mdx resolve to the new page

🤖 Generated with [Claude Code](https://claude.com/claude-code)