### PR TITLE
docs(task-manager): apply Guru cleanup recommendations

### DIFF
--- a/docusaurus/docs/accounts/manage-business-app/files.mdx
+++ b/docusaurus/docs/accounts/manage-business-app/files.mdx
@@ -22,3 +22,11 @@ Share sales decks, onboarding resources, and other collateral directly through B
 - Maintain a "Getting Started" folder with onboarding checklists and service explanations.
 - Replace outdated versions instead of renaming files, which keeps shared URLs consistent.
 - Pair files with Guides to provide both high-level instructions and supporting documentation.
+
+## Task Manager file attachments are different
+
+Files attached to tasks or projects in **Task Manager** are separate from Account Files and are not visible to clients in Business App. Task Manager attachments are internal-only — they can be seen by your team but do not appear anywhere in the client's Business App interface.
+
+To share a file with a client:
+- **Use Account Files** (this page) — upload the file here and toggle it visible in Business App.
+- **Use a cloud storage link** — paste a Google Drive or Dropbox link in a public task note so the client can access it from the task.

--- a/docusaurus/docs/fulfillment/task-manager/getting-started.mdx
+++ b/docusaurus/docs/fulfillment/task-manager/getting-started.mdx
@@ -90,3 +90,33 @@ Yes, the task view shows all your assigned tasks across projects and accounts.
 
 Yes, team members need appropriate permissions to create projects and assign tasks to others.
 </details>
+
+## Known limitations
+
+<details>
+<summary>Does Task Manager support billable hours or time tracking?</summary>
+
+No. Task Manager does not include time tracking or billable hours functionality. For time tracking, use a dedicated third-party tool such as Harvest, Toggl, or similar, and reference the task in your notes for context.
+
+</details>
+
+<details>
+<summary>Can I bulk-update due dates across multiple projects?</summary>
+
+No. The Projects page does not support bulk due date updates — each project must be updated individually. Within a single project, subtask due dates can be bulk-edited using the bulk edit feature in the Tasks view.
+
+</details>
+
+<details>
+<summary>Can I upload ZIP files to tasks?</summary>
+
+No. ZIP archives are not supported in the Task Manager file uploader. To share a collection of files, upload them to a cloud storage service (Google Drive, Dropbox) and paste the link in a task note or project comment.
+
+</details>
+
+<details>
+<summary>Can clients see files I attach to tasks in Task Manager?</summary>
+
+No. Files attached to tasks or projects in Task Manager are visible to your team only — they do not appear in the client's Business App. To share a file with a client, use **Partner Center → Accounts → Files** and toggle the file visible in Business App, or paste a cloud storage link in a public task note.
+
+</details>

--- a/docusaurus/docs/fulfillment/task-manager/projects/create-and-manage-projects.mdx
+++ b/docusaurus/docs/fulfillment/task-manager/projects/create-and-manage-projects.mdx
@@ -62,6 +62,16 @@ Effective project management helps you deliver consistent results by organizing 
 - **Schedule Social Posts**: Automatically generate social post tasks within the project
 - **Client Review**: Require client approval before content goes live
 
+:::info Setting up Client Review
+**Client Review** is only available for Social Calendar projects and requires **Schedule Social Posts** to be selected first. Once both are enabled and the project is created, a **Client Review** task appears at the bottom of the project. To send content for client review:
+
+1. Open the **Client Review** task in the project
+2. Click **Generate new preview**
+3. Click **Send for review**
+
+Clients receive a notification and can approve or request changes before posts go live. If you don't see the Client Review option, confirm that Schedule Social Posts is checked.
+:::
+
 ### Step 4: Complete project creation
 
 1. Add any initial tasks if you want to start with specific deliverables
@@ -96,6 +106,10 @@ Effective project management helps you deliver consistent results by organizing 
    - **Dependency**: Optionally select other tasks that must be completed before this task can start
 
 3. Click **Add** to save the task to your project
+
+:::warning Bulk project due date updates are not supported
+The Projects page does not support bulk due date updates. If you need to change the due date for multiple projects, each one must be updated individually. Note that **subtask** due dates within a single project can be bulk-edited using the bulk edit feature in the Tasks view.
+:::
 
 ### Step 3: Organize and manage tasks
 

--- a/docusaurus/docs/fulfillment/task-manager/tasks/creating-managing-tasks.mdx
+++ b/docusaurus/docs/fulfillment/task-manager/tasks/creating-managing-tasks.mdx
@@ -42,6 +42,10 @@ Create manual tasks for:
 - Account-specific work
 - Tasks not covered by auto-generation
 
+:::info Due dates and timezones
+Task Manager stores all due dates as midnight UTC−6. When you view a task, the due date is displayed in your local timezone — so the same deadline may appear as a different calendar day for team members in timezones significantly ahead of UTC−6. This is expected behavior, not a bug. The actual deadline is the same for everyone; only the displayed calendar date differs.
+:::
+
 ## How to Set Up Auto-Generated Tasks
 
 Auto-generated tasks streamline your fulfillment process by automatically creating tasks based on account activity and configured settings.
@@ -178,5 +182,12 @@ Mentions and Reviews tasks require Reputation AI to be active. Social Posts and 
 <summary>Can I set different auto-generation settings for different accounts?</summary>
 
 Yes, you can configure task generation settings individually for each account in Account Settings > Task generation, or set defaults for all new accounts in the main Settings area.
+
+</details>
+
+<details>
+<summary>Why does a task's due date look different for team members in different timezones?</summary>
+
+Task Manager stores all due dates as midnight UTC−6. When a team member in a timezone significantly ahead of UTC−6 views the task, their local time conversion may shift the displayed date by one day. The underlying deadline is identical for everyone — only the calendar date shown in the UI differs by timezone.
 
 </details>

--- a/docusaurus/docs/fulfillment/task-manager/tasks/task-communication-collaboration.mdx
+++ b/docusaurus/docs/fulfillment/task-manager/tasks/task-communication-collaboration.mdx
@@ -172,6 +172,29 @@ When setting visible tasks to "Waiting on Customer", you can notify clients who 
 3. Add public notes explaining what you're waiting for
 4. Client receives notification with link to Business App
 
+## File attachments
+
+You can attach files to individual tasks and projects in Task Manager to share supporting materials with your team.
+
+### What's supported
+
+- **File types**: Images, videos, and documents
+- **Maximum file size**: 10 MB per file
+- **Maximum files per task or project**: 10 files
+- **ZIP files**: Not supported — ZIP archives cannot be uploaded
+
+### File visibility
+
+Task Manager file attachments are visible to your team only. They do **not** appear in the client's Business App, even if the task itself is set to visible.
+
+To share a file with a client, use one of these approaches instead:
+- **Account Files** — upload through Partner Center → Accounts → Files → toggle visible in Business App
+- **Cloud storage link** — paste a Google Drive or Dropbox link in a public task note
+
+:::info
+For formal social content approval, use the [Social Calendar client review workflow](#social-calendar-client-review) rather than file attachments.
+:::
+
 ## Collaboration Workflows
 
 ### Internal Team Collaboration

--- a/docusaurus/docs/fulfillment/task-manager/templates/index.mdx
+++ b/docusaurus/docs/fulfillment/task-manager/templates/index.mdx
@@ -61,6 +61,34 @@ When you select a template from the library, you can:
 To save your customizations for future use, create a new template using the `project` option after making your changes.
 :::
 
+## Creating recurring tasks with templates
+
+Task Manager supports recurring tasks through project templates. Recurrence is configured at the template level — you set it once and every project created from that template automatically inherits the recurrence schedule.
+
+### How to create a recurring task template
+
+1. Open **Task Manager**
+2. Click the **Templates** tab
+3. Click **Create Template**
+4. Select **Create new template**
+5. Add your tasks, then find the **Recurrence** dropdown on each task you want to repeat
+6. Choose a recurrence option:
+   - **Does not recur** — one-time task (default)
+   - **Daily** — repeats every day
+   - **Weekly on [day]** — repeats on the same day each week
+   - **Every Weekday (Mon–Fri)** — repeats Monday through Friday
+   - **Monthly** — repeats on the same date each month
+   - **Annually** — repeats once per year
+7. Save the template
+
+### How to apply the template
+
+Once saved, select the template when creating a new project. The recurring schedule defined on each task will carry forward into the new project automatically.
+
+:::info
+Recurrence is set at the template level, not on individual tasks added to an existing project. To use recurring tasks, you must create or edit a template first.
+:::
+
 ## Screenshots or Videos
 
 <!-- ![Template Library Selection](./img/template-library-selection.png) -->
@@ -113,4 +141,11 @@ No, you cannot delete or modify the original templates in the library. You can o
 <summary>What happens if I don't customize a library template?</summary>
 
 You can use library templates as-is without any customization. The template will create a project with all the predefined tasks and structure.
+</details>
+
+<details>
+<summary>Does Task Manager support recurring tasks?</summary>
+
+Yes, recurring tasks are supported through templates. Set the Recurrence option on each task when creating or editing a template. Available schedules include daily, weekly on a specific day, every weekday, monthly, and annually. Any project created from that template will include tasks with the configured recurrence.
+
 </details>


### PR DESCRIPTION
## Summary

Updates 6 existing articles based on Guru card cleanup recommendations for the Task Manager card set.

## Changes

### Rec 1 — File attachment visibility
- **`accounts/manage-business-app/files.mdx`** — Added a section clarifying that Task Manager attachments are team-only and not visible in Business App, with guidance on how to share files with clients.
- **`tasks/task-communication-collaboration.mdx`** — Added a File attachments section covering supported types, limits (10 MB / 10 files, no ZIP), visibility limitation, and client-sharing alternatives.

### Rec 2 — Due dates and timezones
- **`tasks/creating-managing-tasks.mdx`** — Added an info callout and FAQ entry explaining due dates are stored as midnight UTC−6 and display differently across timezones (expected behavior, not a bug).

### Rec 3 — Recurring tasks
- **`templates/index.mdx`** — Added a "Creating recurring tasks with templates" section with step-by-step instructions and all 6 recurrence options. Added matching FAQ entry.

### Rec 4 — Social Calendar client review
- **`projects/create-and-manage-projects.mdx`** — Expanded the Social Calendar options section with a callout explaining the Schedule Social Posts dependency and the 3-step client review workflow.

### Rec 5 — Known limitations
- **`getting-started.mdx`** — Added a "Known limitations" FAQ section covering: no billable hours, no bulk project due date updates, no ZIP uploads, and Task Manager files not visible in Business App.
- **`projects/create-and-manage-projects.mdx`** — Added a warning callout about bulk project due date updates not being supported.

## Source
Guru cleanup: Task Manager card set (26 source cards), recommendations dated May 22, 2026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)