### PR TITLE
docs(campaigns): add missing Help Center content from Guru card cleanup

### DIFF
--- a/docusaurus/docs/marketing/campaigns/create-email-campaigns.mdx
+++ b/docusaurus/docs/marketing/campaigns/create-email-campaigns.mdx
@@ -90,7 +90,21 @@ Use this feature to hide or customize the logo for each email you design. The lo
 
 ![Email Builder Logo Customization](./img/marketing/campaigns/email_builder_logo_customization.jpg)
 
-The logo customization block also allows adding URLs to direct users when they click on the logo.
+The logo customization block has three options:
+- **Default** — Uses the partner logo configured in your branding settings.
+- **Custom** — Upload a different image. You can set the width and alignment, and add a URL so clicking the logo takes recipients to a destination of your choice.
+- **Hide** — Removes the logo from this email entirely.
+
+### Adjusting padding between content blocks
+
+If you have two images stacked on top of each other and there's an unwanted gap between them, it's caused by the default padding on each block. To remove the gap:
+
+1. Click the upper block to select it.
+2. In the block settings panel, set **Bottom Padding** to `0`.
+3. Click the lower block to select it.
+4. Set **Top Padding** to `0`.
+
+This eliminates the space between the two blocks. The same approach works for any adjacent blocks where you want tighter spacing.
 
 ### Working with Content Blocks
 

--- a/docusaurus/docs/marketing/campaigns/index.mdx
+++ b/docusaurus/docs/marketing/campaigns/index.mdx
@@ -193,6 +193,38 @@ This prevents disruption to ongoing campaigns and maintains data integrity for r
 </details>
 
 <details>
+<summary>Can I edit a recommended campaign directly, or save it as an email template?</summary>
+
+Recommended campaigns are read-only — you can't edit them in place or save them as a standalone email template. To use one:
+
+1. Go to **Marketing** → **Campaigns** → **Recommended Campaigns**.
+2. Click the campaign name, then click **Actions** → **Copy**.
+3. Open the copy and edit it freely — it's now your own campaign in Draft status.
+
+The copy-first model means your edits never affect the original recommended campaign.
+
+**Why do CTAs give a 404 error when I test a recommended campaign?**
+
+If you preview or test a recommended campaign using a generic test account, any CTA buttons that link to the recipient's Business App (such as product activation or report buttons) will return a 404 error — because those links require a real account with a real user. To test CTAs, use a real account and add yourself as a user, then send the campaign to that account.
+</details>
+
+<details>
+<summary>Where did the Acquisition, Adoption, and Upsell campaign sections go?</summary>
+
+These campaign types were previously displayed as separate sections in the Campaigns view. They're now organized using **tags** in the main Campaigns list — the content is all still there, just accessed differently.
+
+**To find your old campaigns:**
+1. Go to **Marketing** → **Campaigns**.
+2. Use the tag filter to filter by **Acquisition**, **Adoption**, or **Upsell**.
+
+**To create and apply tags to any campaign:**
+1. Open a campaign.
+2. Click **Manage Tags** (or the tag icon) to create a new tag or apply an existing one.
+
+Tags let you organize campaigns any way you like — you're not limited to the three default types. Consider creating tags for your own naming conventions, such as by market, product line, or funnel stage.
+</details>
+
+<details>
 <summary>Is there a limit on how many emails partners can send from the platform?</summary>
 
 Yes, there is a daily email quota for partner-level email sending based on your subscription tier. This limit applies to emails sent by partners on behalf of their clients, such as review requests and partner-initiated campaigns.

--- a/docusaurus/docs/marketing/campaigns/send-marketing-emails.mdx
+++ b/docusaurus/docs/marketing/campaigns/send-marketing-emails.mdx
@@ -163,8 +163,20 @@ When sending campaigns, you can:
 ### Sender Configuration
 Configure who the campaign is sent from:
 1. **Default sender** - Uses your configured email settings
-2. **Salesperson assignment** - When a salesperson is assigned to an account, their information will be used
+2. **Salesperson assignment** - When a salesperson is assigned to an account, their information will be used as the sender, overriding your partner-level sender settings
 3. **Custom sender** - Override with specific sender details for the campaign
+
+**How salesperson sender override works:**
+
+When an account has an assigned salesperson, campaign emails go out from the salesperson's email address and name — not your partner-level "from" address. This is by design so replies go directly to the salesperson managing the relationship.
+
+If the salesperson's email is on an unverified or unauthenticated domain, the platform automatically sends the email from your verified domain while preserving the salesperson's name as the display name (e.g., `Jane Smith via yourdomain.com`). This may appear in Gmail as "via yourdomain.com" in the sender line.
+
+**To send campaigns from your partner-level sender instead:** Remove the salesperson assignment from the account before starting the campaign.
+
+**Reply-to addresses:**
+
+The **Reply Address** field in **Marketing** → **Email Settings** → **Sender and Reply Settings** applies to system emails only (such as Daily Digest notifications) — not to campaign emails. Campaign replies go to the sender address (salesperson or partner-level sender, as described above).
 
 ### Email Deliverability Settings
 Ensure successful delivery by:

--- a/docusaurus/docs/marketing/campaigns/track-email-campaign-performance.mdx
+++ b/docusaurus/docs/marketing/campaigns/track-email-campaign-performance.mdx
@@ -56,8 +56,13 @@ Unfortunately, these external initiations are out of our control. To maintain ac
 - **Completed** - how many campaigns whose emails have all been delivered. **Note:** this does not mean that the recipient has received the email; only that SendGrid has successfully sent the email to the recipient's email server. It will be up to the recipient's email server to determine if the email can be sent to the recipient's inbox.
 
 #### Email performance
-- **Engaged recipients** - how many recipients have clicked on at least one email in their campaign. 
+- **Engaged recipients** - how many recipients have clicked on at least one email in their campaign. This counts the first unique click per email address — if the same address opens multiple emails, they are still counted as one engaged recipient.
 - **Delivery rate** - describes what percentage of emails were successfully delivered. This statistic is calculated by dividing how many emails were successfully delivered with how many emails were processed. Processed events mean that SendGrid has successfully received the email Vendasta sent, but have yet to send to the recipient's email server.
+
+:::note
+Delivery rate and undeliverable are calculated **per account**, not per individual user. If one account has multiple users, the metric reflects the account's overall delivery, not each user separately. This is why delivery rate may show 100% even when only a small number of users received the email.
+:::
+
 - **Open rate** - describes what percentage of all emails have been opened. This statistic is calculated by dividing how many emails were opened with how many emails were delivered. This statistic matches Open rate in the Campaigns page.
 - **Click to open rate** - describes what percentage of your emails opened have had links on their content body clicked. This is calculated by dividing how many click events have links captured with the number of opened emails. This statistic matches CTOR in the Campaigns page.
 - **Undeliverable** - how many emails were unable to be delivered. This statistic is calculated by dividing how many emails were bounced and dropped with how many emails were processed.

--- a/docusaurus/docs/marketing/email-settings/index.mdx
+++ b/docusaurus/docs/marketing/email-settings/index.mdx
@@ -130,6 +130,30 @@ Tells receiving email servers what to do with emails that fail SPF or DKIM check
 ## Frequently Asked Questions
 
 <details>
+<summary>Can I send campaigns from multiple domains or under a different brand?</summary>
+
+Yes — there are two approaches depending on what you're trying to do.
+
+**Option 1: Authorize an additional sender domain**
+
+If you want to send campaigns from a second domain (for example, a sub-brand or a different business unit), you can authenticate that domain in **Marketing** → **Email Settings** → **[Connect Domains](./connecting-domains.mdx)**. Each domain requires SPF, DKIM, and DMARC DNS records. DNS changes can take up to 72 hours to propagate, and verification won't complete until all records are published correctly.
+
+Once verified, you can select the domain as your sender in Email Settings.
+
+**Option 2: Create a separate market**
+
+If you need fully separate branding — different logo, name, and sender identity — you can create a new market in Partner Center. Each market can have its own email settings and branding. When you create a campaign, selecting the right market ensures it sends with that market's branding.
+
+:::note
+Creating additional markets requires a Custom plan. Contact your Vendasta representative to discuss plan options.
+:::
+
+**Troubleshooting:**
+- *Gmail shows "via yourdomain.com" in the sender line* — This appears when the sending domain doesn't match the from address domain. Ensure the domain you're sending from is the one authenticated in Email Settings.
+- *Domain stuck in "Pending"* — Check that all three DNS records (SPF, DKIM, DMARC) are published at your DNS provider and allow up to 72 hours for propagation.
+</details>
+
+<details>
 <summary>Should I add the exact DMARC record provided by the platform?</summary>
 
 No, the DMARC record provided is a recommendation, not a requirement. Any valid DMARC record will work, even if provided by another service. The key requirement is that the record must be valid for verification to succeed.


### PR DESCRIPTION
Addresses six gaps surfaced in the Marketing Automation Campaigns Guru folder cleanup:
- Clarify delivery rate and undeliverable metrics are per-account, not per-user
- Expand sender configuration docs with salesperson override, unverified domain behavior, and reply-to distinction
- Add FAQ on recommended campaign limitations (read-only, copy-first model, CTA 404 behavior)
- Add FAQ on sending from multiple domains or alternate branding via markets
- Add FAQ on campaign tags and where Acquisition/Adoption/Upsell sections went
- Expand email builder logo options and add padding guidance for stacked image blocks