### PR TITLE
docs(ai-capabilities): fix capabilities UI to reflect add/remove model

### DIFF
--- a/docusaurus/docs/ai/ai-capabilities/configuring-capabilities.md
+++ b/docusaurus/docs/ai/ai-capabilities/configuring-capabilities.md
@@ -29,15 +29,17 @@ If you don't see the Configure button, verify you have the necessary permissions
 
 1. In the AI Employee configuration panel, scroll down to the **Capabilities** section.
 2. Click to expand the section if it's collapsed.
-3. You'll see a list of available built-in capabilities with toggle switches.
+3. You'll see a list of capabilities already added to the AI Employee.
 
-## Step 3: Enable Desired Capabilities
+## Step 3: Add Desired Capabilities
 
-For each capability you want to activate:
+Capabilities that appear in the Capabilities section are active. To add a new one:
 
-1. **Review the capability description** to understand what it does.
-2. **Toggle the capability switch** to the "on" position.
+1. Click **+ Add a capability**.
+2. **Review the capability description** to understand what it does.
 3. **Add specific instructions** (optional) to customize how the capability behaves.
+
+To remove a capability, click the three-dot menu next to it and select **Remove**.
 
 ### Common capability configurations
 
@@ -186,7 +188,7 @@ After initial setup:
 ### Capabilities conflicting
 - **Review capability priorities**: Some capabilities may override others
 - **Clarify instructions**: Make trigger conditions more specific
-- **Disable conflicting capabilities**: Temporarily turn off capabilities that interfere
+- **Remove conflicting capabilities**: Remove capabilities that interfere and re-add them once instructions are refined
 
 ## Advanced configuration tips
 


### PR DESCRIPTION
## Summary
- Removed incorrect toggle switch references from the AI capabilities configuration guide
- A capability is active when present in the Capabilities section — there is no on/off toggle
- Updated Step 3 to describe the correct flow: click **+ Add a capability** to add, and use the three-dot menu to remove
- Updated troubleshooting tip to say "remove" instead of "disable"

## Test plan
- [ ] Verify the updated steps match the actual UI in Business App AI Employee configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)