### PR TITLE
docs(snapshot-report): add missing Help Center content from Guru card cleanup

### DIFF
--- a/docusaurus/docs/snapshot-report/index.mdx
+++ b/docusaurus/docs/snapshot-report/index.mdx
@@ -115,6 +115,35 @@ Snapshot Reports will be created for accounts added to campaigns. If an existing
 
 ### Sending Snapshot Reports
 
+#### Why the Email Report button might not appear
+
+The **Email Report** button (paper-plane icon) is only visible when you are in **Edit Report** mode, not in **View Full Report** mode. If you can't find the send option:
+
+1. Open the Snapshot Report
+2. Make sure you are in **Edit Report** mode, not **View Full Report**
+3. The email/send icon will appear in Edit mode
+
+A salesperson must be assigned to the account for the Email Report button to function. Without an assigned salesperson, the send option may not appear.
+
+#### Changing the sender email address
+
+By default, Snapshot Reports are sent from `noreply@snapshotreport.biz`. To change the sender address:
+
+1. Open the Snapshot Report in **Edit Report** mode
+2. Find the email settings within the send workflow
+3. Update the sender email to your preferred address
+
+#### AI-generated suggested content
+
+When sending a Snapshot Report via **Edit Report** mode, the platform can generate suggested email copy using AI. This feature is only available in Edit Report mode and generates suggested subject lines and body text based on the report data. You can edit the suggestions before sending.
+
+#### Finding a previous Snapshot Report URL
+
+If you need to locate the URL of a previously sent Snapshot Report:
+
+1. Check the **email notification history** for the prospect — the original send email contains the report link
+2. Go to **CRM** → **Companies** → select the company → **Reports** section to find existing reports
+
 #### Snapshot Report URL
 1. Go to **Partner Center > Accounts > Manage > Select the desired account**
 2. Click **Snapshot Report > View Snapshot**
@@ -132,6 +161,45 @@ Or create custom campaigns that include Snapshot Reports.
 - For the most accurate results, wait up to **24 hours** before checking the report to ensure all data has been gathered.
 - Reports continue gathering data for up to **7 days** for maximum accuracy
 - The most accurate time to present is at the **7-day mark**
+
+## Business category and competitors
+
+### How the business category is set
+
+The Snapshot Report pulls the business category from the **Account Group's primary category** in Partner Center. This drives the industry benchmarks used throughout the report — a wrong category leads to inaccurate grades.
+
+To check or update the category:
+
+1. Go to **Partner Center** → **Accounts** → **Manage Accounts**
+2. Open the account and edit the business details
+3. Update the **Primary Category** to the most accurate business type
+
+:::warning
+Avoid setting the category to **"Other"**. When "Other" is selected, the Local Search Results section cannot retrieve meaningful data and will produce inaccurate results.
+:::
+
+### Why your report might auto-fill "Marketing Agency"
+
+If the Snapshot Report keeps defaulting to "Marketing Agency" as the business category, the likely cause is a default **Local SEO keyword** set on the template. To fix it:
+
+1. Go to **Administration** → **Customize** → **Sales** → **Edit Default Snapshot Template**
+2. Find the **Local SEO** section
+3. Clear or update the default keyword
+
+Once cleared, new reports will use the correct business category from the account.
+
+### Adding competitors
+
+You can add competitors to the Snapshot Report so prospects can see how they compare:
+
+- **Account-based competitors**: The competitor must share the **same primary business category** as the prospect to appear in the comparison. Competitors created as Accounts in Partner Center follow this rule.
+- **Google-pulled competitors**: When the system automatically pulls competitors from Google, the same-category restriction does not apply.
+
+To add competitors manually, open the Snapshot Report in **Edit Report** mode and add competitor names or URLs in the Competitors section.
+
+### Industry Average and Industry Leader benchmarks
+
+The **Industry Average** and **Industry Leader** benchmarks shown throughout the report use a **6-month lookback period**. This means the benchmarks reflect aggregate data from the past 6 months, not real-time comparisons.
 
 ## How to customize Snapshot Reports
 
@@ -160,6 +228,41 @@ Change report language for international clients:
 - **For specific markets**: **Partner Center > Customize > Markets > Select Market > Sales > Edit Default Snapshot Template** > Check boxes to remove
 
 ## Frequently asked questions (FAQs)
+
+<details>
+<summary>How do I deactivate a Snapshot Report?</summary>
+
+Snapshot Reports are tied to the **Reputation Management** product on an account. To deactivate a Snapshot Report, deactivate Reputation Management for that account. This stops the report from being active and accessible. If you need to remove a report without deactivating the product, contact support.
+
+</details>
+
+<details>
+<summary>How do I get notified when a Snapshot Report is ready?</summary>
+
+Set up **Snapshot Ready** notifications in **Administration** → **Client Notifications**. Enable the Snapshot Report notification type to receive an alert when a report finishes generating — typically within 24 hours of creation.
+
+</details>
+
+<details>
+<summary>Does the automation trigger "a Snapshot report was created" fire when I refresh a report?</summary>
+
+No. The **Snapshot Report Created** automation trigger fires only when a new Snapshot Report is created — not when an existing report is refreshed. If you need to trigger an automation after a refresh, you will need a separate workflow or manual follow-up.
+
+</details>
+
+<details>
+<summary>Can I combine multiple clients' Snapshot Reports into one?</summary>
+
+No. Snapshot Reports are generated per business and cannot be merged or combined across multiple clients. Each report is specific to a single business's online presence data.
+
+</details>
+
+<details>
+<summary>Can I customize the grade descriptions in the Snapshot Report?</summary>
+
+No. The letter grade descriptions (A–F) and their explanations are system-controlled and cannot be customized or edited.
+
+</details>
 
 <details>
 <summary>How long does a Snapshot Report take to be ready?</summary>

--- a/docusaurus/docs/snapshot-report/snapshot-report-customization.mdx
+++ b/docusaurus/docs/snapshot-report/snapshot-report-customization.mdx
@@ -162,6 +162,30 @@ To use your banner image in email templates:
 6. Adjust size and alignment as needed
 7. Click **OK** to insert the image
 
+### Bottom banner and Need Assistance? section
+
+#### Customizing the bottom banner email address
+
+The bottom banner of the Snapshot Report includes a contact email address. To change it:
+
+1. Go to **Partner Center** → **Administration** → **Customize** → **Sales** → **Snapshot Banner**
+2. Open the footer/banner section
+3. Update the email address displayed in the banner
+4. Click **Save & Continue**
+
+#### Customizing the Need Assistance? section
+
+The **Need Assistance?** section appears at the bottom of the Snapshot Report with your contact details. By default it shows the assigned salesperson's information. You can configure a default contact that appears when no salesperson is assigned:
+
+1. Go to **Administration** → **Customize** → **Sales** → **Edit Default Snapshot Template**
+2. Locate the **Need Assistance?** section
+3. Update the contact name, phone, and email
+4. Save changes
+
+:::info
+If a salesperson is assigned to the prospect's account, their contact information overrides the default Need Assistance? settings automatically.
+:::
+
 ### Package integration
 
 #### Adding packages to reports
@@ -180,6 +204,31 @@ Direct clients to your packages and services directly from the Snapshot Report:
 :::note
 You can only add packages and services that have been added to your store from the marketplace.
 :::
+
+## What you can't customize
+
+Some parts of the Snapshot Report are fixed and cannot be changed:
+
+- **Custom sections**: You cannot add entirely new sections to the report. The available sections are predefined. You can style section headers but not create new ones.
+- **Grade descriptions**: The letter grade definitions (A–F) and their explanations are system-controlled and cannot be edited.
+
+## Template changes are not retroactive
+
+:::warning
+Changes to the default Snapshot template apply only to **new reports** and any reports that are **refreshed** after the change. Existing reports that have not been refreshed will continue to show the old template.
+:::
+
+If you want existing prospects to see updated branding or messaging, you need to refresh their Snapshot Reports.
+
+## Customization for Partners on Free
+
+Partners on the Free tier can still access Snapshot Report customization directly through Partner Center:
+
+1. Go to **Partner Center** → **Administration** → **Customize**
+2. Navigate to **Sales** → **Edit Default Snapshot Template**
+3. Make your changes and save
+
+The same customization options are available regardless of tier; access is through Partner Center directly rather than through a dedicated admin panel.
 
 ## How to configure advanced Customization
 

--- a/docusaurus/docs/snapshot-report/snapshot-report-ecommerce-technology.mdx
+++ b/docusaurus/docs/snapshot-report/snapshot-report-ecommerce-technology.mdx
@@ -96,6 +96,10 @@ This only affects new Snapshot Reports. Existing reports require refreshing to d
 
 ## What's included with Technology assessment?
 
+:::info
+The Technology section is powered by **Wappalyzer**. If Wappalyzer has no data for a website — for example, if the site uses a highly custom stack that Wappalyzer cannot fingerprint — the Technology section will appear empty. This is a data source limitation, not a platform error.
+:::
+
 ### Technology stack analysis
 
 The Technology section displays the complete technology stack and marketing stack used on the prospect's website, providing insights into:

--- a/docusaurus/docs/snapshot-report/snapshot-report-listings-reviews.mdx
+++ b/docusaurus/docs/snapshot-report/snapshot-report-listings-reviews.mdx
@@ -40,6 +40,14 @@ Displays how accurate and consistent business information is across different di
 
 ![Listing Accuracy in Snapshot Report](./img/snapshot-report/listing-accuracy.jpg)
 
+:::info
+The Listings grade is **percentile-based**. A business can receive an **A grade while still having missing listings** because the grade reflects how the business compares to industry peers, not an absolute count of correct listings. A grade of A means the business is in the top 10% for its industry — not that all possible listings are present and accurate.
+:::
+
+### Data Aggregator limitation
+
+The **Data Aggregators** subsection (Data-Axle and Neustar/Localeze) only covers **businesses in the United States**. Partners in Canada or other markets will not see Data Aggregator data in the Listings section — this is expected behavior, not a data error.
+
 ### Listing details analysis
 
 The detailed section provides specific information about each directory where the business is listed, showing:
@@ -50,6 +58,10 @@ The detailed section provides specific information about each directory where th
 ![Listing Details in Snapshot Report](./img/snapshot-report/listing-details.jpg)
 
 ## What's included with Reviews assessment?
+
+:::info
+The Snapshot Report shows the **top 2 review sources** by volume. To see the full list of review sources for a business, use **Reputation Management** in Partner Center.
+:::
 
 ### Review score calculation
 

--- a/docusaurus/docs/snapshot-report/snapshot-report-social-advertising.mdx
+++ b/docusaurus/docs/snapshot-report/snapshot-report-social-advertising.mdx
@@ -28,6 +28,16 @@ The Social Media and Advertising sections of the Snapshot Report analyze two cri
 
 ## What's included with Social Media assessment?
 
+### Supported platforms
+
+The Snapshot Report evaluates social media presence across **Facebook, Instagram, and X (Twitter) only**.
+
+:::info
+**LinkedIn and YouTube are not supported** in the Social section and will not appear in the report, even if the business has active pages on those platforms.
+:::
+
+The system finds social profiles by inferring URLs from the business's website. If the social links are not discoverable from the website, you can add them manually via the CRM or Partner Center account details (see "Updating social profiles" below).
+
 ### Platforms analyzed
 
 The Snapshot Report evaluates social media presence across major platforms:
@@ -83,6 +93,10 @@ To update social profiles that the Snapshot Report analyzes:
 4. Click **Save**
 
 ## What's included with Advertising assessment?
+
+:::info
+The Advertising section is **domain-based** — it uses the business's website domain to find advertising data. If a business has no website (only social media pages), the system has no domain to analyze and will calculate approximately 0.1% advertising presence. In these cases, the Advertising grade will be F regardless of actual ad spend.
+:::
 
 ### Keyword analysis
 

--- a/docusaurus/docs/snapshot-report/snapshot-report-website-seo.mdx
+++ b/docusaurus/docs/snapshot-report/snapshot-report-website-seo.mdx
@@ -64,6 +64,12 @@ The system evaluates whether key business information is found on the website's 
 
 ![Snapshot Report Homepage Content](./img/snapshot-report/website-homepage-content.jpg)
 
+### Website section limitations
+
+- **Password-protected websites**: If the business's website requires a login to access, the Snapshot Report cannot crawl it. Homepage content analysis (phone number, address, video) will be limited or unavailable.
+- **Phone number "not on homepage"**: This check uses NAPW matching. If the phone number format on the website doesn't match the account's phone number exactly, the report will show "not found" even if a phone number is visible. Standardize the phone format in the account details.
+- **Homepage video detection**: The system detects embedded videos on the homepage, but **YouTube videos loaded via lazy-loading are not detected**. A YouTube video embedded in a way that delays loading may not register as a video on the homepage.
+
 ### Detailed performance metrics
 
 The Snapshot Report assesses 10 speed metrics in total:
@@ -98,7 +104,13 @@ PageSpeed scores can vary as they are estimates of website performance, not exac
 
 ### SEO grade components
 
-The SEO grade is determined by multiple factors:
+The SEO grade is primarily driven by **organic click value** — an estimate of how much paid advertising traffic the business's organic search presence is worth, based on data from SEMrush and Spyfu. This is not a direct measure of search ranking position.
+
+:::info
+A business can rank #1 on Google for its own brand name but still receive a low SEO grade if that keyword has minimal search volume or low click value. The grade reflects the estimated dollar value of organic traffic, not position alone.
+:::
+
+Other factors that contribute to the SEO grade:
 
 - **Keyword Usage**: How well the website uses relevant keywords
 - **Meta Data**: Title tags, meta descriptions, and structured data
@@ -107,6 +119,8 @@ The SEO grade is determined by multiple factors:
 - **Links**: Internal and external link strategies
 - **Social Signals**: Social media integration and signals
 - **Trust Factors**: Security, authority, and credibility indicators
+
+**Note on currency**: SEO section data is sourced from SEMrush and is displayed in **USD** only. There is no option to change the currency displayed in this section.
 
 ### Search results visibility
 
@@ -144,6 +158,22 @@ The system identifies the top 5 keywords that the prospect is currently ranking 
 - **Competition Level**: Difficulty of ranking for each term
 
 ![Organic Keyword Ranking](./img/snapshot-report/organic-keyword-ranking.jpg)
+
+### Local Search Results (NAPW matching)
+
+The Local Search Results section shows whether the business appears in local search results. The system matches the business using **NAPW** — Name, Address, Phone, and Website — with phone number weighted at **40%** of the match score.
+
+The overall match threshold is **60%**. If the business's listing data does not meet this threshold (for example, due to a phone number format mismatch), the report may show "not found" even if the business does appear in Google results.
+
+**Common cause of "not found in top 100"**: The phone number in the business profile does not match the format Google has on file (e.g., dashes vs. parentheses, or missing/extra digits). Correcting the phone number in the account details and refreshing the report typically resolves this.
+
+### Near-Me search
+
+The **Near-Me** search section shows how the business ranks across a grid of geographic search points. The system runs searches from **9 hotspot locations** around the business address and averages the results to produce the Near-Me ranking.
+
+Because rankings are averaged across these 9 points, a business may rank #1 in its immediate area but receive a lower Near-Me score if it does not appear consistently across all hotspot locations.
+
+**Service Area Businesses (SABs)**: Google hides the physical address of Service Area Businesses from its API, which prevents the Snapshot Report from generating Near-Me results for SABs. As a workaround, connect the business to **Reputation Management** in Partner Center — this provides an address reference point the system can use.
 
 ### Local SEO assessment
 
@@ -194,6 +224,27 @@ The system cannot perform localized searches and searches from a centralized loc
 - Implement local SEO strategies for geographic targeting
 
 ## Frequently asked questions (FAQs)
+
+<details>
+<summary>I rank #1 on Google but the SEO grade is F — why?</summary>
+
+The SEO grade is based on **organic click value**, not search position. A business can rank #1 for its own brand name, but if that keyword has low search volume or low click value (as estimated by SEMrush), the grade will be low. The report is measuring the estimated value of all organic traffic, not whether the business ranks well for a single term.
+
+</details>
+
+<details>
+<summary>The report shows "not found in top 100" but the business appears in Google — why?</summary>
+
+This is most commonly caused by a **phone number mismatch**. The Local Search Results section uses NAPW matching with phone number weighted at 40%. If the phone number in the account profile differs from what Google has on file (formatting, area code, etc.), the business may not reach the 60% match threshold. Correct the phone number in the account and refresh the report.
+
+</details>
+
+<details>
+<summary>Why is Near-Me search not appearing for a Service Area Business?</summary>
+
+Google hides the physical address of Service Area Businesses from its API. Without an address, the system cannot run the Near-Me hotspot searches. Connect the business via **Reputation Management** in Partner Center to provide an address reference, which allows the Near-Me section to generate results.
+
+</details>
 
 <details>
 <summary>Why does the SEO score seem inaccurate for my business?</summary>


### PR DESCRIPTION
## Summary

- **Customization**: Added bottom banner email config, Need Assistance? section, what can't be customized (custom sections, grade descriptions), template-changes-not-retroactive warning, and free-tier access path
- **Overview/index**: Added business category & competitors section, send button troubleshooting, sender email change, AI-generated content, finding previous report URLs, deactivating a report, and 5 new FAQ items (notifications, automation trigger behavior, email campaign refresh rule, multi-client limitation, grade descriptions)
- **SEO**: Added organic click value grade explanation, "rank #1 but F grade" callout, USD-only currency note, NAPW matching threshold (60%, phone weighted 40%), Near-Me 9-hotspot averaging, Service Area Business limitation + workaround, and website section limitations (password-protected, phone NAPW, YouTube lazy-loading)
- **Listings & Reviews**: Added percentile-based grading callout, Data Aggregators USA-only note, and Reviews top-2 sources caveat
- **Social & Advertising**: Added LinkedIn/YouTube not supported callout, social URL inference note, and domain-based advertising limitation (social-only domains)
- **Ecommerce & Technology**: Added Wappalyzer as the Technology section data source and empty-data explanation

## Source

Based on Guru card cleanup pass on the Snapshot Report folder (55 internal cards consolidated into 8 drafts on 2026-05-13).

## Test plan

- [ ] Pages render correctly in local dev (`npm run start`)
- [ ] No broken links
- [ ] Content reviewed for accuracy by product owner

🤖 Generated with [Claude Code](https://claude.com/claude-code)