### PR TITLE
docs(vendasta-services): remove retired MatchCraft AI AdVantage service

### DIFF
--- a/docusaurus/docs/vendasta-services/digital-advertising/how-to-request-a-budget-change-on-matchcraft-ad-services-spend.md
+++ b/docusaurus/docs/vendasta-services/digital-advertising/how-to-request-a-budget-change-on-matchcraft-ad-services-spend.md
@@ -14,7 +14,7 @@ The **Request Spend Change** feature makes it easy for you to make changes to yo
 
 **Note:** The method described below will only apply to future ad spend and not the current month's spend. To add additional funds to the current month, use the One-Time Boost add-on.
 
-Head to [Partner Center](https://partners.vendasta.com/)​ → [Manage Accounts](https://partners.vendasta.com/manage-accounts) and select the account with the live digital ads campaign. Below the "Products" section, click on the three dots next to the active _MatchCraft Managed Ads Campaign_ or _MatchCraft Managed AI AdVantage_ product.
+Head to [Partner Center](https://partners.vendasta.com/)​ → [Manage Accounts](https://partners.vendasta.com/manage-accounts) and select the account with the live digital ads campaign. Below the "Products" section, click on the three dots next to the active _MatchCraft Managed Ads Campaign_ product.
 
 ![spend change.png](./img/19299887344535-f6aa08e5f6.png)
 

--- a/docusaurus/docs/vendasta-services/digital-advertising/index.mdx
+++ b/docusaurus/docs/vendasta-services/digital-advertising/index.mdx
@@ -1,15 +1,15 @@
 ---
 id: digital-advertising
 title: Digital Advertising
-description: "Guides for Vendasta Services digital ad campaigns: MatchCraft Express Ads, Managed Ads Campaign, Managed AI AdVantage, setup, creatives, dashboard, and policies."
+description: "Guides for Vendasta Services digital ad campaigns: MatchCraft Express Ads, Managed Ads Campaign, setup, creatives, dashboard, and policies."
 sidebar_position: 1
 tags: [vendasta-services, digital-advertising, matchcraft, ads, campaigns]
-keywords: [digital ads, MatchCraft, Express Ads, Managed Ads, AI AdVantage, advertising dashboard, order forms, creatives]
+keywords: [digital ads, MatchCraft, Express Ads, Managed Ads, advertising dashboard, order forms, creatives]
 ---
 
 # Digital Advertising
 
-Vendasta Services offers managed digital advertising through **MatchCraft**: **Express Ads** (fast, search-only, lower budget), **Managed Ads Campaign** (multi-platform, conversion-focused, specialist-led), and **Managed AI AdVantage** (full-service launch with landing page, webchat, call tracking, and ads). This section covers how to choose a service, complete order forms, work with creatives and tracking, use the Advertising Intelligence Dashboard, and understand policies and platform options.
+Vendasta Services offers managed digital advertising through **MatchCraft**: **Express Ads** (fast, search-only, lower budget) and **Managed Ads Campaign** (multi-platform, conversion-focused, specialist-led). This section covers how to choose a service, complete order forms, work with creatives and tracking, use the Advertising Intelligence Dashboard, and understand policies and platform options.
 
 ## What is Digital Advertising (Vendasta Services)?
 
@@ -17,7 +17,6 @@ Vendasta Services runs digital ad campaigns on your behalf using MatchCraft-powe
 
 - **Express Ads** – AI-powered search campaigns, quick launch, low ongoing effort. Best for small budgets and awareness or promotions.
 - **Managed Ads Campaign** – Search, social, display, and video with monthly optimization and conversion focus. Best for growth and scaling.
-- **Managed AI AdVantage** – End-to-end package: landing page or site, AI webchat, call tracking, and multi-channel ads. Best for businesses with little or no digital presence.
 
 Campaigns are billed monthly (setup plus first month at order); reporting is available in the Advertising Intelligence Dashboard. Order forms, tracking (GTM, Meta Pixel), and creatives (e.g. display banners) are part of the workflow.
 
@@ -25,7 +24,7 @@ Campaigns are billed monthly (setup plus first month at order); reporting is ava
 
 ### Service and setup
 
-- [MatchCraft Ads Services](./matchcraft-services-overview.md) – Express Ads, Managed Ads Campaign, Managed AI AdVantage
+- [MatchCraft Ads Services](./matchcraft-services-overview.md) – Express Ads, Managed Ads Campaign
 - [Advertising order forms](./completing-digital-ads-order-forms-key-details.md) – Key fields and best practices
 - [Tips for a successful campaign](./how-do-i-get-set-up-for-my-digital-ad-campaign.md) – Promotions, GTM, Facebook page access
 
@@ -55,7 +54,6 @@ Campaigns are billed monthly (setup plus first month at order); reporting is ava
 
 - **Express Ads** – Lower budget, search-only, hands-off, fast launch (e.g. promotions, local awareness).
 - **Managed Ads Campaign** – Moderate to higher budget, multi-platform, conversion-focused, specialist optimization.
-- **Managed AI AdVantage** – Full-service launch with site/landing page, chat, call tracking, and ads; best when you have minimal digital presence.
 
 See [MatchCraft Ads Services](./matchcraft-services-overview.md) for detailed comparison and FAQs.
 </details>
@@ -81,5 +79,5 @@ Use the [Advertising Intelligence Dashboard](./advertising-intelligence-dashboar
 <details>
 <summary>What platforms can we advertise on?</summary>
 
-Search (Google, Bing), display (Google), Facebook & Instagram (Meta), YouTube, LinkedIn, and Amazon Display (US). Support varies by product: Express Ads is search-only; Managed Ads Campaign and AI AdVantage support multiple platforms. See [Advertising platforms](./what-digital-ad-platforms-are-available-to-advertise-on-digital-ads-campaign.md).
+Search (Google, Bing), display (Google), Facebook & Instagram (Meta), YouTube, LinkedIn, and Amazon Display (US). Support varies by product: Express Ads is search-only; Managed Ads Campaign supports multiple platforms. See [Advertising platforms](./what-digital-ad-platforms-are-available-to-advertise-on-digital-ads-campaign.md).
 </details>

--- a/docusaurus/docs/vendasta-services/digital-advertising/matchcraft-services-overview.md
+++ b/docusaurus/docs/vendasta-services/digital-advertising/matchcraft-services-overview.md
@@ -1,10 +1,10 @@
 ---
 title: "MatchCraft Ads Services"
 sidebar_label: "Service Overview"
-description: "A guide to choosing between MatchCraft Express Ads, Managed Ads Campaign, and Managed AI AdVantage for different needs."
+description: "A guide to choosing between MatchCraft Express Ads and Managed Ads Campaign for different needs."
 ---
 
-You have three powerful MatchCraft advertising services at your disposal — now let's figure out which one fits best for your goals, budgets, and level of digital maturity.
+You have two powerful MatchCraft advertising services at your disposal — now let's figure out which one fits best for your goals, budgets, and level of digital maturity.
 
 
 ## MatchCraft Ad Service Options
@@ -13,7 +13,6 @@ You have three powerful MatchCraft advertising services at your disposal — now
 |--------|----------|--------------|
 | **Express Ads** | Small local businesses, startups, minimal effort | Fast AI campaign setup, search-only focus, low budget, hands-off |
 | **Managed Ads Campaign** | Growing SMBs ready to scale and convert | Multi-platform flexibility, expert monthly optimization, conversion-driven |
-| **Managed AI AdVantage** | Businesses starting from scratch, hands-off full digital launch | End-to-end package (landing page, webchat, call tracking, multi-channel ads), full-service execution |
 
 
 ## 1. MatchCraft Express Ads
@@ -66,50 +65,24 @@ You have three powerful MatchCraft advertising services at your disposal — now
 - Scaling ad spend sensibly with ongoing optimization  
 
 
-## 3. MatchCraft Managed AI AdVantage
-
-**Best for:** If you have minimal to no digital presence and want a full-service advertising startup package.
-
-### Ideal profile:
-- New businesses, consultants, or traditional offline businesses going digital  
-- Little or no existing website, landing page, or chat presence  
-- Want a hands-off solution to launch digital marketing and lead capture  
-- Monthly ad spend budget of **$700+**  
-
-### Why you’d choose AI AdVantage:
-- Everything is bundled together: landing page or website, AI-powered webchat, call tracking, plus ad campaigns across channels  
-- The provider handles nearly all execution end-to-end — strategy, setup, launch, optimizations  
-- AI-powered tools drive efficiency in campaign creation and budget allocation  
-- Excellent if you don’t want to manage the technical details yourself  
-
-### Typical use cases:
-- Launching a brand-new online presence or transitioning a traditional business online  
-- Generating leads for high-value services  
-- Simultaneously launching awareness and conversion campaigns  
-- Providing a smooth, low-stress onboarding experience for solopreneurs or time-strapped businesses  
-
-
 ## Choosing the Right Service
 
 Here are a few quick decision prompts to help you match service to situation:
 
 1. **Budget & effort threshold:**  
    - If ad spend is low and you want minimal involvement → consider *Express Ads*.  
-   - If ad spend is moderate to high, and you want ongoing results → lean toward *Managed Ads Campaign*.  
-   - If you want someone else to “just get it done” and are okay investing in a full launch → *Managed AI AdVantage* is a solid pick.
+   - If ad spend is moderate to high, and you want ongoing results → lean toward *Managed Ads Campaign*.
 
 2. **Digital maturity:**  
-   - Just getting started → *AI AdVantage*  
    - Solid web presence and social profiles, now wanting growth → *Managed Campaign*  
    - Existing presence and occasional promotional needs → *Express Ads*  
 
 3. **Desired outcome:**  
    - Brand visibility, awareness, fast launches → *Express Ads*  
    - Lead generation, conversions, scalable growth → *Managed Campaign*  
-   - Full-stack lead generation and online launch → *AI AdVantage*
 
 4. **Management preference:**  
-   - Hands-off, almost-zero effort → *Express Ads* or *AI AdVantage*  
+   - Hands-off, almost-zero effort → *Express Ads*  
    - Some involvement, collaboration preferred → *Managed Campaign*
 
 
@@ -118,8 +91,7 @@ Here are a few quick decision prompts to help you match service to situation:
 Whichever MatchCraft ads path you choose, you’re leveraging powerful AI-driven automation with the flexibility to match your goals, budget, and digital readiness.  
 
 - **Express Ads** are fast and affordable — ideal when speed and awareness matter more than fine-tuned customization.  
-- **Managed Ads Campaign** is for growth-minded businesses ready to scale across channels and focus on conversions.  
-- **Managed AI AdVantage** is the all-in-one launchpad for businesses with minimal online presence who want a hands-off but high-impact approach.
+- **Managed Ads Campaign** is for growth-minded businesses ready to scale across channels and focus on conversions.
 
 Always review your budget, current digital presence, and appetite for campaign management before selecting the right service.  
 

--- a/docusaurus/docs/vendasta-services/digital-advertising/what-digital-ad-platforms-are-available-to-advertise-on-digital-ads-campaign.md
+++ b/docusaurus/docs/vendasta-services/digital-advertising/what-digital-ad-platforms-are-available-to-advertise-on-digital-ads-campaign.md
@@ -12,7 +12,7 @@ tags:
   - social-ads
 ---
 
-With the [MatchCraft Managed Ads Campaign](https://partners.vendasta.com/marketplace/products/MP-WM65PB2J5PL6BCNLB5JJN58DDQWXZVPN), [MatchCraft Managed AI AdVantage](https://partners.vendasta.com/marketplace/products/MP-23KNRJZRP2HZDXQHRSNV775DDKDPCC5D) and [MatchCraft Express Ads](https://partners.vendasta.com/marketplace/products/MP-8MS2CFPW6TM2WW4RZK3D4JZGKM6LF6MZ), Vendasta Services offers advertising across a diverse range of platforms for advertising, catering to different needs and budgets.
+With the [MatchCraft Managed Ads Campaign](https://partners.vendasta.com/marketplace/products/MP-WM65PB2J5PL6BCNLB5JJN58DDQWXZVPN) and [MatchCraft Express Ads](https://partners.vendasta.com/marketplace/products/MP-8MS2CFPW6TM2WW4RZK3D4JZGKM6LF6MZ), Vendasta Services offers advertising across a diverse range of platforms for advertising, catering to different needs and budgets.
 
 ## Search Ads - Google & Bing
 
@@ -22,14 +22,14 @@ Search campaigns on Google and Bing are among the most popular formats. These te
 
 The setup is quick since no creatives are needed. These ads are pay-per-click, meaning you only pay when someone clicks on your ad. Depending on your monthly ad spend budget, we can run these ads on either Google or both Google and Bing. This is beneficial as we often yield high conversions on Bing. Running ads across both platforms maximizes reach and potential results.
 
-* **Supported by:** [MatchCraft Managed Ads Campaign](https://partners.vendasta.com/marketplace/products/MP-WM65PB2J5PL6BCNLB5JJN58DDQWXZVPN), [MatchCraft Managed AI AdVantage](https://partners.vendasta.com/marketplace/products/MP-23KNRJZRP2HZDXQHRSNV775DDKDPCC5D) and [MatchCraft Express Ads](https://partners.vendasta.com/marketplace/products/MP-8MS2CFPW6TM2WW4RZK3D4JZGKM6LF6MZ)
+* **Supported by:** [MatchCraft Managed Ads Campaign](https://partners.vendasta.com/marketplace/products/MP-WM65PB2J5PL6BCNLB5JJN58DDQWXZVPN) and [MatchCraft Express Ads](https://partners.vendasta.com/marketplace/products/MP-8MS2CFPW6TM2WW4RZK3D4JZGKM6LF6MZ)
 
 ## Display Ads - Google
 
 Display ads are image-based banners shown on websites alongside the website’s regular content. They help increase brand awareness by targeting users as they browse online. You can also retarget users who have previously interacted with your ads or website.
 
 Unlike search ads, display ads are great for promoting niche products or services that people might not be searching for. They use visuals to familiarize potential customers with your product. These ads are not pay-per-click; you pay for impressions, meaning your ad gets seen regardless of clicks. This exposure helps build unconscious brand familiarity, increasing the likelihood of future conversions.
-* **Supported by:** [MatchCraft Managed Ads Campaign](https://partners.vendasta.com/marketplace/products/MP-WM65PB2J5PL6BCNLB5JJN58DDQWXZVPN) and [MatchCraft Managed AI AdVantage](https://partners.vendasta.com/marketplace/products/MP-23KNRJZRP2HZDXQHRSNV775DDKDPCC5D)
+* **Supported by:** [MatchCraft Managed Ads Campaign](https://partners.vendasta.com/marketplace/products/MP-WM65PB2J5PL6BCNLB5JJN58DDQWXZVPN)
 
 ## Facebook & Instagram (Meta) Social Ads
 
@@ -40,7 +40,7 @@ Facebook and Instagram ads are better for demand creation, similar to display ad
 The most effective ads on these platforms resemble social posts rather than traditional ads. For example, an ad for dog dental products might feature a cute picture of a dog, making it look like a regular post that users might share, like, or engage with. This approach increases the likelihood of users pausing to read and interact with the ad.
 
 When creating ads, choose high-quality images and videos that blend seamlessly into users' feeds, ensuring they look like natural social media content. This strategy enhances engagement and makes your ads more effective on these visually-driven platforms.
-* **Supported by:** [MatchCraft Managed Ads Campaign](https://partners.vendasta.com/marketplace/products/MP-WM65PB2J5PL6BCNLB5JJN58DDQWXZVPN) and [MatchCraft Managed AI AdVantage](https://partners.vendasta.com/marketplace/products/MP-23KNRJZRP2HZDXQHRSNV775DDKDPCC5D)
+* **Supported by:** [MatchCraft Managed Ads Campaign](https://partners.vendasta.com/marketplace/products/MP-WM65PB2J5PL6BCNLB5JJN58DDQWXZVPN)
 
 ## YouTube Video Ads
 
@@ -67,7 +67,6 @@ A key consideration is that LinkedIn ads cannot be white-labeled. Ads must be ma
 Amazon Display ads allow businesses to reach shoppers with image-based banners on and off Amazon, across a network of sites and apps. This helps increase brand and product awareness by targeting users based on their shopping behaviors.
 
 *Please note*: This platform is currently available only for businesses located in the United States.
-* **Supported by:** [MatchCraft Managed AI AdVantage](https://partners.vendasta.com/marketplace/products/MP-23KNRJZRP2HZDXQHRSNV775DDKDPCC5D)
 
 ## Request a Proposal
 


### PR DESCRIPTION
The MatchCraft Managed AI AdVantage service has been retired. Remove all references across the digital advertising docs under VS.