### PR TITLE
docs(meetings): update external sharing to include summary and transcript

### DIFF
--- a/docusaurus/docs/crm/my-meetings/external-link-sharing.mdx
+++ b/docusaurus/docs/crm/my-meetings/external-link-sharing.mdx
@@ -1,14 +1,14 @@
 ---
 title: Share meeting recordings externally
 sidebar_label: External Link Sharing
-description: Share a public link to a meeting recording with people outside your organization using external link sharing.
-tags: [meetings, sharing, recordings, external]
-keywords: [external link sharing, public meeting link, share recording, public video link]
+description: Share a public link to a meeting recording, AI summary, and transcript with people outside your organization using external link sharing.
+tags: [meetings, sharing, recordings, external, summary, transcript]
+keywords: [external link sharing, public meeting link, share recording, public video link, share transcript, share summary]
 ---
 
 ## Overview
 
-External link sharing lets you generate a public link to a meeting recording that anyone can view, even if they are not part of your organization. This is useful when you need to share a recorded meeting with a client, prospect, or external stakeholder without requiring them to log in.
+External link sharing lets you generate a public link to a meeting recording, AI-generated summary, and transcript that anyone can view, even if they are not part of your organization. This is useful when you need to share a recorded meeting with a client, prospect, or external stakeholder without requiring them to log in.
 
 :::note
 Conversation intelligence features (meeting recording, AI summaries, sales coaching, and conversation scoring) are available with CRM AI Pro. See [CRM AI editions](/ai/ai-workforce/ai-sales-assistant#crm-ai-editions) for details.
@@ -27,15 +27,15 @@ Conversation intelligence features (meeting recording, AI summaries, sales coach
 
 ## What is external link sharing?
 
-External link sharing creates a public URL for a specific meeting recording. Anyone with the link can watch the video without needing an account or login. The link only provides access to the recording itself, not to the AI summary, transcript, sales coaching, or any other meeting details.
+External link sharing creates a public URL for a specific meeting. Anyone with the link can view the recording, AI-generated summary, and transcript without needing an account or login. Sales coaching, conversation scores, and other internal insights are not included in the external link.
 
 This is different from the internal **Share** button on the Meeting Details page, which controls visibility within your organization. External link sharing is designed for audiences outside your company.
 
 ## Why use external link sharing?
 
 - Share a recorded demo or presentation with a prospect after a call
-- Send a meeting recap to a client who could not attend
-- Provide a recording to an external collaborator for review
+- Send a meeting recap with summary and action items to a client who could not attend
+- Provide a recording and transcript to an external collaborator for review
 - Share a training or onboarding session with partners
 
 ## Who can enable or disable external sharing?
@@ -52,7 +52,7 @@ You also need write access to the meeting in the CRM.
 The meeting must have a recording before external sharing can be enabled. If the meeting has not been recorded, the option to share externally will not be available.
 :::
 
-## How to share a meeting recording externally
+## How to share a meeting externally
 
 1. Open the CRM.
 2. In the left-hand menu, select **CRM**, then select **My Meetings**.
@@ -60,9 +60,9 @@ The meeting must have a recording before external sharing can be enabled. If the
 4. Click the meeting to open the **Meeting Details** page.
 5. Select the **External share** option.
 6. Enable **Public access** to generate a shareable link.
-7. Copy the link and send it to anyone you want to share the recording with.
+7. Copy the link and send it to anyone you want to share the meeting with.
 
-The link is ready to use immediately. Recipients can watch the recording by opening the link in any browser.
+The link is ready to use immediately. Recipients can view the recording, summary, and transcript by opening the link in any browser.
 
 ## How to disable external sharing
 
@@ -78,38 +78,42 @@ Disabling and re-enabling external sharing for the same meeting produces the sam
 
 ## What external viewers can see
 
-External viewers who open the public link can watch the meeting video recording. All other meeting data remains private to your organization.
+External viewers who open the public link can access the meeting recording, summary, and transcript. Sales coaching, conversation scores, and other internal insights remain private to your organization.
 
-| Feature | Status |
-|---------|--------|
-| Meeting video recording | Available |
-| AI-generated summary | Coming soon |
-| Transcript | Coming soon |
-| Sales coaching and scores | Coming soon |
-| Action items and topics | Coming soon |
-| Guest and participant details | Coming soon |
+| Feature | Included in external link |
+|---------|--------------------------|
+| Meeting video recording | Yes |
+| Meeting title, date, and duration | Yes |
+| AI-generated summary | Yes |
+| Transcript | Yes |
+| Action items | Yes |
+| Topics discussed | Yes |
+| Sales coaching and scores | No |
+| Guest and participant details | No |
+
+The transcript on the external page is read-only. External viewers cannot download or copy the transcript.
 
 ## How external links work
 
 - Each meeting gets a unique public link the first time external sharing is enabled.
 - The link stays the same even if sharing is disabled and re-enabled later.
 - The link does not expire automatically.
-- No login or account is required to view the recording.
+- No login or account is required to view the recording, summary, or transcript.
 - The public link is independent from the internal visibility setting. Changing the internal visibility (Private, All, or Anyone with the link) does not affect the external link, and vice versa.
 
 ## Best practices
 
 - **Share selectively**
-  Only enable external sharing for meetings where the recording content is appropriate for an outside audience.
+  Only enable external sharing for meetings where the content is appropriate for an outside audience. Remember that the summary, transcript, and action items are also visible to anyone with the link.
+
+- **Review the summary and transcript before sharing**
+  The AI-generated summary and transcript may contain sensitive details discussed during the meeting. Review them before enabling external access.
 
 - **Disable sharing when no longer needed**
   If the external audience no longer needs access, disable public access to prevent further viewing.
 
 - **Communicate context**
-  When sending the link, include a brief note explaining what the recording covers so the recipient knows what to expect.
-
-- **Check recording quality**
-  Review the recording before sharing to confirm it captured the meeting clearly and does not contain sensitive information you did not intend to share.
+  When sending the link, include a brief note explaining what the meeting covers so the recipient knows what to expect.
 
 ## Frequently asked questions
 
@@ -128,9 +132,9 @@ No. The link remains active as long as public access is enabled. If you disable 
 </details>
 
 <details>
-<summary>Can I share the transcript or AI summary externally?</summary>
+<summary>What meeting details are included in the external link?</summary>
 
-No. External link sharing only provides access to the video recording. The transcript, AI summary, sales coaching, and all other meeting details remain internal.
+The external link includes the video recording, AI-generated summary, transcript, action items, and topics discussed. Sales coaching, conversation scores, and guest details are not included.
 
 </details>
 
@@ -158,7 +162,7 @@ View tracking is not currently available for external links.
 <details>
 <summary>Can I password-protect an external link?</summary>
 
-Password protection is not currently available. Anyone with the link can view the recording while public access is enabled.
+Password protection is not currently available. Anyone with the link can view the recording, summary, and transcript while public access is enabled.
 
 </details>
 


### PR DESCRIPTION
## Summary
- Updated the External Link Sharing doc to reflect that AI-generated summary, transcript, action items, and topics are now included in external shared links
- Replaced "Coming soon" table with current Yes/No availability
- Updated FAQ, best practices, and all references from video-only to full meeting content
- Added guidance to review summary and transcript before sharing externally

## Test plan
- [ ] Preview at `/crm/my-meetings/external-link-sharing` on local dev server
- [ ] Verify table renders correctly
- [ ] Confirm no broken links or build warnings from this file

🤖 Generated with [Claude Code](https://claude.com/claude-code)