### PR TITLE
docs(getting-started): align guides with skill style rules

### DIFF
--- a/docusaurus/docs/getting-started/getting-started-guides/getting-started-with-accounts-and-product-activation.mdx
+++ b/docusaurus/docs/getting-started/getting-started-guides/getting-started-with-accounts-and-product-activation.mdx
@@ -11,7 +11,7 @@ keywords: [accounts, product activation, clients, marketplace]
 
 In Vendasta, every client you serve is represented by an **account**. An account holds that client's business profile, their active products, and more. Before you can deliver any services, you need to create accounts for your clients and activate the right products for them. This guide walks you through that core workflow from start to finish.
 
-## Getting Started checklist
+## Getting Started Checklist
 
 1. [Create a client account](#step-1-create-a-client-account): add your client's business to the platform
 2. [Edit and complete the account profile](#step-2-edit-and-complete-the-account-profile): fill in business details to ensure accurate service delivery
@@ -92,7 +92,7 @@ Navigate to **Partner Center** → **Accounts** → **Manage Accounts**, open th
 - **Business Categories**: choose the most specific categories available, as some product features depend on them
 - **Business Hours**: add operating hours to support listing and reporting tools
 
-### Assign to a market (If Markets are part of your subscription) 
+### Assign to a market (if markets are part of your subscription)
 
 If you serve clients across different regions or industries, assign each account to the appropriate **market**. Markets control which branding, products, and pricing apply to a client.
 

--- a/docusaurus/docs/getting-started/getting-started-guides/getting-started-with-branding-and-customization.mdx
+++ b/docusaurus/docs/getting-started/getting-started-guides/getting-started-with-branding-and-customization.mdx
@@ -22,17 +22,17 @@ Some white-labeling features, such as custom domains, are only available on cert
 1. [Set up Partner Branding](#step-1-set-up-partner-branding): your company name, logo, colors, and icons
 2. [Customize Business App](#step-2-customize-business-app): rename the app, add a custom domain, configure the web chat footer
 3. [Control what clients see](#step-3-control-what-clients-see): show or hide pages in Business App
-4. [Set up market-specific branding](#step-4-optional-market-specific-branding) *(optional)*: different branding per customer segment
+4. [Set up market-specific branding](#step-4-market-specific-branding-optional) *(optional)*: different branding per customer segment
 
 ---
 
-## Step 1: Set Up Partner Branding
+## Step 1: Set up Partner Branding
 
 Partner Branding controls how your business is represented across the platform, in client-facing emails, and in Business App.
 
 Navigate to **Partner Center** → **Administration** → **[Partner Branding](https://partners.vendasta.com/customize-branding)**.
 
-### Company Name
+### Company name
 
 This is your brand name as it appears to clients throughout the platform, in emails, and in notifications.
 
@@ -68,7 +68,7 @@ Your logo appears in Business App, outgoing email campaigns, and other client-fa
 
 <img src={require('./img/logo-upload.png').default} alt="Logo upload section in Partner Branding settings" style={{width: '75%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
 
-### Company Avatar / Shortcut Icon
+### Company avatar / shortcut icon
 
 The shortcut icon appears when a client saves Business App to their phone's home screen, and is also used to represent your company in Inbox chat.
 
@@ -94,7 +94,7 @@ Favicons must be **ICO files only** (e.g., `favicon.ico`). PNG and JPG files wil
 
 <img src={require('./img/favicon-upload.png').default} alt="Favicon upload section in Partner Branding" style={{width: '75%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
 
-### Primary Color
+### Primary color
 
 Your brand color is used as an accent throughout the platform and in some client emails. This keeps your visual identity consistent everywhere.
 
@@ -131,7 +131,7 @@ This name will appear in the Business App navigation, in emails sent to clients,
 Keep the name short. Two to three words works best across all device sizes. Avoid special characters.
 :::
 
-### Add a Custom Domain
+### Add a custom domain
 
 A custom domain lets clients access Business App from your own branded URL (e.g., `app.youragency.com`) instead of a default Vendasta URL.
 
@@ -144,7 +144,7 @@ Custom domain setup is available on select plans. [View plan details](https://ww
 
 [Learn more about custom domain setup](/partner-center/#customize-your-domains)
 
-### Web Chat Footer Branding
+### Web chat footer branding
 
 If your clients use Vendasta's web chat widget on their websites, you can enable a footer that reads *"Chat Powered By [Your Agency Name]"*, linking back to your website. This creates backlink SEO value and drives new leads.
 
@@ -199,7 +199,7 @@ Page visibility is set at the **partner level** (applies to all clients) or per 
 
 ---
 
-## Step 4: (Optional) Market-Specific Branding
+## Step 4: Market-specific branding (optional)
 
 If you serve distinct client segments, for example different industries, regions, or tiers, you can set up separate **markets** and apply unique branding to each. This means different logos, colors, and even a different company name per market.
 

--- a/docusaurus/docs/getting-started/getting-started-guides/getting-started-with-projects-in-task-manager.mdx
+++ b/docusaurus/docs/getting-started/getting-started-guides/getting-started-with-projects-in-task-manager.mdx
@@ -30,7 +30,7 @@ This guide will focus on using projects in Task Manager. Projects are an easy wa
 
 **Digital Agent** is the role you want to give your team members to allow them to access Task Manager. To add team members, take the following steps:
 
-1. Go to **Partner Center → Administration → [My Team.](https://partners.vendasta.com/my-team)**
+1. Go to **Partner Center** → **Administration** → [**My Team**](https://partners.vendasta.com/my-team).
 2. Click **Invite team member**.
 3. Enter a name and email address for the team member.
 4. Select a role(s) for the team member.
@@ -40,13 +40,15 @@ This guide will focus on using projects in Task Manager. Projects are an easy wa
 
 [**Learn more.**](../../administration/my-account/my-team/index.mdx)
 
-[Back to top.](#getting-started-checklist)
+[Back to checklist](#getting-started-checklist)
+
+---
 
 ### Navigation basics
 
 To open Task Manager, go to **Partner Center** → **Fulfillment** → **Open Task Manager**.
 
-To find your unique Task Manager login URL (for Digital Agent users to log in directly), navigate to **Partner Center → Fulfillment → Users**.
+To find your unique Task Manager login URL (for Digital Agent users to log in directly), navigate to **Partner Center** → **Fulfillment** → **Users**.
 
 <img src={require('./img/projects-in-task-manager/manage-users-login-url.png').default} alt="Task Manager login URL in Manage Users" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
 
@@ -67,35 +69,38 @@ Here are the main sections to be aware of:
 
 **Manage your team**: Takes you back to Partner Center's **My Team** page, where you can add and manage your team members.
 
-[Back to top.](#getting-started-checklist)
+[Back to checklist](#getting-started-checklist)
+
+---
+
 ## Create a template
 
 ### Basic template
 
-1. Go to **Task Manager → Templates.**
+1. Go to **Task Manager** → **Templates**.
 2. Click **+ Add New Template** and select the type of template you want to create:
-   - **Project** – A multi-step project template.
-   - **Task** – A single task template.
-   - **Select from library** – Choose from pre-made library options.
+   - **Project**: a multi-step project template.
+   - **Task**: a single task template.
+   - **Select from library**: choose from pre-made library options.
 
 <img src={require('./img/projects-in-task-manager/create-new-template.png').default} alt="Create new template dialog with Project, Task, and Select from library options" style={{width: '50%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
 
 3. Fill in the project details:
-   - **Template Name** (required) – The name of your template.
-   - **Tags** (optional) – Admins and managers can manage tags in Settings.
-   - **Template Type** – Choose from the available template types (e.g. Custom).
-   - **Project Assignee** – Who the template will be assigned to by default.
-   - **Due __ days from creation** – The number of days the project is due after creation.
-   - **Recurrence** – How often the project recurs (e.g. Does not recur).
-   - **Project details** – A rich text field for additional project information.
-   - **Advanced settings** – Expand for additional configuration options.
+   - **Template Name** (required): the name of your template.
+   - **Tags** (optional): admins and managers can manage tags in Settings.
+   - **Template Type**: choose from the available template types (e.g. Custom).
+   - **Project Assignee**: who the template will be assigned to by default.
+   - **Due __ days from creation**: the number of days the project is due after creation.
+   - **Recurrence**: how often the project recurs (e.g. Does not recur).
+   - **Project details**: a rich text field for additional project information.
+   - **Advanced settings**: expand for additional configuration options.
 
 <img src={require('./img/projects-in-task-manager/create-project-template.png').default} alt="Create project template page showing project details fields" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
 
 4. Create the tasks associated with the project. Here, you can set the following fields:
-   - **Task Name** - What the task is called.
-   - **Assignee** - Who the task will be assigned to when created.
-   - **Due __ days from creation** - How soon after the project is created the task is due.
+   - **Task Name**: what the task is called.
+   - **Assignee**: who the task will be assigned to when created.
+   - **Due __ days from creation**: how soon after the project is created the task is due.
 
 <img src={require('./img/projects-in-task-manager/create-task-template.png').default} alt="Tasks section showing task name, assignee, due days, and project visibility options" style={{width: '75%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
 
@@ -107,7 +112,9 @@ Here are the main sections to be aware of:
 
 [**Learn more.**](../../fulfillment/task-manager/projects/project-templates-and-automation.mdx)
 
-[Back to top.](#getting-started-checklist)
+[Back to checklist](#getting-started-checklist)
+
+---
 
 ### Advanced template features
 
@@ -125,13 +132,15 @@ Clicking into the advanced settings in the main project configuration section wh
 
 When adding tasks to a project, there are advanced settings available as well. Expand **Advanced settings** on a task to access:
 
-1. **Lock the next task until this one is completed** – When you have two or more tasks in a project template, check this option to prevent the next task from being acted upon until the current one is completed. When a task is locked, its due date is based on when it is unlocked rather than when the project is created.
-2. **Product** – Link a Vendasta Marketplace product (e.g. Reputation AI, Website Pro) to the task. This creates a shortcut inside the task so your team can access the product directly in your customer's Business App.
-3. **Custom fields** – Click **+ Add custom fields** to create additional fields for the task.
+1. **Lock the next task until this one is completed**: when you have two or more tasks in a project template, check this option to prevent the next task from being acted upon until the current one is completed. When a task is locked, its due date is based on when it is unlocked rather than when the project is created.
+2. **Product**: link a Vendasta Marketplace product (e.g. Reputation AI, Website Pro) to the task. This creates a shortcut inside the task so your team can access the product directly in your customer's Business App.
+3. **Custom fields**: click **+ Add custom fields** to create additional fields for the task.
 
 <img src={require('./img/projects-in-task-manager/task-advanced-settings-full.png').default} alt="Task advanced settings showing lock task, product, and custom fields options" style={{width: '75%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
 
-[Back to top.](#getting-started-checklist)
+[Back to checklist](#getting-started-checklist)
+
+---
 
 ## Generate your project
 
@@ -180,7 +189,9 @@ With a Marketplace product selected, every time that you activate this product f
 5. Within the automation, choose **Create a fulfillment project for the account**.
 6. Turn the automation on.
 
-[Back to top.](#getting-started-checklist)
+[Back to checklist](#getting-started-checklist)
+
+---
 
 ## Manage your projects
 
@@ -205,4 +216,6 @@ Projects can be shared to Business App, so your customers can be kept up to date
 If you enable this, your customer will be able to see the entire project timeline including all tasks in the project, as well as any public comments in the tasks. Take care to ensure all information is appropriate to be shared with your customer.
 :::
 
-[Back to top.](#getting-started-checklist)
+[Back to checklist](#getting-started-checklist)
+
+---

--- a/docusaurus/docs/getting-started/getting-started-guides/getting-started-with-subscriptions-and-client-billing.mdx
+++ b/docusaurus/docs/getting-started/getting-started-guides/getting-started-with-subscriptions-and-client-billing.mdx
@@ -11,7 +11,7 @@ keywords: [subscriptions, client billing, billing]
 
 When you activate a product for a client, Vendasta automatically creates a **subscription** to track that recurring service. Subscriptions are the engine behind client billing: they determine when invoices are generated, how much clients are charged, and how you collect payment. This guide walks you through how subscriptions work, how to configure billing for your clients, and how to manage invoices over time.
 
-## Getting started checklist
+## Getting Started Checklist
 
 1. [Understand how subscriptions work](#step-1-understand-how-subscriptions-work): learn the difference between wholesale and retail subscriptions
 2. [Configure your billing settings](#step-2-configure-your-billing-settings): set default billing rules and customize them per client

--- a/docusaurus/docs/getting-started/getting-started-guides/getting-started-with-vendasta-services.mdx
+++ b/docusaurus/docs/getting-started/getting-started-guides/getting-started-with-vendasta-services.mdx
@@ -68,7 +68,7 @@ Accessing the fulfillment form preview in Partner Center is one of the best ways
 
 ## Order the product(s)
 
-### Ordering products - General
+### Ordering products: general
 
 <div style={{position: 'relative', paddingBottom: '56.25%', height: '0'}}>
   <iframe style={{position: 'absolute', top: '0', left: '0', width: '100%', height: '100%'}} src="https://www.loom.com/embed/97f19914b7bf4e2ebc1009975ef1551b?sid=6d42f3b8-7c84-4eb9-b9d3-5f6dc24782d1" frameborder="0" allowFullScreen></iframe>
@@ -93,7 +93,7 @@ Check out this video for full details on inputting information, sharing, and sub
   <iframe style={{position: 'absolute', top: '0', left: '0', width: '100%', height: '100%'}} src="https://www.loom.com/embed/ed6f1b17347c44948d2be512f386c806?sid=f5159b91-7c40-4142-8253-e63489948854" frameborder="0" allowFullScreen></iframe>
 </div>
 
-### Ordering - Website Services
+### Ordering: website services
 
 Website services in particular require a lot of information about a business in order to successfully create their website and web copy with expedient turnaround times. Check out our [website ordering guide](/vendasta-services/websites/vendasta-services-website-ordering-guide) and the video below for more info.
 
@@ -105,7 +105,7 @@ The following video showcases an older workflow from before the implementation o
   <iframe style={{position: 'absolute', top: '0', left: '0', width: '100%', height: '100%'}} src="https://www.loom.com/embed/18352d523eea4be88fe1489adf1d5116?sid=ee4687f2-73d7-4de1-8507-b64125c856dc" frameborder="0" allowFullScreen></iframe>
 </div>
 
-### Ordering - Digital Ads
+### Ordering: digital ads
 
 When ordering Digital Ads, you will be required to choose the ad spend for the campaign. This is the amount specific to the ad spend and then the system will calculate the ad management fee for you. You will be prompted to do this between steps 4 and 5 in the workflow noted above.
 
@@ -137,11 +137,11 @@ This call is also important to ensure that we have all of the necessary access a
 
 You, your sales team, and your customers can keep an eye on the progress of fulfillment for the services you have ordered.
 
-The easiest way to access this information is through Business App → Projects.
+The easiest way to access this information is through **Business App** → **Projects**.
 
 ![Projects view](./img/marketing-services/projects-view.jpg)
 
-There is also a Projects card found in the account under Partner Center → Accounts → Manage Accounts.
+There is also a Projects card found in the account under **Partner Center** → **Accounts** → **Manage Accounts**.
 
 ![Projects card](./img/marketing-services/projects-card.jpg)
 
@@ -149,10 +149,10 @@ Your salespeople can view this information on the account page under Fulfillment
 
 ![Fulfillment projects](./img/marketing-services/fulfillment-projects.jpg)
 
-You can also find information by going into Task Manager → Projects. But note that some of this information may be "grayed out" or inaccessible because the project is being completed in Vendasta Services' Task Manager account and a read-only version is being shared with you.
+You can also find information by going into **Task Manager** → **Projects**. But note that some of this information may be "grayed out" or inaccessible because the project is being completed in Vendasta Services' Task Manager account and a read-only version is being shared with you.
 
 ![Task Manager](./img/marketing-services/task-manager.jpg)
 
 [**Learn more.**](/getting-started/getting-started-guides/getting-started-with-projects-in-task-manager)
 
-[Back to top](#getting-started-checklist)
+[Back to checklist](#getting-started-checklist)

--- a/docusaurus/docs/getting-started/getting-started-guides/getting-started-with-your-team.mdx
+++ b/docusaurus/docs/getting-started/getting-started-guides/getting-started-with-your-team.mdx
@@ -98,7 +98,7 @@ For admins and salespeople, you can control exactly what they can see and do in 
 1. Go to **Partner Center** → **Administration** → **My Team**.
 2. Click the menu icon (⋮) next to the team member's name.
 3. Click **Edit member**.
-4. If the user is an admin, click **Show more permissions** to see the full list.
+4. If the team member is an admin, click **Show more permissions** to see the full list.
 5. Toggle individual permissions on or off.
 6. Click **Save**.
 


### PR DESCRIPTION
Apply mechanical style fixes from getting-started-guide skill across six guides:

- Replace en dashes with colons in checklist/glossary items
- Sentence-case headings (Title Case → sentence case)
- Bold nav-path segments individually (**Section** → **Page**)
- Standardize step-section endings to `[Back to checklist]` + `---`
- Replace "the user" with "the team member" where it refers to a person
- Normalize "Getting Started Checklist" heading casing