### PR TITLE
docs(ai-workforce): remove Setup from sidebar labels and page titles

### DIFF
--- a/docusaurus/docs/vendasta-services/ai-workforce-setup/ai-data-analyst-setup.md
+++ b/docusaurus/docs/vendasta-services/ai-workforce-setup/ai-data-analyst-setup.md
@@ -1,7 +1,7 @@
 ---
-title: "AI Data Analyst Setup: Service Expectations"
-sidebar_label: "AI Data Analyst Setup"
-description: "An overview of the AI Data Analyst Setup service, detailing the process from the fulfillment form through data source configuration, training, and the 30-day check-in."
+title: "AI Data Analyst: Service Expectations"
+sidebar_label: "AI Data Analyst"
+description: "An overview of the AI Data Analyst service, detailing the process from the fulfillment form through data source configuration, training, and the 30-day check-in."
 ---
 
 import OptimizationPlanSection from './_optimization-plan-section.mdx';

--- a/docusaurus/docs/vendasta-services/ai-workforce-setup/ai-human-resources-coordinator-setup.md
+++ b/docusaurus/docs/vendasta-services/ai-workforce-setup/ai-human-resources-coordinator-setup.md
@@ -1,7 +1,7 @@
 ---
-title: "AI Human Resources Coordinator Setup: Service Expectations"
-sidebar_label: "AI Human Resources Coordinator Setup"
-description: "An overview of the AI Human Resources Coordinator Setup service, detailing the process from the fulfillment form through onboarding, HR Coordinator configuration, training, and the 30-day check-in."
+title: "AI Human Resources Coordinator: Service Expectations"
+sidebar_label: "AI Human Resources Coordinator"
+description: "An overview of the AI Human Resources Coordinator service, detailing the process from the fulfillment form through onboarding, HR Coordinator configuration, training, and the 30-day check-in."
 ---
 
 import OptimizationPlanSection from './_optimization-plan-section.mdx';

--- a/docusaurus/docs/vendasta-services/ai-workforce-setup/ai-inside-sales-representative-setup.md
+++ b/docusaurus/docs/vendasta-services/ai-workforce-setup/ai-inside-sales-representative-setup.md
@@ -1,7 +1,7 @@
 ---
-title: "AI Inside Sales Representative Setup: Service Expectations"
-sidebar_label: "AI Inside Sales Representative Setup"
-description: "An overview of the AI Inside Sales Representative Setup service, detailing the process from the fulfillment form through onboarding, ISR configuration, training, and the 30-day check-in."
+title: "AI Inside Sales Representative: Service Expectations"
+sidebar_label: "AI Inside Sales Representative"
+description: "An overview of the AI Inside Sales Representative service, detailing the process from the fulfillment form through onboarding, ISR configuration, training, and the 30-day check-in."
 ---
 
 import OptimizationPlanSection from './_optimization-plan-section.mdx';

--- a/docusaurus/docs/vendasta-services/ai-workforce-setup/ai-receptionist-setup.md
+++ b/docusaurus/docs/vendasta-services/ai-workforce-setup/ai-receptionist-setup.md
@@ -1,7 +1,7 @@
 ---
-title: "AI Receptionist Setup: Service Expectations"
-sidebar_label: "AI Receptionist Setup"
-description: "An overview of the AI Receptionist Setup service, detailing the process from the initial call to the final configuration and ongoing support."
+title: "AI Receptionist: Service Expectations"
+sidebar_label: "AI Receptionist"
+description: "An overview of the AI Receptionist service, detailing the process from the initial call to the final configuration and ongoing support."
 ---
 
 import OptimizationPlanSection from './_optimization-plan-section.mdx';

--- a/docusaurus/docs/vendasta-services/ai-workforce-setup/ai-reputation-specialist-setup.md
+++ b/docusaurus/docs/vendasta-services/ai-workforce-setup/ai-reputation-specialist-setup.md
@@ -1,7 +1,7 @@
 ---
-title: "AI Reputation Specialist Setup: Service Expectations"
-sidebar_label: "AI Reputation Specialist Setup"
-description: "An overview of the AI Reputation Specialist Setup service, detailing the process from the fulfillment form to the final configuration and ongoing support."
+title: "AI Reputation Specialist: Service Expectations"
+sidebar_label: "AI Reputation Specialist"
+description: "An overview of the AI Reputation Specialist service, detailing the process from the fulfillment form to the final configuration and ongoing support."
 ---
 
 import OptimizationPlanSection from './_optimization-plan-section.mdx';

--- a/docusaurus/docs/vendasta-services/ai-workforce-setup/ai-support-agent-setup.md
+++ b/docusaurus/docs/vendasta-services/ai-workforce-setup/ai-support-agent-setup.md
@@ -1,7 +1,7 @@
 ---
-title: "AI Support Agent Setup: Service Expectations"
-sidebar_label: "AI Support Agent Setup"
-description: "An overview of the AI Support Agent Setup service, detailing the process from the fulfillment form through channel configuration, knowledge base setup, training, and the 30-day check-in."
+title: "AI Support Agent: Service Expectations"
+sidebar_label: "AI Support Agent"
+description: "An overview of the AI Support Agent service, detailing the process from the fulfillment form through channel configuration, knowledge base setup, training, and the 30-day check-in."
 ---
 
 import OptimizationPlanSection from './_optimization-plan-section.mdx';


### PR DESCRIPTION
## Summary
- Removed "Setup" from `title`, `sidebar_label`, and `description` frontmatter across all 6 AI employee service pages

## Test plan
- [ ] Verify sidebar labels no longer show "Setup" suffix in local dev
- [ ] Confirm page titles render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)