### PR TITLE
docs(automations): apply Guru cleanup recommendations

### DIFF
--- a/docusaurus/docs/automations/automation-steps-reference.mdx
+++ b/docusaurus/docs/automations/automation-steps-reference.mdx
@@ -188,7 +188,7 @@ Steps marked **(draft)** are in development and may change or be removed before 
 | Log a call activity to the contact | Logs a call record on the contact's activity timeline. | Available on contact-scoped triggers. | When an outbound call is detected via integration, log the call on the contact. |
 | Add a note to the contact | Adds a note to a contact record. | Available on contact-scoped triggers. | When a contact hits a milestone, log it as a note for the next touchpoint. |
 | Create a CRM sales task for the contact | Creates a CRM sales task on the contact. | Available on contact-scoped triggers. | When a contact is created, create a follow-up task on the new contact. |
-| Send a webhook | Sends an HTTP POST request with custom data to an external URL. | | When a key event happens, notify an external system via webhook. |
+| Send a webhook | Sends an HTTP POST request with custom data to an external URL. Data must be sent as JSON in the request body — sending as headers is the most common misconfiguration. Cannot send file attachments. | Not available on all contact-based triggers. All mapped values must be strings; passing integers causes a runtime error. | When a key event happens, notify an external system or trigger a Zapier Zap. |
 | Trigger a webhook *(draft)* | Triggers an existing webhook configuration with data from the workflow. | Available on account-scoped triggers. | |
 
 ## Integrations

--- a/docusaurus/docs/automations/creating-and-configuring-automations.mdx
+++ b/docusaurus/docs/automations/creating-and-configuring-automations.mdx
@@ -16,11 +16,17 @@ Several settings can be configured for each automation you create. You can acces
 
 ### Entry settings
 
-Many trigger events and conditions can be met multiple times. For example, **A customer makes a payment** trigger with the trigger options set to **Succeeds or fails** will fire each time a customer attempts to pay for an invoice or shopping cart purchase. The entry settings allow you to specify whether you want the automation workflow to start only the first time the trigger criterion is met or every time.
+Many trigger events and conditions can be met multiple times. For example, **A customer makes a payment** trigger with the trigger options set to **Succeeds or fails** will fire each time a customer attempts to pay for an invoice or shopping cart purchase. The entry settings allow you to specify how often the automation should run when the trigger fires.
 
 **Options:**
-- **Run once per account**: The automation will only run the first time the trigger conditions are met for each account
-- **Run every time**: The automation will run each time the trigger conditions are met, regardless of previous runs
+
+- **Only once per account** — The automation runs a maximum of one time per account, ever. Once it has run for an account, that account is excluded from all future runs, even if the trigger fires again. Use this for one-time onboarding flows or welcome sequences.
+- **One at a time per account** — Prevents concurrent runs for the same account. If a second trigger fires while a run is already in progress for that account, the second trigger is dropped. Once the first run completes, new triggers will start fresh runs normally. Use this when overlapping runs would cause duplicate actions.
+- **Multiple times per account** — The automation runs every time the trigger conditions are met, with no frequency or concurrency limits. Use this for ongoing notifications, recurring task creation, or any scenario where re-triggering is intentional.
+
+:::warning Common misconception
+**One at a time per account** does not limit the automation to running once total. It only prevents two runs from overlapping simultaneously. If the trigger fires again after the first run finishes, a new run will start. To run only once ever, use **Only once per account**.
+:::
 
 ### Error handling settings
 
@@ -65,6 +71,19 @@ To copy an automation from a specific automation:
 2. Click **Duplicate**.
 
 ![Duplicate from a specific automation](./img/automations/duplicating-automations/duplicate_from_specific_automation.jpg)
+
+## Automation market scope
+
+Automations apply to **all markets** by default. Single-market automation creation is no longer supported — if you duplicate an automation, the copy will be scoped to all markets regardless of how the original was configured.
+
+To restrict an automation to a specific market, add a market condition to the trigger:
+
+1. In the trigger step, click **Add conditions for starting this automation**.
+2. Set **Condition type** to **Account data**.
+3. Select **Market** → **Is** → choose the market from the dropdown.
+4. Save the trigger.
+
+The automation will only fire for accounts in that market. To target multiple specific markets, add additional market conditions using **OR** logic.
 
 ## Organizing automations with tags
 

--- a/docusaurus/docs/automations/managing-your-automations.mdx
+++ b/docusaurus/docs/automations/managing-your-automations.mdx
@@ -25,6 +25,23 @@ Filter the activity list to narrow down what you're looking at:
 
 ![Automation Activity filters](./img/automations/activity/automation_activity_filters.jpg)
 
+#### Filter by company
+
+The Company filter requires a **Company ID**, not the company name. Entering a company name will return no results.
+
+To find a Company ID:
+1. Go to **Partner Center** → **CRM** → **Companies** and open the company.
+2. Look at the browser URL: `.../companies/76543/details` — the number is the Company ID.
+3. Enter that number in the Company filter.
+
+#### Adjusting the date range
+
+Filters only return results within the selected date range. If an expected run isn't showing up, extend the date range to cover the period when the automation ran — the default window may not include older activity.
+
+:::tip
+Filters are case-sensitive and will not match if there are leading or trailing spaces in the field. If you're not seeing results you expect, verify the ID is entered exactly and the date range is wide enough.
+:::
+
 ### Activity statuses
 
 Each run shows one of:

--- a/docusaurus/docs/automations/partner-made-automation-templates.mdx
+++ b/docusaurus/docs/automations/partner-made-automation-templates.mdx
@@ -44,3 +44,18 @@ Navigate to Partner Center > Administration > Customize Business App.
 ![Publish toggle for templates](../business-app/automations/img/business-app-automations/templates-publish-toggle.png)
 
 **Please note:** These templates are strictly for your clients, and your clients will not be able to create templates for themselves.
+
+## Why isn't my template visible in Business App?
+
+Templates must be **published** before clients can see them. A template that has been created but not published is in **Draft** status and is only visible to Partner admins in Partner Center — it will not appear in Business App.
+
+| Status | Visible to |
+|--------|------------|
+| **Draft** | Partner admins only (Partner Center) |
+| **Published** | All clients in Business App |
+
+If clients can't find your template, return to the template and confirm the publish toggle is turned on.
+
+### Who can publish templates
+
+Only **Partner admins** can publish automation templates. If the publish toggle is unavailable or greyed out, check that your account has Partner admin permissions. Sub-users and restricted roles cannot publish templates.

--- a/docusaurus/docs/automations/trigger-automation-using-zapier.mdx
+++ b/docusaurus/docs/automations/trigger-automation-using-zapier.mdx
@@ -96,3 +96,38 @@ Before publishing the Zap, be sure to test the steps in Zapier. This can help id
 ![Zapier Test Step](../business-app/automations/img/business-app/zapier/zapier-vendasta-app-14.jpg)
 
 After testing, a 'Run Automation Successful' message confirms that the Zap is working as expected and ready to be published.
+
+## Connect Facebook Lead Ads to Vendasta automations
+
+You can automatically create contacts in Vendasta CRM whenever a new lead submits a Facebook Lead Ad. This uses Zapier as middleware between Facebook and Vendasta.
+
+**Prerequisites:**
+- An active [Zapier](https://zapier.com) account
+- A Facebook Lead Ads account with at least one active lead form
+- Partner Center access with permission to manage automations and CRM
+
+### Set up the Zap
+
+1. In Zapier, create a new Zap and set **Facebook Lead Ads** as the trigger with **New Lead** as the trigger event.
+2. Connect your Facebook account, then select the Page and lead form to watch.
+3. Click **Test trigger** to pull in a sample lead.
+4. Add a Vendasta action:
+   - **Run Automation** — triggers a specific Vendasta automation for each new lead, allowing you to run a full onboarding or notification flow.
+   - **Create or Update Contact** — writes the lead directly to CRM.
+5. Connect your Vendasta account and enter your Partner ID when prompted.
+6. Map the lead fields (first name, last name, email, phone) to the corresponding Vendasta CRM fields.
+7. Test the action, then publish the Zap.
+
+### Associate contacts with companies
+
+If a contact should be linked to a company in Vendasta CRM, pass the **Company ID** in the **Primary Company** field — not the company name. The company must already exist in CRM before the Zap runs.
+
+To find a Company ID, open the company in **Partner Center** → **CRM** → **Companies** and check the URL: `.../companies/76543/details` — the number is the Company ID.
+
+### Common issues
+
+| Issue | Fix |
+|-------|-----|
+| Primary company not linking | Use the numeric Company ID, not the company name |
+| Leads not appearing in CRM | Verify the Zap is **On** and all required fields are mapped |
+| Automation not triggering | Confirm the automation is toggled **On** in Partner Center and uses a compatible trigger type |

--- a/docusaurus/docs/automations/troubleshooting-automations.mdx
+++ b/docusaurus/docs/automations/troubleshooting-automations.mdx
@@ -49,6 +49,27 @@ Some steps can only run once per account regardless of settings. For example, an
 
 Design around these limits by using different campaigns or by using pause/resume campaign steps instead.
 
+## Webhook action isn't sending data correctly
+
+### External system receives no data
+
+The most common cause is that fields were mapped as **request headers** instead of in the **request body**. Webhook data must be sent as JSON in the request body.
+
+Open the **Send Webhook** step and verify that your field mappings are in the **Body** section as JSON key–value pairs, not in a headers section. Remove any header mappings and re-add the fields to the body.
+
+### `id.trim is not a function` error
+
+This error means a mapped field value is an integer rather than a string. All webhook body values must be strings. Re-map the affected field as text, or use the `toString()` expression to convert the value before passing it.
+
+### Webhook URL is not responding
+
+Confirm the URL is reachable from outside your network and accepts HTTP POST requests. Test it with a tool like [webhook.site](https://webhook.site) before connecting it to the automation.
+
+### Limitations
+
+- File attachments (PDFs, images, etc.) cannot be sent via webhook. Pass a URL to the file instead.
+- The Send Webhook step is not available on all contact-based triggers.
+
 ## Campaign failed to start
 
 When starting an email campaign from an automation, you may see this error:


### PR DESCRIPTION
## Summary

Updates six existing automation articles based on Guru cleanup recommendations (34-card export).

### Changes

| Article | What was added |
|---|---|
| `creating-and-configuring-automations` | Expanded entry settings to cover all 3 run frequency options with a misconception callout; added market scope section with trigger condition workaround |
| `troubleshooting-automations` | New webhook troubleshooting section covering headers-vs-JSON-body error, `id.trim` error, and limitations |
| `automation-steps-reference` | Expanded Send a webhook row with payload format requirements and limitations |
| `trigger-automation-using-zapier` | New Facebook Lead Ads via Zapier setup section with company ID note and common issues |
| `managing-your-automations` | Expanded Activity filters with Company ID lookup steps and date range troubleshooting tip |
| `partner-made-automation-templates` | Added draft vs. published visibility explanation and permissions note |

### Source
Guru cleanup export: Automations section (56-page export, 34 cards)

🤖 Generated with [Claude Code](https://claude.com/claude-code)