### PR TITLE
docs(orders): add missing Help Center content from Guru card cleanup

### DIFF
--- a/docusaurus/docs/commerce/invoices/create-and-apply-tax-rates.mdx
+++ b/docusaurus/docs/commerce/invoices/create-and-apply-tax-rates.mdx
@@ -66,7 +66,28 @@ Alternatively, to apply a tax rate to a line item on an invoice, you can click t
 
 The tax rates that you have defined will be automatically applied to Shopping Cart purchases, as well as sales orders generated from Shopping Carts containing items that can't be purchased with a credit card. The application of tax rates is based on the address of the account, according to the regions for which you have specified tax rates.
 
-Note that if no tax rates for a given region have been created, purchases and sales orders conducted through the Shopping Cart by customers located in the region will not have a tax rate applied to them. 
+Note that if no tax rates for a given region have been created, purchases and sales orders conducted through the Shopping Cart by customers located in the region will not have a tax rate applied to them.
+
+### Taxes on Sales Orders and the invoice gap
+
+Tax rates configured for an account's location will appear in the **Retail Summary** section of a Sales Order. However, when you **create an invoice from a Sales Order**, those taxes do **not** automatically carry over to the invoice.
+
+This happens because the Sales Order stores the tax *rate* (a percentage), but the invoice requires a specific *tax ID* (the named tax rate you created in Administration > Tax Rates). Since the tax ID isn't stored on the order itself, the invoice builder cannot apply it automatically.
+
+**What to do:**
+
+When creating an invoice from a Sales Order:
+
+1. Open the invoice after it is generated
+2. For each taxable line item, click the **⋮** menu and select **Set Item Tax**
+3. Choose the appropriate tax rate from your configured list
+4. Review the total and send or charge the invoice
+
+**If taxes aren't appearing on your Sales Order at all:**
+
+- Confirm the account has a complete address (city, state/province, country, postal code)
+- Confirm you have created a tax rate for that location in **Administration > Tax Rates**
+- Tax rates apply based on the account's address — if the address is missing or in an unconfigured region, no tax is shown 
 
 
 ## Video Walkthrough

--- a/docusaurus/docs/commerce/orders/creating-and-managing-orders.mdx
+++ b/docusaurus/docs/commerce/orders/creating-and-managing-orders.mdx
@@ -169,6 +169,31 @@ With simplified sales orders, administrators can:
 
 You can track delivery in the Order Activity card and resubmit to new or same contacts using the "Resubmit for Customer Approval" button.
 
+### Resending the approval email
+
+If a customer hasn't received or can't find their approval email:
+
+1. Open the order in **Commerce > Orders**
+2. Click **Resend to a customer** in the order toolbar
+3. Confirm the contact and send
+
+:::note Why customers may receive the approval email more than once
+Orders approaching their expiry date trigger an automatic reminder re-send job (typically 1–2 days before expiry). If your customer receives the approval email multiple times, this is why. To stop the re-sends, either ask the customer to approve the order or cancel it.
+:::
+
+### Editing an order after it has been placed
+
+Orders can only be edited freely while in **Draft** status. Once submitted:
+
+- **Salespeople** cannot edit the order at all
+- **Admins with "Can Manage Orders"** can add or remove items from a **Pending** order before it is approved
+
+If you need to change something on a submitted order that is not in Pending status (for example, changing a contract start date), you must **decline or cancel the order** and create a new one with the correct details.
+
+### Cancelled orders cannot be restored
+
+Once an order is cancelled, it cannot be uncancelled or restored. If you need to re-create the order, use the **Duplicate** option from the order's action menu to copy it into a new draft, then update as needed and resubmit.
+
 ### Creating Orders for Admin Approval
 
 1. Create your order following the steps above

--- a/docusaurus/docs/commerce/orders/order-configuration-and-administration.mdx
+++ b/docusaurus/docs/commerce/orders/order-configuration-and-administration.mdx
@@ -30,12 +30,39 @@ With order configuration and administration, you can:
 - Manage Terms of Service for customer approvals
 - Control salesperson actions and capabilities
 
+:::info Orders experience refresh — July 2025
+The Orders workflow in Partner Center was redesigned in July 2025. If you see references to the older "Sales Orders" or "Sales and Success Center" flow, the steps may differ from your current interface.
+:::
+
 ## How to Set Up Order Configuration
 
 ### Accessing Order Configuration
 
 To access order configuration settings:
 **Partner Center > Administration > Order Settings**
+
+### Standalone products vs. packages-only
+
+By default, salespeople can add individual (standalone) products to orders. To restrict salespeople to selling only packages:
+
+1. Go to **Administration > Order Settings**
+2. Under **For Salespeople**, enable **"Prevent salespeople from selling standalone products on opportunities and orders"**
+
+When this is on, salespeople can only add pre-configured packages to orders. Admins are not affected by this restriction.
+
+### Company category limit for order submission
+
+Orders created from a **CRM Company** profile require the company to have **10 or fewer business categories** assigned. If you cannot submit an order from a Company, check the company's category count:
+
+1. Open the Company record in **CRM > Companies**
+2. Review the categories listed on the profile
+3. Remove categories until 10 or fewer remain, then retry submitting the order
+
+### Ad spend (variable pricing) in packages
+
+Products with variable pricing — such as ad spend for digital advertising products — **cannot have their amount adjusted when bundled inside a package**. The ad spend amount is locked to whatever value was set when the package was configured.
+
+**Workaround:** If you need to set a custom ad spend amount, order the product as a standalone item outside of the package. Standalone orders allow the variable amount to be set per order.
 
 ### Workflow Configuration Options
 

--- a/docusaurus/docs/commerce/orders/order-processing-and-activation.mdx
+++ b/docusaurus/docs/commerce/orders/order-processing-and-activation.mdx
@@ -55,6 +55,12 @@ Understanding order statuses is crucial for managing your sales process effectiv
 
 ## Approval Workflows
 
+### Manual vendor approval
+
+Some marketplace products require the vendor to manually approve the order before it can be activated. When this is the case, the order will show a **"Manual vendor approval required"** indicator on the relevant line item. No action is required from you — the vendor is notified automatically. Activation proceeds once the vendor approves on their end.
+
+If an order has been waiting on vendor approval for longer than expected, contact the vendor directly through **Marketplace > [Product] > Contact Us**.
+
 ### Where Orders Go After Submission
 
 Based on partner configuration, orders can be sent to one of two places:
@@ -85,6 +91,40 @@ Some partners prefer to collect payment before activating products — for examp
 :::info
 Products remain in **Approved** status until a Partner Center admin explicitly agrees to billing and activates them. Approval alone — without the billing agreement — does not trigger activation.
 :::
+
+## Post-activation: notifications, refunds, and SMB-initiated orders
+
+### Activation email notifications
+
+Activation emails to clients are **off by default**. To notify clients when a product activates, set up an Automation:
+
+1. Go to **Automations > Create Automation**
+2. Set the trigger to an order or product activation event
+3. Add a **Send Email** or **Send Notification** action targeting the client contact
+
+This replaces the legacy activation email behavior and gives you full control over the message content and timing.
+
+### Rejected-order refunds are automatic
+
+If an order fails to activate and is rejected, any payment collected for that order is automatically refunded as a **credit note**. You do not need to request a refund manually.
+
+To find the credit note:
+- Go to **Administration > My Billing** to see the credit applied to your account
+- Go to **Commerce > Financial Documents > Credit Notes** for the formal credit note document
+
+### Reviewing SMB-initiated orders before activation
+
+If your clients can place orders themselves (through the store), those orders activate automatically by default. To hold SMB-initiated orders for Partner review before activation:
+
+1. Go to **Administration > Order Settings > Default Content**
+2. Add a custom form with an **Administrative Questions** section to every order
+3. Mark a required field as hidden from the customer — the order cannot activate until an admin fills in that field
+
+This effectively gates activation on an admin completing the internal field, giving you a review step before products go live.
+
+### Stair-step pricing and bulk activations
+
+If your products use stair-step pricing (where the first tier is free and the price increases with volume), activating large batches of accounts at once can trigger the higher tier unexpectedly. **Recommendation:** use a **free-unit discount** instead of a free first tier to avoid unintended charges during bulk activations.
 
 ## Product Activation Process
 
@@ -227,4 +267,44 @@ Once you've agreed to billing terms and selected activation timing, you cannot c
 <summary>What's the difference between Canceled and Archived orders?</summary>
 
 Canceled orders are specifically marked as canceled (useful for tracking churn), while Archived orders are simply moved out of active view for historical purposes. Neither status cancels existing subscriptions.
+</details>
+
+<details>
+<summary>Can I disable auto-activation when a customer pays during approval?</summary>
+
+No. When a customer pays during the approval step, product activation triggers automatically — this cannot be disabled. If you need to delay activation after payment, use one of these workarounds:
+
+- **Set a future contract start date** on the order line items so products activate on that date instead of immediately
+- **Use a manual invoice flow** instead of the customer-approval payment flow, then activate manually when ready
+</details>
+
+<details>
+<summary>The MatchCraft Ads Express order form shows a timeout page — what do I do?</summary>
+
+This happens when MatchCraft Ads Express is not yet activated on the account before the order form is accessed. To resolve it:
+
+1. Activate **MatchCraft Ads Express** on the account first
+2. Then submit the order — the order form will load correctly
+</details>
+
+<details>
+<summary>"Proceed to next step" is grayed out for an add-on product — why?</summary>
+
+This usually means the parent product is **suspended** in Vendor Center. To resolve it:
+
+1. Go to **Vendor Center > Products** and check if the parent product is suspended
+2. Resume activations on that product
+3. Return to the order — the "Proceed to next step" button should become active
+</details>
+
+<details>
+<summary>An order shows "Deferred" status — what does that mean?</summary>
+
+**Deferred** means the order approval email failed to deliver to the recipient. This is typically an email deliverability issue. To resolve it:
+
+- Check that the recipient email address is correct and reachable
+- Confirm your sending domain has valid **SPF** and **DMARC** records configured
+- Try resending the order to a different contact or email address
+
+If deliverability is confirmed but the issue persists, contact support.
 </details>


### PR DESCRIPTION
## Summary

Incorporates content from the Orders Guru cleanup recommendation file (22 source cards, 6 recommendations) into 4 existing docs.

**order-configuration-and-administration.mdx** (Rec #1):
- July 2025 Orders experience refresh callout
- Standalone products vs. packages-only toggle explanation
- Company category limit (10 max) for order submission from CRM Company
- Ad spend locked in packages + standalone product workaround

**creating-and-managing-orders.mdx** (Recs #2, #3):
- Resending the customer approval email
- Why customers receive the approval email multiple times (expiry re-send job)
- What can be edited on a placed order (Draft only; admin Pending edits)
- Cancelled orders cannot be restored; use Duplicate to recreate

**order-processing-and-activation.mdx** (Recs #2, #5, #6):
- Manual vendor approval explanation
- Activation emails off by default + Automations workaround
- Rejected-order refunds are automatic + where to find credit notes
- SMB-initiated order review gate (Administrative Questions workaround)
- Stair-step pricing bulk activation warning
- New FAQs: auto-activation workarounds, MatchCraft timeout, grayed-out "Proceed to next step", Deferred order status

**create-and-apply-tax-rates.mdx** (Rec #4):
- Tax behavior on Sales Orders (Retail Summary)
- Why taxes don't auto-transfer to invoices (rate vs. tax ID)
- Step-by-step workaround for manually applying tax on invoice from order
- Troubleshooting missing taxes on Sales Orders

## Test plan

- [ ] Review each updated section for accuracy against the Guru cleanup recommendation file
- [ ] Confirm no `>` blockquote characters introduced
- [ ] Spot-check new `<details>` FAQ entries render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)