### PR TITLE
docs(marketplace): add missing Help Center content from Guru card cleanup

### DIFF
--- a/docusaurus/docs/marketplace/manage-store/index.mdx
+++ b/docusaurus/docs/marketplace/manage-store/index.mdx
@@ -99,6 +99,46 @@ Step-by-step videos: product discovery and configuration, product settings and p
 
 <iframe src="https://www.loom.com/embed/36752df6d3e3495c9f4f8648a3846b3f" frameborder="0" width="100%" height="400px" allowFullScreen></iframe>
 
+## Store configuration and customization notes
+
+### Public Store URL
+
+The Public Store URL is derived from your **Business App URL** — it cannot be set independently. To change your Public Store URL, update your Business App subdomain in **Administration > Partner Branding**.
+
+### Favicon scope
+
+Your favicon applies to **Business App only**. It does not appear on the Public Store URL. The Public Store uses the browser default favicon unless your Public Store is embedded on a website that has its own favicon.
+
+### Editing the "Need Help" card
+
+The **Need Help** section that appears in the Store is configured in **Vendor Center > Marketing**. Update the contact details, messaging, or links there to customize what customers see.
+
+### Disabling account creation from the Store
+
+By default, customers can create a new account directly from the Public Store. To disable this:
+
+1. Go to **Administration > Customize Business App**
+2. Find the **Store / Shopping Cart** settings
+3. Disable the **Allow account creation from Store** option
+
+### Reordering packages in the All category
+
+The **All** category cannot be reordered via drag-and-drop in the default list view. To reorder packages within it:
+
+1. Switch to **Grid view** in **Marketplace > Packages**
+2. Click **Edit Order**
+3. Drag packages into your preferred order and save
+
+### Removing a product from your store
+
+Removing a product from the store requires updating every package that contains it:
+
+1. Go to **Marketplace > Packages** and identify packages containing the product
+2. Edit each package to remove the product line item
+3. Save and republish the affected packages
+
+If you only want to stop new activations without removing the product from all packages, use **Suspend new activations** in Vendor Center instead.
+
 ## Advanced and testing
 
 - **Multi-market:** Customize per market (products, pricing, categories, theme). If availability or pricing looks wrong, check product and package assignments per market and customer-to-market assignment.

--- a/docusaurus/docs/marketplace/packages/package-management-store-integration.mdx
+++ b/docusaurus/docs/marketplace/packages/package-management-store-integration.mdx
@@ -45,6 +45,37 @@ Effective package management drives better results:
 
 ## How to Manage Package Lifecycle
 
+### Adding multiple instances of a product to a package
+
+You cannot add the same product more than once to a package directly. To sell multiple units of a product, use **add-ons** instead:
+
+1. In Vendor Center, create an add-on for the product
+2. Enable **Allow multiple purchases per account** on the add-on if needed
+3. Add the base product plus the add-on to the package
+
+Alternatively, if the product has **Allow multiple purchases per account** enabled (under Advanced settings in Editions), customers can purchase it multiple times — but note this disables add-on support for that product.
+
+### New package pricing model and invoice/Shopping Cart compatibility
+
+Packages must use the **new line-item pricing model** to work with invoices and Shopping Cart checkout. Legacy packages (created before the pricing model update) are automatically migrated when first opened and saved in the package editor. If a package is not appearing as an option when creating an invoice, open it in **Marketplace > Packages**, save it, and try again.
+
+### Price visibility in the store preview
+
+For package pricing to display to customers in the store, the package's **Purchase behaviour** must be set to **Add to Shopping Cart**. If another option (Contact Sales, External URL) is selected, the price is intentionally hidden from the preview and store listing.
+
+### Copy a package across markets
+
+To make a package available in a different market:
+
+1. Go to **Marketplace > Packages**
+2. Switch to the market containing the package you want to copy
+3. Click the **options menu (⋮)** on the package
+4. Select **Copy**
+5. Choose the target market from the dropdown
+6. Click **Save and Publish**
+
+The copied package appears in the target market. Adjust pricing or contents as needed for that market.
+
 ### Edit packages
 1. Navigate to **Partner Center** → **Marketplace** → **Packages**
 2. Select target market (if using Markets)
@@ -212,6 +243,37 @@ Direct links are automatically available for all published packages with **Add t
 - Same campaign editor and workflow as the rest of **Marketing**
 - Performance tracking and analytics
 - Automated customer segmentation and targeting
+
+#### Buy It Now link workflow
+
+When a customer clicks a Buy It Now link, the current flow is:
+
+1. Customer is prompted to log in (or create an account)
+2. After login, they are directed to **Business App > Store** where the package is pre-loaded
+3. They complete checkout from there
+
+The link does not take customers directly to a checkout page — it routes through Business App.
+
+#### Adding a Contact Sales button to a package
+
+For the **Contact Sales** button to appear on a package in the store, the package must have a **salesperson assigned via a Contact Form**. Without a salesperson configured, the Contact Sales option will not display even if "Contact Sales" is selected as the Purchase option. Set this up in **Manage Store > [package] > Purchase behaviour > Contact Sales**.
+
+#### Upgrade Path and Call to Action text
+
+The **Upgrade Path** setting (which product to upsell to) and the **Call to Action** button text are configured independently. Changing the Upgrade Path does not automatically update the CTA text — update the button label manually to match.
+
+#### Draft package preview URLs
+
+Preview links for draft (unpublished) packages are accessible to anyone who has the URL, even though the package is not in the public Store. This is intentional — it lets you share a preview with stakeholders for review before publishing. The package will not appear in the store or be purchasable until it is published.
+
+#### Business App "Check out" button prerequisites
+
+The **Check out** button in Business App Store requires two things to be active:
+
+- **Orders** must be enabled for the partner
+- **Vendasta Payments** must be configured
+
+If either is missing, the Check out button will not function or will not appear.
 
 ### Package sharing best practices
 

--- a/docusaurus/docs/marketplace/packages/package-troubleshooting-guide.mdx
+++ b/docusaurus/docs/marketplace/packages/package-troubleshooting-guide.mdx
@@ -11,6 +11,34 @@ keywords: [package troubleshooting, package visibility, duplicate packages, pack
 
 This guide addresses common package issues with step‑by‑step solutions for visibility problems, duplicates, links, pricing, multi‑market sync, and when to escalate.
 
+## Product visibility and activation constraints
+
+### "Available in store" is set to Yes but the product isn't appearing
+
+Setting a product to **Available in store** makes it eligible for the store, but customers cannot find or purchase it until it is added to a **published package** that is assigned to a visible store category. Without that package step, the product remains invisible to customers regardless of the availability setting.
+
+### Custom product missing from Order Products
+
+If your custom product doesn't appear in the **Order Products** list when creating an order for an account, the most likely cause is that the account has **no address on file**. Custom products use the account's business profile address to determine availability. Add an address to the account's business profile and the product should appear.
+
+### Country-specific product activation
+
+Some Marketplace products are restricted to specific countries. If an account could previously activate a product but can no longer do so, check whether the **business profile country** on the account has changed. The account's country must match the country availability configured on the product. Update the business profile address if needed.
+
+### Review Widget Carousel requires Review Widget Pro
+
+The Carousel display option in the Review Widget is not available on the standard Review Widget — it requires the **Review Widget Pro** add-on. Activate Review Widget Pro on the account to unlock the Carousel option.
+
+### Finding a product's SKU
+
+Every product in the Vendasta Marketplace has a SKU identifier. To find it:
+
+1. Go to **Marketplace > Discover Products** (or **My Products**)
+2. Click into the product
+3. Look at the URL in your browser — the SKU is the string of characters at the end (e.g. `MP-XXXXXXXXXXXXXXXX`)
+
+SKUs follow the format `MP-` followed by alphanumeric characters. When contacting Support about a specific product, including the SKU speeds up identification.
+
 ## Common package visibility issues
 
 Package visibility problems are among the most frequent issues encountered in marketplace management. Understanding the root causes and systematic solutions ensures your packages reach customers effectively.
@@ -170,6 +198,25 @@ Resolution
 4. Save the package
 
 This migration is a one-time conversion. After saving, the package uses the new pricing model going forward. The overall package price is preserved during migration — only the per-item breakdown is new.
+
+### Package Profit showing as unavailable
+
+If the **Package Profit** field shows as unavailable, the most common cause is a **currency mismatch** — the package currency does not match the currency configured for your market. Go to **Manage Store > Currency** and confirm the market currency matches the currency used in the package.
+
+### Retail price not updating after editing a package
+
+In the new package editor, updating the retail price of an item inside a package does not automatically recalculate and display the updated total in the list and grid views immediately. This is a known behavior. To apply the updated price:
+
+1. Open the package in **Marketplace > Packages**
+2. Remove the affected product from the package
+3. Re-add the product and set the correct retail price
+4. Save and publish the package
+
+Note: bulk pricing updates across multiple packages are not currently supported. Each package must be updated individually.
+
+### Package not appearing when adding it to an invoice
+
+Packages must use the **new line-item pricing model** to be compatible with invoices and the Shopping Cart checkout. If a package was created with the legacy pricing model, open and save it in the package editor — it will automatically migrate to the new model. After saving, the package should appear as an option when creating invoices.
 
 ## Advanced troubleshooting scenarios
 

--- a/docusaurus/docs/marketplace/products/create-manage-custom-products.mdx
+++ b/docusaurus/docs/marketplace/products/create-manage-custom-products.mdx
@@ -113,6 +113,27 @@ Configure the steps taken when provisioning your product:
 - **Notifications** — Add one or more recipient email addresses to receive notifications when the product is activated, canceled, or deactivated.
 - **Required products** — Select products that must be purchased before your product can be activated.
 
+#### Auto Activation Toggle
+
+The **Auto Activation** toggle (found in **Marketplace > Products > [your product] > Product Info**) allows the product to activate automatically without requiring an admin to manually process an order.
+
+:::info Order Form dependency
+Auto Activation only works if the product has **no Order Form** configured. If an Order Form is attached, the toggle has no effect — the order must be manually processed so the form can be completed. Remove the Order Form first if you want auto activation to apply.
+:::
+
+#### Auto-activating a product when a new account is created
+
+To activate a custom product automatically every time a new account is created:
+
+1. Go to **Partner Center > Administration > Customize > Account Creation**
+2. Under **Products to activate on account creation**, add your custom product
+
+The product will activate on every new account without requiring a separate order.
+
+#### Notification recipients behavior
+
+Email addresses added to **Notifications** receive alerts whenever the product is activated, canceled, or deactivated. These recipients persist on the product record regardless of whether the email address is still an active user in your platform. If someone unexpected is receiving activation emails, check the Notifications list in Vendor Center and remove any outdated addresses.
+
 ### Order form
 
 Build a custom order form to collect information when customers purchase your product. The form includes:
@@ -222,6 +243,10 @@ The **Compare product** tab shows the activation status of your product and lets
 
 - **Suspend new activations** — Prevent new customers from activating the product while keeping it available for existing users.
 - **Open** — Open the product (and all of its add-ons) to the marketplace so it can be activated.
+
+## Custom products and the Start/Stop Selling buttons
+
+Custom (private) products you create in Vendor Center do not have **Start Selling** or **Stop Selling** buttons. This is by design — your own products are already enabled for selling in your marketplace. To prevent a custom product from being ordered, use **Suspend new activations** in the **Compare product** tab of Vendor Center instead.
 
 ## Best practices
 


### PR DESCRIPTION
## Summary

Incorporates content from the Marketplace, Packages & Store Guru cleanup recommendation file (37 source cards, 5 recommendations) into 4 existing docs.

**create-manage-custom-products.mdx** (Rec #1):
- Auto Activation Toggle and Order Form dependency
- Auto-activating a product on new account creation
- Notification recipients persist regardless of user status
- Custom products have no Start/Stop Selling buttons; use Suspend instead

**package-troubleshooting-guide.mdx** (Recs #2, #3):
- "Available in store" alone insufficient — needs published package in a visible category
- Custom product missing from Order Products → account has no address
- Country-specific product activation requires matching business profile country
- Review Widget Carousel requires Review Widget Pro add-on
- How to find a product SKU from the Marketplace URL
- Package Profit unavailable → currency mismatch
- Retail price not updating → remove/re-add product workaround
- Bulk pricing updates not supported
- Package not appearing on invoice → open/save to migrate to new pricing model

**manage-store/index.mdx** (Recs #2, #4):
- Public Store URL inherits from Business App URL (can't be set independently)
- Favicon scope is Business App only, not Public Store
- Need Help card editing in Vendor Center > Marketing
- Disabling account creation from the Store
- Reordering packages in the All category (Grid view > Edit Order)
- Removing a product requires updating all containing packages

**package-management-store-integration.mdx** (Recs #3, #5):
- Adding multiples of a product — use add-ons, not duplicate line items
- New pricing model required for invoices/Shopping Cart compatibility
- Price visibility in store requires Add to Shopping Cart purchase behaviour
- Copy a package across markets (three-dot menu workflow)
- Buy It Now flow: login → Business App → Store (not direct checkout)
- Contact Sales button requires a salesperson on the Contact Form
- Upgrade Path and CTA text are configured independently
- Draft package preview URLs are intentionally public (not a security issue)
- Business App Check out button requires Orders + Vendasta Payments

## Test plan

- [ ] Review each updated section for accuracy against the Guru cleanup recommendation file
- [ ] Confirm no `>` blockquote characters introduced
- [ ] Spot-check new `<details>` FAQ entries and callouts render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)