### PR TITLE
docs(ai-workforce): remove generated index, make category dropdown only

### DIFF
--- a/docusaurus/docs/vendasta-services/ai-workforce-setup/_category_.json
+++ b/docusaurus/docs/vendasta-services/ai-workforce-setup/_category_.json
@@ -1,6 +1,5 @@
 {
   "label": "AI Workforce",
   "position": 1,
-  "collapsed": true,
-  "link": { "type": "generated-index" }
+  "collapsed": true
 }

--- a/docusaurus/docusaurus.config.ts
+++ b/docusaurus/docusaurus.config.ts
@@ -259,8 +259,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           { from: '/partner-center/AI-receptionist-features-by-plan', to: '/ai/ai-workforce/ai-receptionist-features-by-plan' },
           // AI Workforce Optimization Plan content is now on every service page
           { from: '/vendasta-services/ai-workforce-setup/ai-workforce-optimization-plan', to: '/vendasta-services/ai-workforce-setup/ai-data-analyst-setup' },
-          // AI Workforce Setup index merged into individual service pages
-          { from: '/vendasta-services/ai-workforce-setup', to: '/vendasta-services/ai-workforce-setup/ai-data-analyst-setup' },
         ],
       },
     ],


### PR DESCRIPTION
## Summary
- Removes `"link": { "type": "generated-index" }` from `_category_.json` so the AI Workforce sidebar item is a non-clickable dropdown only
- Removes the now-unnecessary redirect from `/vendasta-services/ai-workforce-setup`

🤖 Generated with [Claude Code](https://claude.com/claude-code)