### PR TITLE
fix(nginx): serve directory index files for all doc routes

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -31,7 +31,7 @@ server {
 
     # Main handler - serve files or fallback to index.html for SPA routing
     location / {
-        try_files $uri /index.html;
+        try_files $uri $uri/ /index.html;
         expires 1h;
         add_header Cache-Control "public, no-transform";
     }


### PR DESCRIPTION
try_files was missing the $uri/ argument, causing nginx to fall back to the root index.html for every subpath URL instead of serving the correct page. Adding $uri/ tells nginx to resolve directory requests and serve their index.html.