### PR TITLE
docs: add Help Center articles from Guru cleanup (Accounts + CRM)

### DIFF
--- a/docusaurus/docs/accounts/accounts-lists/list-actions.mdx
+++ b/docusaurus/docs/accounts/accounts-lists/list-actions.mdx
@@ -7,6 +7,13 @@ sidebar_position: 4
 
 The following administrative actions are available from **Partner Center > Accounts > Lists >  click the three dots next to the desired list**.
 
+## Account list limits
+
+| Limit | Value | Workaround |
+|-------|-------|------------|
+| Maximum accounts per list | 5,000 | Create multiple lists and apply a shared tag to all accounts across lists. Use the tag to filter and work with the full set. |
+| Bulk product activation cap | 500 accounts per action | Split accounts into multiple lists and activate in batches. |
+
    [Export Account Data](#export-account-data)
 
    [Add Tags](#add-tags)
@@ -60,7 +67,17 @@ After selecting **Export Account Data**, you will be taken to the List's **Histo
 
 ## Add Tags
 
-Allows you to add tags to every account in the List. This is useful should you wish to use tags to filter accounts later.
+Adds a tag to every account in the list. This is useful for filtering accounts later or for merging multiple lists into a logical group.
+
+**To bulk-add a tag without overwriting existing tags:**
+
+1. Go to **Partner Center** > **Accounts** > **Lists**.
+2. Click the three dots next to the list.
+3. Select **Add Tags**.
+4. Choose an existing tag or create a new one.
+5. Click **Apply**.
+
+Tags are appended — existing tags on accounts are not removed.
 
 ## Add To Campaign
 

--- a/docusaurus/docs/accounts/manage-accounts/create-accounts.mdx
+++ b/docusaurus/docs/accounts/manage-accounts/create-accounts.mdx
@@ -93,17 +93,23 @@ If no suitable category exists, select "Other" - but note that some product feat
 
 ### Handling special business types
 
-**Service Area Businesses** (no physical storefront):
-- Select "Service Area Business" checkbox
-- Use owner's address or main office location
-- Define service radius in business settings
-- Focus on service categories rather than location-based categories
+**Service Area Businesses (SABs)** — businesses that serve customers at the customer's location and have no fixed public storefront (plumbers, landscapers, mobile pet groomers, etc.):
+
+SABs commonly don't appear in the account creation search bar. This is expected — the search uses Google's Locations API, which only surfaces businesses with a verified physical address. An SAB that doesn't list a street address publicly won't appear in results.
+
+**To create an account for an SAB:**
+
+1. In the **Create Account** search, type the business name. If it doesn't appear, click **Skip to Account Creation** (or **Go to Account Creation**).
+2. Fill in the business name and a valid street address. If the SAB has no public address, use the owner's address or a city/ZIP placeholder.
+3. Once the account is created, update the listing to define a service area radius and remove or hide the public street address if needed.
+
+:::warning
+Creating an account with **no street address** limits Listing Sync and other listing-dependent products. Those products require a physical address to sync data. Add a valid street address before activating listing products.
+:::
 
 **Multi-Location Businesses**:
-- Create separate accounts for each physical location
-- Use consistent naming convention (e.g., "Business Name - Location")
-- Plan to group using Multi-Location Groups later
-- Ensure each location has unique address information
+
+**Multi-Location Businesses** — create separate accounts for each physical location, use a consistent naming convention (e.g., "Business Name - Location"), and plan to group them using Multi-Location Groups later.
 
 ## How to import multiple accounts
 
@@ -138,9 +144,16 @@ Before importing accounts:
 - Market Assignment
 - Additional Contact Information
 - Business Hours
+- `ServiceAreaBusiness` — set to `TRUE` if the account is a Service Area Business; `FALSE` or blank otherwise. This field is **case-sensitive**: only `TRUE` and `FALSE` (uppercase) are valid. Using `true`, `True`, `yes`, or any other value will cause the row to fail validation.
+
+**Save format:** Save your file as **CSV UTF-8** (not standard CSV or Excel format) to avoid character encoding errors during import.
 
 :::info
 Use consistent formatting for phone numbers, addresses, and categories to ensure successful import processing.
+:::
+
+:::warning
+Automatic product activation **does not run on CSV-uploaded accounts**. Products you want activated for imported accounts must be bulk-activated separately after import using account lists or the Activate Product action.
 :::
 
 ### Executing the import
@@ -170,6 +183,17 @@ After successful import:
 4. **Configure products and services** for new accounts
 5. **Set up user access** for customer dashboard access
 
+### Enrichment after import
+
+After import, the system attempts to enrich each account with data from Google (address, phone, categories, hours). Some accounts are skipped and won't be enriched:
+
+- The business's country or state doesn't match what's on Google
+- The company name or address on the CSV is significantly different from the Google listing (low similarity score)
+- No Google listing exists for the business
+- The account has no street address (SABs without an address are not enriched)
+
+Accounts that aren't enriched still import successfully — they just retain only the data from your CSV.
+
 ## How to handle account creation issues
 
 ### Business not found in search
@@ -198,6 +222,7 @@ After successful import:
 - **Invalid phone formats**: Use consistent formatting (e.g., (555) 123-4567)
 - **Address validation failures**: Verify addresses exist and are properly formatted
 - **Category assignment errors**: Use exact category names from the system (refer to [Business Categories](../../directory/business-categories.mdx) or [download the complete list](../../directory/downloads/business-categories-list.csv) for all valid category options)
+- **`ServiceAreaBusiness` validation error**: This field only accepts `TRUE` or `FALSE` (uppercase). Using any other value — including `true`, `yes`, `1`, or leaving it as a non-blank non-`TRUE`/`FALSE` value — will cause the row to fail. Blank is treated as `FALSE`.
 
 **Duplicate business handling:**
 - **Similar names**: Review carefully for legitimate duplicates vs. similar businesses
@@ -241,11 +266,11 @@ You can adjust user permissions later from Manage Users if needed.
 
 If a business doesn’t appear in the `Create account` search:
 
-- It may be a Service Area Business (businesses without a storefront might not appear in the search results)
-- Click `Skip to account creation` to add the business manually
+- **Service Area Business** — SABs without a public address are not returned by Google’s Locations API, which powers the search. This is expected, not a bug. Click **Skip to Account Creation** to add the account manually.
+- **New or recently listed businesses** — New businesses may not yet appear in Google’s database. Use manual creation.
+- **Name variations** — Try shortened names (drop "LLC", "Inc.", etc.) or search by address instead.
 
-This ensures you can still create the account even when search doesn’t return the business.
-- Schedule onboarding activities for complex accounts
+Clicking **Skip to Account Creation** always lets you create the account manually regardless of whether it appears in search results.
 
 ## Frequently asked questions (FAQs)
 
@@ -288,7 +313,13 @@ Review the error messages, correct data formatting issues in your CSV file, and 
 <details>
 <summary>How do I create accounts for service area businesses without addresses?</summary>
 
-Select "Service Area Business" during creation and use the owner's address or main office location. Configure the service area radius in the account settings after creation.
+SABs often won't appear in the Create Account search because Google's Locations API doesn't surface businesses without a verified public address. To create the account:
+
+1. Type the business name in the search bar. If it doesn't appear, click **Skip to Account Creation**.
+2. Enter the business name and a street address (use the owner's address or a placeholder city/ZIP if there's no public address).
+3. After the account is created, update the listing to define a service area and hide the street address if needed.
+
+Creating an account with no street address will limit Listing Sync and other listing products until an address is added.
 </details>
 
 <details>

--- a/docusaurus/docs/accounts/manage-accounts/delete-accounts.mdx
+++ b/docusaurus/docs/accounts/manage-accounts/delete-accounts.mdx
@@ -40,9 +40,20 @@ Account deletion is permanent and irreversible. All data associated with the acc
 ### System impact
 - Account removed from all lists and groups
 - Automated campaigns and communications stopped
-- Billing and subscription records archived
 - User access immediately revoked
-- Product services discontinued
+- Active products are automatically cancelled and deactivated
+
+### Billing after deletion
+
+Deleting an account **does not cancel active billing commitments**. If a product had a commitment period (for example, an annual contract), billing continues until the end of that commitment period even after the account and product are deleted. You will see charges on your bill through the end of the commitment.
+
+:::warning
+If you delete an account with products on active commitments, you will continue to be billed for those products until the commitment period ends. Cancel commitments before deleting the account if you want to stop billing immediately (subject to cancellation terms).
+:::
+
+### What happens to accounts under a deactivated market
+
+If a market is deactivated, all accounts assigned to that market are automatically reassigned to the **default market** within the same Partner ID. The accounts themselves are not deleted.
 
 ## How to delete individual accounts
 
@@ -246,4 +257,16 @@ Only current authorized users or account administrators should be able to reques
 <summary>Will deleting the associated company also delete the account?</summary>
 
 No, deleting the associated company will not also delete the account, however, deleting an account will delete the associated company.
+</details>
+
+<details>
+<summary>I deleted my account but I'm still being billed — why?</summary>
+
+If a product on that account had an active commitment (such as an annual contract), billing continues through the end of the commitment period even after the account is deleted. Deletion cancels product access but does not terminate commitment billing early. Contact support if you believe the commitment has already expired and billing should have stopped.
+</details>
+
+<details>
+<summary>What if I want to stop products but keep the account?</summary>
+
+You can cancel or deactivate individual products from the account's product management page without deleting the account. This preserves the account data and history while stopping the product services.
 </details>

--- a/docusaurus/docs/accounts/manage-users/welcome-email.mdx
+++ b/docusaurus/docs/accounts/manage-users/welcome-email.mdx
@@ -1,0 +1,72 @@
+---
+title: Customizing the welcome email
+sidebar_label: Welcome email
+description: Learn what the Business App welcome email contains, what can be customized, and how to use Marketing Campaigns as the recommended workaround for custom onboarding content.
+tags: [users, welcome-email, campaigns, onboarding]
+keywords: [welcome email, customize, onboarding, marketing campaigns, white label]
+---
+
+# Customizing the welcome email
+
+## What is the welcome email?
+
+When a Business App user is created, the platform automatically sends them a welcome email with a link to set their password and access their dashboard. This email uses the white-label settings from the market the account is assigned to (logo, brand colors, sender name).
+
+## What you can and cannot customize
+
+| Element | Customizable? |
+|---------|--------------|
+| Logo and brand colors | Yes — via market white-label settings |
+| Sender name and email domain | Yes — via email domain settings |
+| Subject line | No — hard-coded |
+| Email body content | No — hard-coded |
+| Custom introductory message | Yes — a short message can be added at user creation time |
+
+The body of the welcome email is fixed and cannot be edited directly. The most common workaround is to use a **Marketing Campaign** to send a fully custom onboarding email after the user logs in for the first time.
+
+## Recommended workaround: Marketing Campaigns
+
+Most partners use a Marketing Campaign to deliver custom onboarding content. This lets you control the message completely and send a series of emails rather than a single welcome note.
+
+**How to set this up:**
+
+1. Go to **Partner Center** > **Marketing** > **Campaigns** > **Product Adoption**.
+2. Create a new campaign with the welcome content you want your customers to receive.
+3. Go to **Partner Center** > **Accounts** > **Manage Business App** > **Customize Business App** > **Notifications**.
+4. Enable the **Onboarding campaign** checkbox and select your campaign from the dropdown.
+5. Click **Save**.
+
+New customers will be automatically enrolled in the campaign when they log in for the first time.
+
+## Which market's white label is used
+
+The welcome email uses the white-label settings of the market the account is assigned to, with one exception:
+
+- **Resending from Account Details**: uses the account's assigned market branding
+- **Resending from the Users page**: uses the default market branding
+- **Initial creation email**: always uses the default market branding, regardless of the account's market assignment
+
+If your markets have different branding, make sure the correct market is assigned to the account before sending or resending the welcome email.
+
+## Frequently asked questions
+
+<details>
+<summary>Can I resend the welcome email?</summary>
+
+Yes. From the account's user list, click the three-dot menu next to the user and select **Resend Welcome Email**. You can also resend from **Accounts** > **Manage Users**.
+</details>
+
+<details>
+<summary>A user didn't receive their welcome email — what should I check?</summary>
+
+1. Confirm the email address on the user account is correct.
+2. Ask the user to check their spam or junk folder.
+3. Verify that notifications are enabled under **Customize Business App** > **Notifications** > **Allow sending of notifications**.
+4. Check that your email domain is configured correctly under **Marketing** > **Email Settings**.
+</details>
+
+<details>
+<summary>Can I add a custom message to the welcome email?</summary>
+
+Yes, a brief custom introductory message can be added when creating or editing a user. This appears in the welcome email above the login link. For fully custom content, use a Marketing Campaign as described above.
+</details>

--- a/docusaurus/docs/commerce/orders/order-processing-and-activation.mdx
+++ b/docusaurus/docs/commerce/orders/order-processing-and-activation.mdx
@@ -70,6 +70,22 @@ Based on partner configuration, orders can be sent to one of two places:
 2. Administrator with "Can Manage Orders" permissions reviews the order
 3. Admin either approves or declines the order
 
+## How to approve an order without activating products
+
+Some partners prefer to collect payment before activating products — for example, during staged onboarding or when a customer needs to pay before services begin. You can approve a sales order and collect payment without activating the products by leaving the billing agreement checkbox unchecked.
+
+**Step-by-step:**
+
+1. Create and submit the sales order as usual.
+2. When approving the order, you will see a **billing agreement checkbox** ("I understand that I will be billed for activated products").
+3. **Leave this checkbox unchecked** and proceed to approve the order.
+4. The order moves to **Approved** status. Products are not activated. The customer can be invoiced at this point.
+5. To activate the products later, a Partner Center admin must return to the order, check the billing agreement checkbox, and select an activation timing option.
+
+:::info
+Products remain in **Approved** status until a Partner Center admin explicitly agrees to billing and activates them. Approval alone — without the billing agreement — does not trigger activation.
+:::
+
 ## Product Activation Process
 
 ### Does an Approved Order Automatically Activate Products?

--- a/docusaurus/docs/crm/companies/index.mdx
+++ b/docusaurus/docs/crm/companies/index.mdx
@@ -252,3 +252,45 @@ Lead scoring empowers customer-facing representatives with precise and customiza
 **Configuration**: Lead scoring is configured in `Partner Center` > `Administration` > `Score`. See the [Score documentation](../../administration/data-management/score/index.mdx) for detailed setup instructions.
 
 **Availability**: Lead scoring works out of the box for all users on the Professional subscription or above.
+
+## Bulk deleting companies
+
+You can delete multiple company records at once to clean up CRM data.
+
+:::warning
+Bulk deletion is **permanent and cannot be undone**. Any notes attached to deleted companies are lost and cannot be recovered, even if you recreate the company later. Export any records you may need before deleting.
+:::
+
+**Limits:** Companies are deleted in batches of **100 records** at a time.
+
+**Steps:**
+
+1. Go to **Partner Center** > **CRM** > **Companies**.
+2. Increase the items-per-page setting to show more records (up to 100).
+3. Use filters or search to narrow to the records you want to delete.
+4. Click the top-left checkbox to select all visible records.
+5. Click **Actions** > **Delete**.
+6. Confirm the deletion.
+
+Repeat for additional batches if you need to delete more than 100 companies.
+
+## Recreating a deleted company
+
+If a company was accidentally deleted, you can trigger the system to recreate it — as long as the associated account still exists in Partner Center.
+
+**What gets recovered:**
+- The Company record (with a new Company ID)
+- Business profile information synced from the account
+
+**What is NOT recovered:**
+- Notes and activity history from the deleted company record
+- The original Company ID (a new one is assigned)
+
+**How to recreate:**
+
+1. Go to the associated account in **Partner Center** > **Accounts** > **Manage Accounts**.
+2. Open the account and click **Edit Account**.
+3. Make a minor change to the Business Profile — the recommended approach is to add a tag and then remove it.
+4. Save the account.
+
+Saving triggers a sync that recreates the Company record linked to that account. The recreated company will have a fresh activity timeline with no previous notes.

--- a/docusaurus/docs/crm/companies/lifecycle-stages.mdx
+++ b/docusaurus/docs/crm/companies/lifecycle-stages.mdx
@@ -1,0 +1,69 @@
+---
+title: CRM lifecycle stages explained
+sidebar_label: Lifecycle stages
+description: The full definition of each CRM lifecycle stage, how automatic transitions work, and how to manually change a stage.
+tags: [crm, lifecycle, leads, pipeline]
+keywords: [lifecycle stages, lead, MQL, SQL, prospect, customer, CRM stages]
+---
+
+# CRM lifecycle stages explained
+
+## What are lifecycle stages?
+
+Lifecycle stages represent where a contact or company is in your sales and customer relationship process — from initial awareness through active customer. Stages affect lead scoring, automation triggers, filtering, and pipeline reporting, so understanding them is essential for using the CRM correctly.
+
+## The stages, defined
+
+| Stage | Definition |
+|-------|-----------|
+| **Visitor** | Someone who has interacted with your content or website but has not yet been identified as a potential buyer. |
+| **Lead** | A contact or company that has shown interest and entered the CRM. **This is the default stage for new records.** |
+| **MQL** (Marketing Qualified Lead) | A lead that marketing has determined is a good fit based on engagement or profile criteria. |
+| **SAL** (Sales Accepted Lead) | A lead that the sales team has reviewed and accepted for follow-up. |
+| **SQL** (Sales Qualified Lead) | A lead that sales has engaged with and confirmed is ready for the sales process. |
+| **Prospect** | An SQL that has an active Opportunity in the CRM. **Set automatically when an Opportunity is created on the record.** |
+| **Customer** | A company that has a closed-won Opportunity. **Set automatically when an Opportunity is marked Closed Won.** |
+| **Former Customer** | A company that was previously a customer but is no longer active. |
+
+## Automatic stage transitions
+
+Three stage transitions happen automatically based on CRM activity:
+
+1. **Lead** — Assigned to all new contacts and companies by default.
+2. **Prospect** — Set automatically when an Opportunity is created on the record.
+3. **Customer** — Set automatically when an Opportunity on the record is marked **Closed Won**.
+
+You do not need to manually move records through these transitions — the CRM updates them when the associated action occurs.
+
+## Manually changing a stage
+
+You can manually set or override a lifecycle stage from a contact or company record:
+
+1. Open the contact or company profile.
+2. Find the **Lifecycle stage** field in the sidebar or details panel.
+3. Select the new stage from the dropdown.
+4. Save the record.
+
+:::warning
+If automations are configured to manage lifecycle stages (for example, an automation that sets a stage based on activity), your manual change may be overridden the next time the automation runs. Check your active automations before making manual stage changes at scale.
+:::
+
+## Frequently asked questions
+
+<details>
+<summary>Why did a contact's stage change automatically?</summary>
+
+The most common causes are: an Opportunity was created (moves to Prospect) or closed won (moves to Customer). An automation may also be configured to update stages based on activity or criteria. Check the activity feed on the record to see when the stage changed.
+</details>
+
+<details>
+<summary>Can I add custom lifecycle stages?</summary>
+
+The default lifecycle stages are fixed. You cannot add or rename stages. For additional segmentation, use Tags or custom fields.
+</details>
+
+<details>
+<summary>Can I filter contacts and companies by lifecycle stage?</summary>
+
+Yes. In **CRM** > **Companies** or **Contacts**, use **Add filter** > **Lifecycle stage** to view records in a specific stage.
+</details>

--- a/docusaurus/docs/crm/contacts/index.mdx
+++ b/docusaurus/docs/crm/contacts/index.mdx
@@ -44,13 +44,27 @@ The Contacts section eliminates manual processes through bulk import/export capa
 
 In the Vendasta CRM, you can efficiently add or update multiple contacts and companies at once by importing them in a single file. This powerful feature streamlines contact management and ensures data accuracy through proper field mapping during the import process.
 
+### Partner Center vs. Business App imports
+
+The import rules differ depending on where you import:
+
+| | Partner Center import | Business App import |
+|---|---|---|
+| Flow | B2B — contacts are linked to companies | B2C — contacts can stand alone |
+| Company name required? | Yes, on the first contact row | No |
+| Use case | Sales CRM, account management | Consumer/client-facing lists |
+
+If you're importing contacts for B2B sales work, import through **Partner Center > CRM > Contacts**. If you're managing consumer contacts for a Business App client, import through Business App.
+
 ### Before you begin
 
 Before initiating an import:
 
 - Ensure you have permission to manage CRM contacts and companies
 - Confirm that each contact entry includes at least one of the following: First name, last name, email, or phone number
-- Ensure each company entry includes a company name
+- **Company name (first-row rule)**: In Partner Center imports, company name must be populated on the **first** contact row. It does not need to appear on every subsequent row — but the first row requires it or the import will fail with "Company name is required."
+- **Business categories**: If your CSV includes a business category, select it from the dropdown during field mapping — do not type it as free text. Free-text categories do not map to the CRM's category list and will silently break downstream syncing.
+- **No blank rows**: Blank rows in your CSV cause "No company or contact found" errors. Remove all empty rows before importing.
 - **Import limits**: Maximum file size is 5 MB, which typically allows for up to 35,000 contacts per import
 - Prepare your data with unique identifiers for bulk updates (Contact ID, External ID, or email)
 
@@ -144,6 +158,33 @@ To perform bulk updates of existing contacts:
 To export Contacts or Companies from the CRM, click the checkbox in the top-left corner of the table, then click `select all...` > `Export`.
 
 ![Export Contacts Interface](./img/crm/contacts/export-contacts.jpg)
+
+### Common import errors
+
+| Error | Most likely cause | Fix |
+|-------|-------------------|-----|
+| "Company name is required" | The first contact row in the CSV has no company name | Add a company name to the first row. Subsequent rows don't require it. |
+| "No company or contact found" | Blank rows in the CSV, or the file is malformed | Remove all empty rows. Open in a text editor to check for hidden characters. |
+| CSV parsing failures | File saved in the wrong format or encoding | Save as **CSV UTF-8** and ensure no merged cells or special formatting. |
+| Category not syncing | Category entered as free text instead of selected from dropdown | Re-import and select the category from the dropdown during field mapping. |
+
+### Bulk-assigning salespeople during import
+
+You can assign salespeople to companies during a CSV import by including a `SalespersonID` column. This avoids manual reassignment after the import.
+
+**How to find a salesperson's ID:**
+
+1. Go to **Partner Center** > **Administration** > **My Team**.
+2. Click the three dots next to the salesperson and select **Edit Salesperson**.
+3. The salesperson's UID appears in the browser URL bar — copy the value after `/salespeople/`.
+
+**How to use it in your CSV:**
+
+1. Add a column named `SalespersonID` to your import CSV.
+2. Paste each salesperson's UID into the column for the rows (companies) they should own.
+3. During import, map the `SalespersonID` column to the **Salesperson** CRM field.
+
+To assign multiple salespeople to a single company, add additional columns named `AdditionalSalespersonID1`, `AdditionalSalespersonID2`, etc., and map them during import.
 
 ## Campaign management
 

--- a/docusaurus/docs/crm/contacts/sms-communication-consent.mdx
+++ b/docusaurus/docs/crm/contacts/sms-communication-consent.mdx
@@ -1,0 +1,68 @@
+---
+title: SMS communication consent
+sidebar_label: SMS consent
+description: Why SMS campaign messages aren't delivered, what the consent states mean, and how to update SMS consent for a contact.
+tags: [crm, contacts, sms, consent, campaigns]
+keywords: [SMS consent, communication consent, unset, subscribed, SMS not delivered]
+---
+
+# SMS communication consent
+
+## Why SMS messages from campaigns aren't delivered
+
+The most common reason campaign SMS messages aren't delivered to a contact is that their SMS consent is set to **Unset**. Unlike email, SMS legally requires **explicit opt-in consent** (Subscribed status) before messages can be sent. Contacts without confirmed consent are skipped by the campaign delivery system.
+
+If you've sent an SMS campaign and some contacts didn't receive it, check their SMS consent status first.
+
+## What the consent states mean
+
+| Status | What it means | Can receive SMS? |
+|--------|--------------|-----------------|
+| **Subscribed** | The contact has explicitly opted in to receive SMS | Yes |
+| **Unset** | No consent has been recorded — neither opted in nor opted out | No |
+| **Unsubscribed** | The contact has opted out of SMS | No |
+
+**Unset is not the same as opted in.** A contact who hasn't explicitly opted out still cannot receive SMS until they are moved to Subscribed. This is a regulatory requirement — sending SMS without explicit consent can violate laws such as TCPA (US) and similar regulations in other jurisdictions.
+
+## How to update SMS consent for a contact
+
+1. Go to **Partner Center** > **CRM** > **Contacts**.
+2. Open the contact's profile.
+3. Find the **Communication consent** section (usually in the contact details panel).
+4. Locate **SMS consent**.
+5. Change the status to **Subscribed**.
+6. Save the record.
+
+:::warning
+Only update a contact's SMS consent to Subscribed if you have a documented record that the contact has explicitly opted in to receive SMS messages from your organization. Setting consent without actual opt-in creates legal and compliance risk.
+:::
+
+## Collecting SMS consent
+
+Contacts can opt in to SMS through:
+
+- A form with an explicit SMS opt-in checkbox
+- A keyword opt-in (contact texts a keyword to your number)
+- Written consent collected at point of sale or during onboarding
+
+Do not manually mark contacts as Subscribed unless you have a record of their consent.
+
+## Frequently asked questions
+
+<details>
+<summary>Can I bulk-update SMS consent for multiple contacts?</summary>
+
+Contact your Vendasta account team to confirm the current bulk consent update options. For large lists, the recommended approach is to run a re-consent campaign that lets contacts opt in themselves, which creates a documented opt-in record.
+</details>
+
+<details>
+<summary>A contact texted back "STOP" — what happens?</summary>
+
+When a contact replies STOP to an SMS, their consent is automatically updated to Unsubscribed. The platform honors opt-outs immediately. Do not manually reset their consent to Subscribed — doing so overrides their explicit opt-out request.
+</details>
+
+<details>
+<summary>Why can't I just set all contacts to Subscribed?</summary>
+
+Sending SMS to contacts who haven't explicitly consented violates telecommunications regulations in most jurisdictions (including TCPA in the US). Violations can result in significant fines. Only contacts with a verifiable opt-in record should be set to Subscribed.
+</details>

--- a/docusaurus/docs/crm/salespeople/index.mdx
+++ b/docusaurus/docs/crm/salespeople/index.mdx
@@ -138,6 +138,31 @@ To delete a salesperson:
 All salesperson deletions are permanent. Before clicking `Delete`, make sure you want to delete this salesperson. Any accounts that were assigned to the salesperson before deletion will become unassigned. A `Partner Center` admin can reassign these accounts.
 :::
 
+## Why a salesperson can't see companies assigned to them
+
+Assigning a salesperson to a Company record is not enough for them to see it. Access to companies in the CRM requires **two things to match**:
+
+1. The salesperson must have the appropriate CRM role/permissions.
+2. The Company's market must be one the salesperson is **assigned to**.
+
+If either layer doesn't match, the salesperson won't see the company — even if they're listed as the assigned salesperson on the record.
+
+### How to check and fix a market mismatch
+
+**Check the salesperson's market assignment:**
+
+1. Go to **Partner Center** > **Administration** > **My Team**.
+2. Click the three dots next to the salesperson and select **Edit Salesperson**.
+3. Review the **Markets** field to see which markets they're assigned to.
+
+**Check the Company's market:**
+
+1. Open the Company record in **Partner Center** > **CRM** > **Companies**.
+2. Click **Edit** and go to **Basic Information**.
+3. Check the **Market** field.
+
+**Fix:** Update either the salesperson's market assignments or the Company's market so they match. Once they do, the salesperson will be able to see the Company in their CRM view.
+
 ## Administration and management
 
 Manage your salespeople by going to **Partner Center > Administration > My Team**. This centralized management interface provides all the tools needed to maintain accurate salesperson information and ensure proper system access across your organization.

--- a/docusaurus/docs/marketplace/products/edition-changes.mdx
+++ b/docusaurus/docs/marketplace/products/edition-changes.mdx
@@ -1,0 +1,60 @@
+---
+title: Edition changes and proration
+sidebar_label: Edition changes
+description: Understand how upgrading or downgrading product editions is billed, including proration for Vendasta O&O products.
+tags: [marketplace, editions, billing, proration]
+keywords: [edition change, upgrade, downgrade, proration, standard, pro, billing]
+---
+
+# Edition changes and proration
+
+## Which products this applies to
+
+Edition changes and proration apply to Vendasta's own-and-operated (O&O) products:
+
+- Reputation Management
+- Social Marketing
+- Customer Voice
+
+These products offer Standard and Pro editions. When you change editions, the charge is prorated based on how many days the current edition has been active in the billing cycle.
+
+## What happens when you upgrade
+
+When you upgrade from Standard to Pro mid-cycle, you are charged immediately for the Pro edition. The charge is reduced by the prorated value of the days Standard was already active in the current billing period.
+
+**Worked example:**
+
+- Social Marketing renews on December 25
+- You upgrade from Standard to Pro on December 15
+- Standard was active for 10 days of the 30-day cycle before the upgrade
+- The Pro charge is reduced by the prorated Standard cost for those 10 days (approximately $9.49 in this example)
+
+The net result is that you pay for Pro from the upgrade date through the renewal date, minus credit for unused Standard days.
+
+## What happens when you downgrade
+
+When you downgrade from Pro to Standard, the change typically takes effect at the next renewal date rather than immediately. You continue to have Pro access until the renewal date, and Standard billing begins on the next cycle.
+
+:::info
+Downgrade timing may vary. Check the product's current subscription details to confirm when the change takes effect.
+:::
+
+## Frequently asked questions
+
+<details>
+<summary>Why was I charged immediately when I upgraded?</summary>
+
+Edition upgrades on O&O products (Reputation Management, Social Marketing, Customer Voice) are charged immediately when the upgrade is applied, prorated from the upgrade date through the next renewal date. This is different from most subscription changes, which take effect at renewal.
+</details>
+
+<details>
+<summary>How is the prorated credit calculated?</summary>
+
+The credit equals the daily rate of the edition you're upgrading from, multiplied by the number of days it was active in the current cycle before the upgrade. This amount is subtracted from the full price of the new edition.
+</details>
+
+<details>
+<summary>Does edition change apply to add-ons?</summary>
+
+Add-ons are separate from edition changes and are billed independently. Changing an edition does not automatically change or remove add-ons.
+</details>

--- a/docusaurus/docs/marketplace/products/yext-listing-sync-troubleshooting.mdx
+++ b/docusaurus/docs/marketplace/products/yext-listing-sync-troubleshooting.mdx
@@ -1,0 +1,56 @@
+---
+title: Yext Listing Sync troubleshooting
+sidebar_label: Yext troubleshooting
+description: Resolve common Yext Listing Sync errors including "Invalid Entity Field Categories" and other sync issues.
+tags: [yext, listing-sync, troubleshooting, marketplace]
+keywords: [yext error, invalid entity field categories, listing sync, yext troubleshooting]
+---
+
+# Yext Listing Sync troubleshooting
+
+## Error: "Invalid Entity Field Categories"
+
+### What this error means
+
+The error "Invalid Entity Field Categories" appears in Yext Listing Sync when the business category assigned to the account is not in Yext's category catalog. Yext maintains its own list of supported business categories, and categories that don't map to a valid Yext category will cause this error.
+
+This is a configuration issue — it does not indicate a problem with the sync service itself.
+
+### How to fix it
+
+Update the account's business category to one that Yext supports. Choose a category that closely describes the business.
+
+**Example:** If the account has "Car detailing service" and that category isn't in Yext's catalog, update it to "Auto Repair Shop" or another similar supported category.
+
+**Steps:**
+
+1. Navigate to **Partner Center** > **Accounts** > **Manage Accounts**.
+2. Open the account with the error.
+3. Click **Edit Account** and go to **Business Profile** > **Categories**.
+4. Remove the unsupported category and select a similar category from the available list.
+5. Save the account.
+6. Retry the Yext Listing Sync from the account's product settings.
+
+:::tip
+If you're unsure which category Yext supports, choose a broader industry category (e.g., "Automotive" or "Home Services") as a starting point. You can update it again once you identify the closest supported option.
+:::
+
+## Frequently asked questions
+
+<details>
+<summary>How do I know which categories Yext supports?</summary>
+
+Yext's supported category list is not exposed directly in Partner Center. The most reliable approach is to select a well-known, broad industry category from the Business Categories list and test the sync. If the error persists, try a broader parent category.
+</details>
+
+<details>
+<summary>Will changing the category affect other listing products?</summary>
+
+Yes. The business category is shared across all listing products on the account. Changing it affects how the business is categorized on all connected directories, not just Yext. Choose a category that accurately represents the business.
+</details>
+
+<details>
+<summary>The category looks correct — why is Yext still rejecting it?</summary>
+
+Some categories that appear valid in Partner Center are not in Yext's specific catalog. Even if a category works for other listing products, Yext may not support it. Try a similar category or a broader parent category.
+</details>


### PR DESCRIPTION
## Summary

Implements 15 Help Center article recommendations surfaced during the Guru card cleanup across the **Accounts** and **CRM** sections. Covers both updates to existing articles (missing content added) and 5 new articles for gaps with no existing coverage.

### Accounts section (8 recommendations)

**Updated existing articles:**
- `create-accounts.mdx` — SAB account creation (why search fails, Skip to Account Creation workflow, Listing Sync warning); CSV import (`ServiceAreaBusiness` field case-sensitivity, UTF-8 format, enrichment behavior, auto-activation limitation)
- `list-actions.mdx` — 5,000 account list size limit and 500-account bulk activation cap with workarounds; expanded Add Tags step-by-step
- `delete-accounts.mdx` — Commitment billing continues after deletion; market deactivation reassigns to default market; new FAQs
- `order-processing-and-activation.mdx` — How to approve an order without activating products (invoice-first workflow)

**New articles:**
- `marketplace/products/edition-changes.mdx` — Edition upgrade/downgrade proration for O&O products with worked example
- `accounts/manage-users/welcome-email.mdx` — What's customizable, Marketing Campaigns workaround, market white-label behavior
- `marketplace/products/yext-listing-sync-troubleshooting.mdx` — "Invalid Entity Field Categories" error fix

### CRM section (7 recommendations)

**Updated existing articles:**
- `crm/contacts/index.mdx` — Partner Center vs. Business App import differences; first-row company name rule; categories dropdown note; common errors table; bulk-assigning salespeople via CSV
- `crm/salespeople/index.mdx` — Market-based visibility explanation (two-layer access: role + market) with fix steps
- `crm/companies/index.mdx` — Bulk delete (100-record limit, irreversibility, notes-lost warning); recreating a deleted company

**New articles:**
- `crm/companies/lifecycle-stages.mdx` — Full lifecycle stage glossary with automatic transitions and manual override caveat
- `crm/contacts/sms-communication-consent.mdx` — Consent states, why Unset blocks SMS, how to update, compliance context

## Test plan

- [ ] Verify new pages render correctly in a local dev build (`npm run start` from `docusaurus/`)
- [ ] Confirm new files appear in the sidebar under their respective sections
- [ ] Check that no existing links are broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)