### PR TITLE
docs(email-settings): add FAQs and troubleshooting from Guru cleanup

### DIFF
--- a/docusaurus/docs/marketing/campaigns/index.mdx
+++ b/docusaurus/docs/marketing/campaigns/index.mdx
@@ -239,7 +239,48 @@ Yes, there is a daily email quota for partner-level email sending based on your 
 
 The quota resets daily. If you need a higher email limit, consider upgrading your subscription tier.
 
-Note: Businesses sending emails through their own Campaigns have a separate quota that is not affected by the partner-level limit.
+**Campaign sending throughput:** Campaigns send at approximately **4 emails per minute** regardless of list size. This rate is fixed to protect domain reputation and deliverability. For large lists, this means a campaign to 1,000 contacts takes roughly 4 hours to complete. To work around this for time-sensitive sends, split your list into smaller segments and schedule them across multiple days.
+
+**SMB sending allowance:** Businesses (SMBs) sending emails through their own Campaigns have a separate daily allowance — up to 100,000 emails per day — once the SMB domain is configured for Campaigns in Email Settings. This allowance is independent of the partner-level quota above.
+
+</details>
+
+<details>
+<summary>My campaign appears stuck while sending or is loading indefinitely. What should I do?</summary>
+
+Campaigns go through a queue before emails start sending. The processing window is typically **10–15 minutes** before the first batch goes out. If the campaign is still stuck after 15 minutes:
+
+1. **Confirm all required fields are filled in** — Missing sender information, mailing address, or required campaign fields can prevent sending. Check **Partner Center > Administration > Partner Defaults** to verify your mailing address is configured.
+2. **Check for invalid contact addresses** — Invalid or malformed email addresses in your audience can stall the sending queue. Remove any contacts with clearly invalid addresses and retry.
+3. **Retry the campaign** — Go to **Marketing > Campaigns**, find the campaign, and check whether a retry option is available.
+
+If the campaign remains stuck after these steps, contact Vendasta support.
+
+</details>
+
+<details>
+<summary>Some contacts didn't receive the campaign email. How do I check and retry?</summary>
+
+1. Go to **Marketing > Campaigns** and open the campaign
+2. Check the **Campaign Reports** tab to see delivery status by contact — look for drops, bounces, or undelivered entries
+3. For contacts who were dropped rather than bounced, you may be able to re-add them and resend
+4. For very large lists, consider splitting into smaller batches on future sends to make it easier to identify and retry any drops
+
+Hard-bounced addresses (permanent delivery failures) cannot be automatically resubscribed. Contact Vendasta support if you need to reinstate a contact that hard-bounced.
+
+</details>
+
+<details>
+<summary>What do common bounce codes in Campaign Reports mean?</summary>
+
+| Code | Meaning | What to do |
+|------|---------|-----------|
+| `550 Blocked` | The receiving server rejected the email | Check whether your IP or domain is on a blacklist at [MXToolbox](https://mxtoolbox.com/blacklists.aspx) |
+| `550 5.7.509` (DMARC) | Email failed DMARC alignment | Verify your SPF and DKIM records are correctly configured and aligned — see [Email Authentication](/marketing/email-settings/email-authentication) |
+| `550 5.7.606 Access denied` | IP address banned by the receiving server | This requires delisting; contact Vendasta support |
+| `550 5.1.1 User unknown` | The recipient email address doesn't exist | Remove the address from your list |
+
+For a full list of error codes, see [Email Deliverability](/marketing/email-settings/email-deliverability).
 
 </details>
 

--- a/docusaurus/docs/marketing/email-settings/email-authentication/index.mdx
+++ b/docusaurus/docs/marketing/email-settings/email-authentication/index.mdx
@@ -58,14 +58,101 @@ To get the specific DNS records you need to add:
 DNS changes can take up to 48 hours to fully propagate across the internet. Be patient if your authentication doesn't show as verified immediately.
 :::
 
-## Troubleshooting
+## SPF troubleshooting
 
-If you're having trouble with email authentication:
+### You can only have one SPF record per domain
 
-- **Double-check your DNS records** - Make sure you've copied the values exactly as shown in Partner Center
-- **Wait for propagation** - DNS changes can take time to take effect
-- **Contact your DNS provider** - They can help verify that records were added correctly
-- **Check for existing records** - Some domains may already have SPF records that need to be modified rather than replaced
+DNS allows you to create multiple TXT records, but SPF requires a single record. If you add Vendasta's SPF entry as a second `TXT v=spf1 ...` record, it breaks SPF validation and email delivery will fail.
+
+**How to fix:** Combine all `include:` entries into a single SPF record. For example:
+
+```
+v=spf1 include:sendgrid.net include:mail.otherprovider.com -all
+```
+
+If you use a host like DreamHost that already sends through MailChannels, your combined record would be:
+
+```
+v=spf1 include:sendgrid.net include:mailchannels.net -all
+```
+
+### `-all` vs. `~all`
+
+| Mechanism | Meaning | Effect |
+|-----------|---------|--------|
+| `-all` | Hard fail | Unauthenticated emails are rejected |
+| `~all` | Soft fail | Unauthenticated emails are accepted but may be marked as spam |
+
+Use `-all` for the strongest protection. If you see emails silently landing in spam without a clear bounce, check whether your record ends in `~all` instead of `-all`.
+
+### The 10-DNS-lookup limit
+
+SPF has a hard limit of 10 DNS lookups per evaluation. Each `include:` counts toward this limit. If your record chains too many providers, SPF evaluation will fail even if the record syntax is correct.
+
+**To check:** Use a tool like [MXToolbox SPF Lookup](https://mxtoolbox.com/spf.aspx) to count your lookups and identify which `include:` entries can be consolidated or replaced with flattened IP ranges.
+
+### Common SPF issues
+
+| Symptom | Likely cause |
+|---------|-------------|
+| SPF not verifying in Partner Center | Multiple SPF records, or DNS hasn't propagated yet (allow up to 72 hours) |
+| Emails fail after adding Vendasta DNS record | You created a second SPF record; merge them into one |
+| SPF passes but emails still go to spam | `~all` softfail; change to `-all`, and check DKIM and DMARC too |
+
+## DMARC troubleshooting
+
+### Choosing a DMARC policy
+
+| Policy | Meaning |
+|--------|---------|
+| `p=none` | Monitor only — failed emails are delivered anyway |
+| `p=quarantine` | Failed emails go to spam/junk |
+| `p=reject` | Failed emails are rejected entirely |
+
+**Recommended starting point:** Begin with `p=none` to collect reports without affecting delivery, then tighten to `p=quarantine` or `p=reject` once you've confirmed SPF and DKIM are aligned.
+
+### Stopping DMARC failure reports
+
+If you're receiving a flood of DMARC report emails, it's because your DMARC record includes a `ruf=mailto:` (forensic reports) or `rua=mailto:` (aggregate reports) tag. To stop them, remove those tags from the record value.
+
+For example, change:
+
+```
+v=DMARC1; p=none; rua=mailto:reports@yourdomain.com; ruf=mailto:forensics@yourdomain.com
+```
+
+to:
+
+```
+v=DMARC1; p=none
+```
+
+### You can only have one DMARC record per domain
+
+Like SPF, you can only have one DMARC TXT record at `_dmarc.<yourdomain>`. If you use multiple monitoring services, combine their reporting addresses into a single `rua` tag using comma-separated `mailto:` addresses:
+
+```
+v=DMARC1; p=none; rua=mailto:service1@vendor.com,mailto:service2@vendor.com
+```
+
+### Verifying your DMARC record in Partner Center
+
+Go to **Partner Center > Marketing > Email Settings** and find your domain. A green checkmark next to DMARC means the record is valid and detected. An error state means either the record is missing, has a syntax problem, or DNS propagation is still in progress (allow up to 72 hours).
+
+### Common DMARC issues
+
+| Symptom | Likely cause |
+|---------|-------------|
+| Emails bounce with DMARC reject | Policy is `p=reject` and SPF or DKIM alignment is failing; verify both pass before tightening policy |
+| Receiving DMARC reports for every failed delivery | `ruf=mailto:` is set in the record; remove it |
+| Multiple DMARC records broke verification | Consolidate to a single `_dmarc.<domain>` TXT record |
+
+## General troubleshooting
+
+- **Double-check your DNS records** — Make sure you've copied the values exactly as shown in Partner Center
+- **Wait for propagation** — DNS changes can take up to 72 hours to take effect globally
+- **Contact your DNS provider** — They can verify that records were added correctly
+- **Check for conflicting records** — Look for existing SPF or DMARC records that need to be merged rather than replaced
 
 ## Need Help?
 

--- a/docusaurus/docs/marketing/email-settings/email-deliverability.mdx
+++ b/docusaurus/docs/marketing/email-settings/email-deliverability.mdx
@@ -119,6 +119,15 @@ Use merge tags to personalize:
 - Check how emails appear on different devices and email clients
 - Use email testing tools to check for spam triggers
 
+### 8. Gmail-specific considerations
+
+Gmail applies stricter filtering than many other providers, particularly for:
+
+- **Links that collect user information** — Gmail flags emails containing links to pages that gather user data, even if the content is legitimate. If campaigns are consistently filtered only on Gmail accounts, review your links and replace any that point to data-collection pages with safer alternatives.
+- **Linked-page content** — Gmail evaluates not just the email content but also the content of linked pages. Pages with spam signals can cause the email to be filtered even if the email itself looks clean.
+
+If Gmail-only filtering persists after reviewing links and content, register your domain on [Google Postmaster Tools](https://postmaster.google.com/) to monitor your domain reputation and authentication results with Gmail.
+
 ## Technical Configuration
 
 ### Platform Authentication
@@ -241,6 +250,74 @@ If your message is rejected with any of these reasons, it means your IP or domai
 3. **Review content** - Ensure your email content doesn't trigger spam filters
 4. **Verify authentication** - Check that your SPF, DKIM, and DMARC records are properly configured
 5. **Monitor sending practices** - Review your sending volume, frequency, and list hygiene
+
+</details>
+
+<details>
+<summary>Links in my emails are being blocked or rewritten by Microsoft Defender Safe Links. How do I fix this?</summary>
+
+Microsoft Defender Safe Links is a security feature in Microsoft 365 that rewrites URLs in incoming emails and scans them before allowing them to open. This can cause campaign links — including links sent through `sendgrid.net` — to be blocked or display an error page.
+
+There are two resolution paths depending on whether the affected user is on a personal Outlook.com account or a managed Microsoft 365 organization.
+
+**For organizations with Microsoft Defender Premium (IT admin required):**
+
+1. Sign in to the [Microsoft 365 Defender portal](https://security.microsoft.com)
+2. Go to **Email and collaboration > Policies and rules > Threat policies > Safe Links**
+3. Edit the applicable Safe Links policy
+4. Under **Do not rewrite the following URLs**, add:
+   - `*.sendgrid.net/*`
+   - `*.<your-partner-domain>.com/*`
+   - `*.<your-business-app-url>.com/*`
+5. Save the policy
+
+Use wildcard syntax as shown. Changes take effect for new emails after the policy is saved.
+
+**For individual users on Outlook.com:**
+
+1. Sign in to [Outlook.com](https://outlook.com)
+2. Go to **Settings > Mail > Junk email**
+3. Under **Safe Links**, disable the link-rewriting option
+
+Note that this only applies to future messages — previously received emails with rewritten links are not affected.
+
+If the issue persists after updating the policy, confirm the correct Safe Links policy was edited and that the wildcard syntax matches your domains exactly.
+
+</details>
+
+<details>
+<summary>How do I help a recipient whitelist my sender address so emails don't go to spam?</summary>
+
+Ask recipients to add your sender address to their safe senders list using the steps for their email client.
+
+**Outlook 365:**
+1. Go to **Settings > View all Outlook settings > Mail > Junk email**
+2. Under **Safe senders and domains**, click **Add**
+3. Enter your sender email address or domain and save
+
+**Gmail:**
+1. Open a previous email from your sender address
+2. Click the three dots in the top right of the email
+3. Select **Filter messages like these**
+4. Click **Create filter**
+5. Check **Never send it to Spam** and click **Create filter**
+
+Alternatively, the recipient can drag the email from Spam to their inbox — Gmail treats this as a "Not spam" signal and learns from it over time.
+
+</details>
+
+<details>
+<summary>Calendar invitation emails are going to spam in Gmail. How do I fix this?</summary>
+
+Gmail sometimes routes calendar invitation emails to spam, even when the sender is trusted. This is a Gmail-side behavior related to how it handles calendar events from unknown senders.
+
+Ask the recipient to:
+
+1. Find the calendar invitation email in their **Spam** folder
+2. Open the email and click **Add to Calendar**
+3. Click **Report as Not Spam** (or drag the email to the inbox)
+
+Once the recipient marks the email as Not Spam, future calendar invitations from the same sender are more likely to land in the inbox.
 
 </details>
 

--- a/docusaurus/docs/marketing/email-settings/index.mdx
+++ b/docusaurus/docs/marketing/email-settings/index.mdx
@@ -171,6 +171,37 @@ Yes, the platform has a limit of 32,000 characters of HTML source code per email
 While not required, registering your domain with Google Postmaster Tools provides valuable insights into your email deliverability and reputation with Gmail users, which can help optimize your email performance.
 </details>
 
+<details>
+<summary>Can I use a different domain for Marketing Email Settings vs. Partner Branding Email Settings?</summary>
+
+No. Marketing Email Settings and Partner Branding Email Settings are tied — they share the same sending domain. You cannot configure a separate domain for campaign sends versus brand notifications (such as Daily Digests or Executive Reports). If you change the domain in one place, it affects both.
+
+</details>
+
+<details>
+<summary>Why does the reply-to address always match my sender email?</summary>
+
+The reply-to address is automatically set to match the market's sender email. This is intentional — it prevents white-label breaks on automated emails like Daily Digests and Executive Reports, which need to reply back to the configured sender identity rather than a different address.
+
+If you need different reply-to addresses across audiences, the supported approach is to create separate markets, each with its own sender email. The platform natively supports up to two authenticated sending domains.
+
+</details>
+
+<details>
+<summary>I'm getting an "Invalid DNS zone file" error when adding a CNAME record. How do I fix this?</summary>
+
+This error typically means there is a conflicting A record at the same hostname where you're trying to add a CNAME. DNS does not allow a CNAME and an A record to coexist at the same name.
+
+To fix this:
+
+1. Log in to your DNS provider (GoDaddy, Namecheap, etc.)
+2. Look for an existing A record at the same hostname as the CNAME you're trying to add
+3. Delete the A record, then add the CNAME
+
+If you're unsure which record is conflicting, use a DNS lookup tool like [MXToolbox](https://mxtoolbox.com/DNSLookup.aspx) to see all existing records for the hostname before making changes.
+
+</details>
+
 ## Best Practices
 
 ### Domain Management


### PR DESCRIPTION
## Summary

Updates 4 existing articles based on the Guru Email Settings section cleanup (30 internal cards → 7 Help Center recommendations).

- **email-authentication/index.mdx**: Added dedicated SPF troubleshooting (single-record requirement, worked combine example, `-all` vs `~all`, 10-lookup limit) and DMARC troubleshooting (policy comparison, stopping `ruf=` reports, one-record-per-domain, verifying in Partner Center)
- **email-deliverability.mdx**: Added Gmail-specific filtering guidance (links, linked-page content), recipient whitelisting steps for Outlook 365 and Gmail, calendar invitation spam fix, and Microsoft Defender Safe Links FAQ with both resolution paths (Defender Premium and Outlook.com)
- **email-settings/index.mdx**: Added FAQs for Marketing vs Partner Branding domain coupling, reply-to behavior, and Invalid DNS zone file errors
- **campaigns/index.mdx**: Expanded sending limits FAQ with ~4 emails/minute throughput explanation and SMB allowance; added campaign delivery troubleshooting FAQs (stuck loading, partial delivery/retry, bounce code reference)

Source: Vendasta Guru "Email Settings" section cleanup — 30 Guru cards consolidated into 7 Help Center recommendations (2026-05-12).

## Test plan

- [ ] Verify SPF/DMARC tables render correctly in email-authentication/index.mdx
- [ ] Verify new FAQ dropdowns render correctly in all four files
- [ ] Confirm no broken internal links

🤖 Generated with [Claude Code](https://claude.com/claude-code)