### PR TITLE
docs(weblate): update Translate & Customize article

### DIFF
--- a/docusaurus/docs/administration/advanced/translate-customize/index.mdx
+++ b/docusaurus/docs/administration/advanced/translate-customize/index.mdx
@@ -46,8 +46,19 @@ To customize text for your customers:
 
 1. In Weblate, open the **project** you want to customize (e.g. Business App) and the **component** (e.g. Executive Report).
 2. At the bottom of the language list click **Create white-labeled translation**.
-3. Select a language from the list and click **Customize**.
+3. Select a language from the list and click **Create**.
 4. The new translation is created shortly; open it from the component page.
+
+## Permission levels
+
+There are two permission tiers in Weblate:
+
+| Role | What you can do |
+|------|----------------|
+| **Viewer** | View all Global translations, make suggestions, and create white-labeled translations visible only to your customers |
+| **Trusted Translator** | All Viewer privileges, plus the ability to review Viewer suggestions and contribute directly to Global translations |
+
+To become a Trusted Translator, contact your Vendasta representative.
 
 ## Frequently asked questions
 
@@ -73,12 +84,6 @@ In Weblate click **Browse All Projects** to see available projects.
 <summary>How can I contribute to a translation?</summary>
 
 Follow the quick-start video tour in Weblate for your first contribution; see Quick Links there for more documentation.
-</details>
-
-<details>
-<summary>Do I need special permissions to translate?</summary>
-
-There are two tiers. **Viewer**: view all Global translations, make suggestions, and make a copy of Global translations that only your customers see. **Trusted Translator**: all Viewer privileges plus review of Viewer suggestions and ability to contribute to Global translations. Contact us to become a Trusted Translator.
 </details>
 
 <details>
@@ -141,14 +146,3 @@ Current internationalization tech does not fully support declensions. We are exp
 Weblate translations and contributions are available only on Premium subscription and above.
 </details>
 
-<details>
-<summary>What incentives are there for contributing translations?</summary>
-
-We are exploring how we can reward contributions. Look for updates in the coming months.
-</details>
-
-<details>
-<summary>How can I see how text is used in the platform to suggest better translations?</summary>
-
-We are exploring ways to provide more context, descriptions, and screenshots to support translation.
-</details>


### PR DESCRIPTION
## Summary

- Promoted Viewer/Trusted Translator permission tiers to a dedicated **Permission levels** section (previously buried in an FAQ entry)
- Fixed white-label workflow button label: **Customize** → **Create**
- Removed two stale aspirational FAQ entries ("What incentives are there for contributing translations?" and "How can I see how text is used in the platform...") flagged as outdated in a Guru card review

## Source

Based on a Guru cleanup recommendation from internal card "Translate and Customize with Weblate" (last verified 2024-12-28 by Jayapradha Karunakaran).

## Test plan

- [ ] Verify button label matches current Weblate UI (`Create` vs `Customize`)
- [ ] Confirm Permission levels table is accurate for both tiers
- [ ] Confirm removed FAQ entries are no longer relevant

🤖 Generated with [Claude Code](https://claude.com/claude-code)