### PR TITLE
docs(inbox-lists): add missing Help Center content from Guru card cleanup

### DIFF
--- a/docusaurus/docs/accounts/accounts-lists/create-account-lists.mdx
+++ b/docusaurus/docs/accounts/accounts-lists/create-account-lists.mdx
@@ -59,3 +59,46 @@ Required CSV fields include CompanyName and Zip. Keep unknown fields empty; the 
 Tags for contacts, companies, and accounts have a maximum length of 50 characters and may include only standard alphanumeric characters (A-Z, 0-9), dashes (-), spaces ( ), or underscores (_).
 
 Please avoid using special characters such as @, #, $, %, &, etc., as they can interfere with filtering and searching functionality.
+
+### Choosing the right import template
+
+There are several CSV templates depending on what you are importing:
+
+| What you're importing | Template to use |
+|-----------------------|-----------------|
+| Business accounts (create or update) | `import_list_template.csv` — downloaded from the Import Lists dialog |
+| Bulk-update existing accounts | Bulk Update CSV template — available at **Partner Center > Accounts > Bulk Update** |
+| Users for Business App access | `user-import-template.csv` — see [Create User Lists & Bulk Import Users](./create-user-lists-bulk-import-users) |
+| CRM contacts and companies | `Contacts_Companies_Import_template` — downloaded from **CRM > Contacts > Import** |
+
+Using the wrong template is a common cause of import failures. Always start from the template for your specific import type.
+
+### Understanding key column names
+
+**`UserGreetingName1`** — This column maps to the **Greeting name** field on the user record, not a job title. It is the informal name the platform uses when addressing the user (e.g., in emails). Do not put a job title here; use the `job_title` column for that.
+
+### Country codes: UK must be entered as `GB`
+
+The import system uses **ISO 3166-1 alpha-2** two-character country codes. The United Kingdom's code is **`GB`**, not `UK`. Entering `UK` will cause the row to fail or import with a blank country.
+
+Common codes to remember:
+
+| Country | Correct code |
+|---------|-------------|
+| United Kingdom | `GB` |
+| United States | `US` |
+| Canada | `CA` |
+| Australia | `AU` |
+
+### Import size limits
+
+The front-end import accepts a maximum of **5,000 records per file**. If your list exceeds 5,000 rows, split it into multiple files and import them sequentially. For very large one-time imports, contact Support to request a bulk import as a managed task.
+
+### Common import errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| Row fails with country error | `UK` used instead of `GB` (or other invalid code) | Replace with the correct ISO alpha-2 code |
+| Phone number import fails | Phone numbers contain formatting characters like `(`, `)`, or spaces | Use digits only or E.164 format: `+14165551234` |
+| Import completes but data is wrong | Wrong template used for the import type | Re-export using the correct template and reimport |
+| Malformed CSV error | CSV was edited in an app that changed encoding or delimiters | Open in a plain-text editor to verify commas and UTF-8 encoding |

--- a/docusaurus/docs/accounts/accounts-lists/list-actions.mdx
+++ b/docusaurus/docs/accounts/accounts-lists/list-actions.mdx
@@ -7,6 +7,17 @@ sidebar_position: 4
 
 The following administrative actions are available from **Partner Center > Accounts > Lists >  click the three dots next to the desired list**.
 
+## Customizing a static list view
+
+You can change which columns appear in your list view to surface the information that matters most to you (email, phone, tags, etc.):
+
+1. Open your list in **Partner Center > Accounts > Lists**
+2. Click the **gear icon** in the upper-right corner of the list table
+3. Check or uncheck the columns you want to show or hide (e.g., Email, Phone, Tags)
+4. Close the panel — the view saves automatically
+
+Customized column views are per-user and per-list, so each team member can set up their own preferred view.
+
 ## Account list limits
 
 | Limit | Value | Workaround |
@@ -64,6 +75,14 @@ Creates a downloadable CSV with the current data of all accounts in the List. Th
 - Healthcare fields (if applicable)
 
 After selecting **Export Account Data**, you will be taken to the List's **History** page. Once the export has finished, you will be able to download the CSV by clicking the **Menu** icon ![Menu icon](./img/accounts/lists/menu-icon.png), then **Account NAP/Product CSV**.
+
+:::note Export limitations
+The exported CSV is informational data only. It does **not** include clickable links back to the account records in Partner Center — you cannot click directly into an account from the spreadsheet.
+:::
+
+### Exporting user details (names and emails)
+
+The standard Export Account Data export contains account/business data (NAP + products), not individual user names and email addresses. To export a list of users associated with your accounts, contact Support and request a user details export.
 
 ## Add Tags
 

--- a/docusaurus/docs/ai/ai-workforce/ai-voice-receptionist.md
+++ b/docusaurus/docs/ai/ai-workforce/ai-voice-receptionist.md
@@ -325,6 +325,35 @@ All call recordings, transcripts, and summaries are automatically saved to:
 This allows your team to review interactions, follow up with callers, and maintain a complete record of customer communications. Note that call recordings and transcripts are available with Premium Conversations AI.
 </details>
 
+### Configuration
+
+<details>
+<summary>Can I change the Interruption Threshold (Voice Activity Detection)?</summary>
+
+The **Interruption Threshold** controls how sensitive the AI is to detecting that a caller has started speaking (voice activity detection). It is set on a scale of **0.6 – 0.75**, with a default of **0.75**.
+
+- **Higher value (0.75)** — the AI waits longer before treating speech as an interruption. Use when callers are in noisy environments or when the AI is cutting off too early.
+- **Lower value (0.6)** — the AI responds more quickly to detected speech. Use when callers feel the AI is not picking up on their words fast enough.
+
+Adjust this setting in your AI Voice Receptionist configuration if callers report being cut off or if the AI is slow to acknowledge them.
+</details>
+
+<details>
+<summary>How do I configure Missed Call Text-Back?</summary>
+
+Missed Call Text-Back sends an SMS to a caller when their call is not answered. To configure it:
+
+1. Go to **AI > AI Workforce > Voice Receptionist > Configure**
+2. Find the **Missed Call Text-Back** toggle and enable it
+3. Choose the timing option:
+   - **Immediately** — sends the text as soon as the call is not answered by a human
+   - **If the forwarded call is missed** — sends the text only if the forwarded-to number also doesn't answer
+
+:::note
+If the forwarded call rings through to voicemail and the voicemail system picks up, the carrier considers the call "connected" — even if no human answered. In this case, the "If the forwarded call is missed" option will not trigger. Use **Immediately** if you want to ensure the text always goes out.
+:::
+</details>
+
 ### Troubleshooting
 
 <details>
@@ -356,6 +385,12 @@ Yes! You can update your AI Voice Receptionist anytime by:
 - **Changing voice settings** in the Profile > Speech section
 
 Changes take effect immediately, so you can continuously improve your AI's performance based on real-world interactions.
+</details>
+
+<details>
+<summary>Can the AI Voice Receptionist receive SMS verification codes or MFA texts?</summary>
+
+No. The Conversations AI phone number assigned to your AI Voice Receptionist is not able to receive SMS verification codes or multi-factor authentication (MFA) texts. If you need to verify an account or receive a one-time code, use a personal mobile number or a separate business phone number for that purpose.
 </details>
 
 <details>

--- a/docusaurus/docs/business-app/conversations/conversations-ai/index.mdx
+++ b/docusaurus/docs/business-app/conversations/conversations-ai/index.mdx
@@ -5,6 +5,10 @@ description: Setup and configuration guide for AI receptionist capabilities in C
 
 # Conversations AI
 
+:::info Inbox Pro has been retired
+Inbox Pro was retired on **July 16, 2025** and replaced by Conversations AI. If you are migrating from Inbox Pro, activate Conversations AI **first**, then deactivate Inbox Pro — doing it in the wrong order may require re-enabling certain channels. The "Inbox" tab in Business App has been renamed to "Conversations." Your previous settings and channels are retained when the migration order is followed correctly.
+:::
+
 Conversations AI is a paid product upgrade that adds AI receptionist functionality to the standard Conversations platform. The AI employee can handle incoming communications across multiple channels when human staff are unavailable.
 
 ## What Conversations AI Unlocks
@@ -144,6 +148,14 @@ Premium voice features are limited to US and Canada businesses. See [Geographic 
 - Error handling for failed API connections
 
 ## Frequently Asked Questions
+
+### **Inbox Pro migration**
+
+**Q: We were on Inbox Pro — what do we need to do?**
+Inbox Pro was retired July 16, 2025. Activate Conversations AI first, then deactivate Inbox Pro. If you deactivated Inbox Pro before activating Conversations AI, some channels (SMS, social) may need to be re-enabled after activation. Contact support if channels are missing after migration.
+
+**Q: Why does the "Inbox" tab now say "Conversations"?**
+This is a UI rename only — it reflects the product rename from Inbox Pro to Conversations AI. No functionality was removed.
 
 ### **Product Selection**
 

--- a/docusaurus/docs/business-app/conversations/conversations-ai/understanding-lead-capture-notifications.mdx
+++ b/docusaurus/docs/business-app/conversations/conversations-ai/understanding-lead-capture-notifications.mdx
@@ -141,6 +141,40 @@ Every notification includes an AI-generated conversation summary. This summary:
 **Example summary:**
 > "Visitor is interested in getting a quote for backyard landscaping. They have a 500 sq ft area and want low-maintenance plants. Prefers to be contacted by phone in the afternoon."
 
+## Notification timing: new leads vs. follow-ups
+
+New lead notifications fire **only when a brand-new contact is created**. If the same person messages again — from a known number, email, or device — you receive a "Conversation Update" instead of a "New Lead."
+
+Follow-up messages from existing contacts do not trigger a notification by default. To get alerted on follow-ups, set up an Automation:
+
+1. Go to **Automations** and create a new automation
+2. Set the trigger to **"A contact communication summary is created"**
+3. Add the action **"Send notification"** to the appropriate team member(s)
+
+This fires after each conversation summary is generated, covering both new leads and returning contacts.
+
+## Reply-to on new lead notification emails
+
+When you receive a "New Lead from Web Chat" email notification, the reply-to address is `noreply@<your-domain>`. Replying to that email will not reach your customer. Instead:
+
+- **Forward the notification** to share it with a colleague
+- **Click the link in the notification** to open the conversation in Conversations AI and reply from there
+
+## Auto-follow and unfollowing conversations
+
+You are automatically set to follow a conversation when:
+
+- You **send a message** in that conversation
+- You are **assigned as Salesperson** to the account (follows all past and future conversations for that account)
+
+Auto-following means you will receive notifications for that conversation even when "Only my events" is selected. To stop receiving notifications for a conversation you don't need to track, click the **star (★)** in the conversation header to unfollow it.
+
+If someone other than the intended Salesperson is receiving Inbox notifications, check whether they participated in a conversation (and were auto-followed) or were assigned as Salesperson to the account.
+
+## Closed conversations reopening
+
+When a customer sends a new inbound message on a number or channel tied to a conversation that was previously marked as closed, the conversation automatically **reopens**. This is expected behavior — there is no separate notification type for a reopened conversation; it appears as a new inbound message in the conversation thread.
+
 ## Frequently asked questions
 
 **Q: Why didn't I get a "New Lead" notification?**
@@ -173,3 +207,13 @@ Every notification includes an AI-generated conversation summary. This summary:
 - For duplicate contacts (recognized by email/phone match), the existing record is preserved
 - Only missing postal code may be added automatically
 - You can manually update other fields in the CRM if needed
+
+**Q: Someone other than the Salesperson is getting Inbox notifications — why?**
+- Any user who sends a message in a conversation is automatically set to follow it
+- Users assigned as Salesperson to an account follow all conversations for that account
+- To stop receiving notifications, the user can unfollow the conversation by clicking the ★ in the conversation header
+
+**Q: I'm not getting any notifications at all — what should I check?**
+- Confirm your user account exists and is active in Partner Center
+- Verify Conversations AI is activated for the account
+- Check that notification preferences are enabled (bell icon > gear icon > enable "All events" or "Only my events")

--- a/docusaurus/docs/business-app/conversations/sms/us-businesses-sms-registration.mdx
+++ b/docusaurus/docs/business-app/conversations/sms/us-businesses-sms-registration.mdx
@@ -41,6 +41,39 @@ By unifying the SMS number for both review requests and Conversations AI communi
 
 <iframe src="//www.loom.com/embed/af8eae1a260e4b5b93879c91fc09f16f" width="560" height="315" frameBorder="0" allowFullScreen></iframe>
 
+## Finding your assigned SMS phone number
+
+After activating Conversations AI Pro, your business is automatically assigned an SMS number based on the business profile address. To find it:
+
+1. Go to **Business App > Administration > Conversation Settings**
+2. Look for **Your SMS number**
+
+If a local number is unavailable for your area code, a neighboring area number is assigned. Contact support to request a different area code or a toll-free number as an alternative.
+
+## Responding via SMS: Partner Center vs. Business App
+
+Conversations AI in **Business App** supports two-way SMS with customers. **Partner Center** does not support replying via SMS to customer messages — if you receive an SMS lead in Partner Center, open Business App to reply.
+
+## SMS campaign failures
+
+SMS campaigns will fail to send if the account's mailing address is incomplete. The following fields are required:
+
+- Street address
+- City
+- Postal / ZIP code
+
+Update the business profile address to resolve the issue before resending.
+
+## SMS automation delivery timing
+
+SMS automations deliver more slowly than email because each message undergoes carrier verification and rate-limiting. This is expected behavior — the **"Sent"** status in automation logs reflects when the message was queued, not when it was delivered.
+
+For large automations, batch no more than **250 contacts per trigger** to avoid queue congestion and ensure timely delivery.
+
+## Messaging Templates and the "SMS Configuration" label
+
+The **Messaging Templates** section in Inbox Settings includes a label called "SMS Configuration," but the templates created there are not SMS-only. They are available across **all messaging channels** in Conversations AI, including web chat, email, and SMS. You can use any template regardless of which channel the conversation is on.
+
 ## FAQs
 
 <details>
@@ -146,4 +179,16 @@ Registration is only available for US-based businesses, with Conversations AI Pr
 <summary><strong>There was a mistake on the registration form I submitted - can I cancel it?</strong></summary>
 
 No, the form cannot be edited or canceled once submitted. If information was missing or incorrect, the registration will eventually move to a 'failed' status. Once registration fails, the form can be resubmitted.
+</details>
+
+<details>
+<summary><strong>Can I restart the registration process if it's taking too long?</strong></summary>
+
+No. Do not attempt to restart or resubmit a registration that is still in progress. Restarting creates a duplicate submission and makes things worse — it can extend the wait time or cause the original registration to be rejected. Wait for the current submission to reach an approved or failed status before taking any action.
+</details>
+
+<details>
+<summary><strong>The webchat SMS function has been suspended — what does "forbidden industry" mean?</strong></summary>
+
+US phone carriers block SMS registration for certain industries regardless of whether the business is legal in their state. If a business's registration is suspended for "forbidden industry," SMS messaging cannot be enabled for that account. The business can still use web chat, email, WhatsApp, Facebook, and Instagram channels through Conversations AI. See the "Why was the registration rejected?" section above for the full list of restricted industries.
 </details>

--- a/docusaurus/docs/conversations/index.mdx
+++ b/docusaurus/docs/conversations/index.mdx
@@ -277,6 +277,31 @@ This ensures appropriate access control while maintaining team collaboration ben
 </details>
 
 <details>
+<summary>How do I remove a user's access to the Conversations tab?</summary>
+
+To prevent a user from seeing the Conversations tab in Partner Center:
+
+1. Go to **Partner Center > My Team**
+2. Find the user and click their row action menu
+3. Select **Edit member**
+4. Under **Admin permissions**, locate the Conversations permission and disable it
+
+The user will no longer see the Conversations tab after saving.
+</details>
+
+<details>
+<summary>Can I restrict a user so they only see conversations from their assigned market?</summary>
+
+Not currently. Conversations access in Partner Center is all-or-nothing — a user either has access to all conversations or none. There is no way to filter a user's view to only their assigned market's conversations. If you need to limit access, the only option is to remove Conversations access entirely for that user.
+</details>
+
+<details>
+<summary>Why does my multi-location user have a different Conversations view than a single-account user?</summary>
+
+Multi-location users and single-account users see different views in Conversations AI, particularly in how AI Webchat configuration appears. This is a known difference in how the product handles multi-location account structures. If this difference is causing confusion for your team, contact support for guidance on your specific setup.
+</details>
+
+<details>
 <summary>How does the "Following" feature help me manage conversations?</summary>
 
 The **★ Following** feature helps you focus on priority conversations:

--- a/docusaurus/docs/crm/index.mdx
+++ b/docusaurus/docs/crm/index.mdx
@@ -243,6 +243,12 @@ Following these steps will allow you to manage access to the company's `Business
 </details>
 
 <details>
+<summary>Why does a CRM string field autocomplete with values from other contacts?</summary>
+
+When you type into a CRM string field, you may see autocomplete suggestions pulled from values previously entered into that same field on other contacts. This is expected product-wide behavior — autocomplete draws from a global list of previously used values for each field, not from the specific contact you are editing. It is not a bug. You can ignore or dismiss the suggestion and type the correct value.
+</details>
+
+<details>
 <summary>Why would I use companies over accounts right now?</summary>
 
 Accounts and companies serve different purposes:


### PR DESCRIPTION
## Summary

Incorporates content from two Guru cleanup recommendation files (Inbox/Conversations AI and Lists) into existing docs. All changes are additions to existing files — no new files created.

**Conversations AI / Inbox (6 files):**
- `conversations-ai/index.mdx` — Inbox Pro retirement callout, correct migration order, migration FAQs (Rec #1)
- `understanding-lead-capture-notifications.mdx` — notification timing (new leads only), Automations workaround for follow-up alerts, reply-to email behavior, auto-follow/unfollow, closed conversation reopening (Rec #4)
- `ai-voice-receptionist.md` — Interruption Threshold FAQ, Missed Call Text-Back setup, SMS verification codes caveat (Rec #5)
- `us-businesses-sms-registration.mdx` — finding assigned phone number, Partner Center vs Business App for SMS replies, campaign failures, automation batching/timing, Messaging Templates clarification, restart registration and forbidden industry FAQs (Rec #6)
- `conversations/index.mdx` — access permission FAQs: market visibility restriction, multi-location view difference, removing Conversations tab access (Rec #8)
- `crm/index.mdx` — CRM field autocomplete global behavior FAQ (Rec #9)

**Lists (2 files):**
- `list-actions.mdx` — column customization guide (gear icon), export limitations callout (no hyperlinks back to accounts), user details export via Support (Rec #1)
- `create-account-lists.mdx` — template selection table, `UserGreetingName1` field clarification, UK→GB country code, 5,000-record limit, common import errors table (Rec #2)

## Test plan

- [ ] Review each updated section for accuracy against the Guru cleanup recommendation files
- [ ] Confirm no `>` blockquote characters were introduced
- [ ] Spot-check that new `<details>` FAQ entries render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)