### PR TITLE
docs(notifications): add missing Help Center content from Guru card cleanup

### DIFF
--- a/docusaurus/docs/administration/platform-settings/client-notifications/index.mdx
+++ b/docusaurus/docs/administration/platform-settings/client-notifications/index.mdx
@@ -1,32 +1,80 @@
 ---
-title: Client Notifications
-description: Configure client notification settings and communication preferences
-sidebar_position: 3
+id: client-notifications
+title: Partner Center notification settings
+description: Configure Partner Center notification preferences, including the master toggle, Platform vs. User scope, and app vs. email delivery.
+sidebar_position: 1
 ---
 
-## Global Notification Settings
+# Partner Center notification settings
 
-### Access Partner Center
-- Go to Partner Center → Administration → Client Notification.
-### Check Global Notification Settings
-- If a user's Global Notification setting is disabled, they will not receive notifications from any product.
-- Individual product notifications will not function unless the global switch is enabled.
+Partner Center notifications keep you and your team informed about activity across orders, tasks, products, and more. Before any individual notification can fire, the master toggle must be enabled.
 
-### Enable Global Notifications
-- Turn on Global Settings.
-Once the global notification toggle is enabled, the notification settings for each area of the platform and each product become available. You can then enable or disable notifications for each product independently, such as Business App, Social Marketing, Advertising Intelligence, and others.
-# Client Notifications
+## The master notification toggle
 
-This section provides settings for managing client notifications and communication preferences within your Vendasta platform.
+The master toggle controls all notifications. When it is off, no notifications are sent — regardless of individual settings.
 
-## Notification Settings
+To enable it:
 
-- Email Notifications - Configure automated email notifications for clients
-- SMS Notifications - Set up text message notifications and alerts
-- Notification Templates - Create and customize notification message templates
-- Delivery Settings - Configure notification timing and frequency preferences
-- Client Preferences - Allow clients to manage their own notification settings
+1. Go to **Partner Center** → **Administration** → **Client Notifications**
+2. Find **Global Settings** (also labelled **All Notifications** in some views)
+3. Turn the toggle **on**
 
-*Note: Detailed guides for client notification configuration will be added here.*
+Once the master toggle is on, the notification settings for each product and platform area become available to configure individually.
 
-If you need assistance with client notifications or have questions about communication settings, please contact our support team.
+:::warning
+If you have enabled notifications for specific products but are not receiving anything, check the master toggle first — it is the most common cause.
+:::
+
+## Platform Settings vs. User Settings
+
+Notifications can be configured at two different scopes:
+
+| Scope | Who configures it | What it controls |
+|---|---|---|
+| **Platform Settings** | Partner Center admin | Notifications for the entire partner account (e.g., all sales orders, regardless of who placed them) |
+| **User Settings** | Individual user | Notifications relevant only to that user (e.g., only sales orders where they are involved) |
+
+**When to use Platform Settings:** Use this scope for team-wide visibility — for example, alerting your whole sales team when any order is placed.
+
+**When to use User Settings:** Use this scope for personal relevance — for example, a salesperson who only wants to be notified about their own accounts or tasks.
+
+:::info
+Platform Settings are managed by administrators and apply across the team. Users can adjust their own User Settings without affecting others.
+:::
+
+## App vs. email delivery
+
+For each notification, you can choose how it is delivered:
+
+- **App** — Notification appears in the Partner Center notification panel
+- **Email** — Notification is sent to the user's email address
+- Both options can be enabled simultaneously
+
+Configure delivery for each notification type in **Administration** → **Client Notifications**, then expand the relevant product or area.
+
+## Configuring notifications per product
+
+After enabling the master toggle, expand each product section to configure its notifications:
+
+- **Business App** — activity within your clients' Business App
+- **Review Management** — new reviews and responses
+- **Social Marketing** — post publishing and campaign activity
+- **Website Pro** — website changes and alerts
+- **Orders and Commerce** — order placements, fulfillments, and billing events
+- **Task Manager** — task assignments, updates, and completions
+
+Enable or disable individual notification types within each section, and set App and/or Email delivery per type.
+
+## Common questions
+
+**I enabled a notification but I'm not receiving it.**
+Check the master toggle in **Administration** → **Client Notifications** → **Global Settings**. If it is off, no notifications fire regardless of individual settings.
+
+**I'm receiving too many notifications.**
+Switch from Platform Settings to User Settings so you only receive notifications relevant to your own activity, rather than all activity across the account.
+
+**A teammate's notifications aren't working.**
+Confirm the master toggle is on, then check whether the specific notification type is enabled under Platform Settings. The individual user can also check their own User Settings.
+
+**Notifications are enabled but email isn't arriving.**
+Confirm email delivery is toggled on for that notification type. Also check spam or junk folders, and verify the user's email address in their profile.

--- a/docusaurus/docs/administration/platform-settings/client-notifications/notification-behaviors.mdx
+++ b/docusaurus/docs/administration/platform-settings/client-notifications/notification-behaviors.mdx
@@ -1,0 +1,65 @@
+---
+id: notification-behaviors
+title: How specific notifications work
+description: Understand the behavior of Task Assignee Update, Daily Digest, product activation, and abandoned cart notifications in Partner Center.
+sidebar_position: 2
+---
+
+# How specific notifications work
+
+Some Partner Center notifications behave differently than expected. This article explains how four commonly misunderstood notification types work so you can configure them correctly.
+
+## Task Assignee Update
+
+The **Task Assignee Update** notification fires when a task is **reassigned** to a different user — it does not fire when a task is first created and assigned.
+
+- **Triggers:** Changing the assignee on an existing task
+- **Does not trigger:** Initial task creation with an assignee set
+
+If you want to be notified about all task activity including creation, use the broader task notification options available in **Administration** → **Client Notifications** → **Task Manager**.
+
+## Product activation notifications
+
+When a product is activated for a client, a notification is sent to the configured recipients. However, **deactivating a product does not generate a notification**.
+
+- **Triggers notification:** Product activation
+- **Does not trigger notification:** Product deactivation
+
+If your team needs to track deactivations, use the Orders section of Partner Center or set up an automation to log deactivation events.
+
+## Daily Digest email
+
+The Daily Digest email summarizes activity from the previous day. It is only sent **if there was activity** during that period — if nothing happened, no email is sent.
+
+- **Frequency:** Once per day
+- **Condition:** Only sent when there is activity to report
+- **Content:** Summary of previous day's events across configured notification types
+
+If you stop receiving the Daily Digest, it likely means there was no qualifying activity the day before — not that the notification is broken.
+
+## Abandoned shopping cart notifications
+
+When a client leaves items in their shopping cart without completing a purchase, Partner Center sends notifications to help recover the sale:
+
+- **Salesperson notification:** The assigned salesperson is alerted that a cart has been abandoned
+- **Client reminder:** The client receives a follow-up reminder about their cart
+
+**Important:** The salesperson notification does not include the cart contents. Cart contents are private to the cart owner and are not shared with salespeople or partners.
+
+:::info
+Abandoned cart notifications help your team follow up on potential sales, but they do not expose what the client was browsing or purchasing.
+:::
+
+## Common questions
+
+**Why didn't I get a Task Assignee Update notification when the task was created?**
+This notification only fires on reassignment. Initial task creation does not trigger it.
+
+**We deactivated a product but no one was notified.**
+Product deactivations do not generate notifications. Use the Orders section to track deactivation history.
+
+**I haven't received the Daily Digest in a few days.**
+Check whether there was any platform activity those days. The digest is skipped entirely when there is nothing to report.
+
+**Can I see what was in an abandoned cart?**
+No. Cart contents are private to the cart owner. Salespeople see only that a cart was abandoned, not what it contained.

--- a/docusaurus/docs/administration/platform-settings/client-notifications/visual-visitor-notification-rules.mdx
+++ b/docusaurus/docs/administration/platform-settings/client-notifications/visual-visitor-notification-rules.mdx
@@ -1,0 +1,59 @@
+---
+id: visual-visitor-notification-rules
+title: Configuring Visual Visitor notification rules
+description: Learn how to set up and manage notification rules within Visual Visitor, including instant alerts, daily and weekly reports, and watch list alerts.
+sidebar_position: 3
+---
+
+# Configuring Visual Visitor notification rules
+
+Visual Visitor has its own notification system that is separate from Partner Center notifications. Visual Visitor notification rules are configured **inside the Visual Visitor product**, not in Partner Center → Administration → Client Notifications.
+
+## Where to find notification rules
+
+1. Open **Business App**
+2. Navigate to **Visual Visitor**
+3. Go to **Lead Handling** → **Notification Rules**
+
+## Available rule types
+
+Visual Visitor offers five types of notification rules:
+
+| Rule type | What it does |
+|---|---|
+| **Instant Email Alert** | Sends an email immediately when a tracked visitor activity occurs |
+| **Daily Email Report** | Sends a summary of visitor activity from the previous day |
+| **Weekly Email Report** | Sends a summary of visitor activity from the previous week |
+| **Watch List Email Alert** | Sends an alert when a specific company or contact on your Watch List visits |
+| **URL Email Alert** | Sends an alert when a visitor lands on a specific URL you are tracking |
+
+## How to enable and configure a rule
+
+1. In **Lead Handling** → **Notification Rules**, locate the rule type you want to configure
+2. Enable the rule using the toggle
+3. Set the recipients (email addresses to notify)
+4. Configure any filters or thresholds specific to that rule type
+5. Click **Update My Notification Rules** to save
+
+:::tip
+Click **Update My Notification Rules** after making any changes — unsaved changes will not take effect.
+:::
+
+## Report send times
+
+- **Daily Email Reports** are sent at approximately **3:00 am Eastern Time** each morning, covering the previous day's activity
+- **Weekly Email Reports** are sent at approximately **3:00 am Eastern Time** on Monday mornings, covering the previous week
+
+## Common questions
+
+**I looked in Partner Center → Notifications but couldn't find Visual Visitor settings.**
+Visual Visitor notifications are managed inside the Visual Visitor product itself, not in Partner Center's main notification settings. Go to **Business App** → **Visual Visitor** → **Lead Handling** → **Notification Rules**.
+
+**I enabled a rule but am not receiving emails.**
+Confirm you clicked **Update My Notification Rules** after enabling the rule. Also verify the email address listed as a recipient is correct.
+
+**What time does the Daily Report arrive?**
+Daily reports are sent around 3:00 am Eastern Time each morning.
+
+**Can I notify multiple people with one rule?**
+Yes. Add multiple email addresses as recipients when configuring the rule.


### PR DESCRIPTION
## Summary

- Rewrote the `client-notifications/index.mdx` stub with full content covering the master notification toggle, Platform vs. User Settings, app vs. email delivery, and per-product configuration
- Added new article on specific notification behaviors (Task Assignee Update, product activation/deactivation, Daily Digest, abandoned cart)
- Added new article on configuring Visual Visitor notification rules (separate from Partner Center notifications)

## Source

Based on Guru card cleanup pass on the Notifications folder (8 internal cards consolidated into 3 drafts on 2026-05-13).

## Test plan

- [ ] Pages render correctly in local dev (`npm run start`)
- [ ] No broken links
- [ ] Content reviewed for accuracy by product owner

🤖 Generated with [Claude Code](https://claude.com/claude-code)