### PR TITLE
docs: add cross-repo Vendasta Services doc-sync skill

### DIFF
--- a/.claude/skills/sync-vendasta-services-docs/SKILL.md
+++ b/.claude/skills/sync-vendasta-services-docs/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: sync-vendasta-services-docs
+description: >-
+  Keep Vendasta Services documentation in sync across the two repos:
+  servicesdocs.io (SMB, grey-labeled) and Partner Center docs (partner,
+  branded). Use after editing, drafting, or deleting an article in either repo
+  to produce reviewable suggested edits to the counterpart article in the other
+  repo, audience-adapted automatically. Also handles articles that exist in only
+  one repo (flag and ask). Trigger when the user says things like "sync this
+  article", "update the other repo", "propagate this change", or after editing a
+  Vendasta Services doc.
+---
+
+# Sync Vendasta Services docs across repos
+
+Two repositories document the same Vendasta Services offerings for different
+audiences. When an article changes in one, this skill produces **suggested
+edits to the counterpart in the other repo, adapted for that audience**, for a
+teammate to review before committing. It never auto-commits, and never deletes
+or creates an article without asking.
+
+## The two repos
+
+| | **services-docs** (SMB) | **partnercenter-docs** (Partner) |
+|---|---|---|
+| Site | servicesdocs.io | docs.vendasta.com |
+| Audience | SMB owners & operators | Vendasta partners (agencies/resellers) |
+| Branding | **Grey-labeled** — never name a brand, company, product, or team. Use "our team", "the platform", "the dashboard". | **Branded** — "Vendasta", "Partner Center", "Business App", and product names are expected. |
+| Article root | `docs-site/docs/` | `docusaurus/docs/vendasta-services/` |
+| Repo rules | `<repo>/CLAUDE.md` (strict section order, `:::info`/`:::warning`) | `<repo>/CLAUDE.md` (never use `>`, em-dash rules, `require()` images) |
+
+Both follow Docusaurus. Section folders mostly share names
+(`digital-advertising`, `listings-claims-optimization`, `ai-workforce-setup`,
+`websites`, `social-media-management`, `expectations`, `using-the-platform`).
+**The Partner repo intentionally has extra articles with no SMB counterpart**
+(e.g. partner training, white-labeling communications, budget-change requests).
+That is by design — do not force a counterpart to exist.
+
+## Step 1 — Locate both repos
+
+You may be invoked from either repo. Determine which one you are in and find the
+other:
+
+- **services-docs** root contains `docs-site/docs/` and a `CLAUDE.md` mentioning
+  `servicesdocs.io`.
+- **partnercenter-docs** root contains `docusaurus/docs/vendasta-services/` and a
+  `CLAUDE.md` mentioning `docs.vendasta.com`.
+
+Find the other repo by checking, in order: the session's additional working
+directories, sibling directories of the current repo, then ask the teammate for
+its path if not found. Confirm the resolved path before editing anything in it.
+
+## Step 2 — Identify what changed
+
+If the teammate named a file, use it. Otherwise inspect the **source repo's**
+working tree:
+
+```bash
+git status --porcelain && git diff --stat HEAD
+```
+
+Classify each changed Vendasta Services article as **edited**, **new (drafted)**,
+or **deleted** (staged deletions and `git status` `D`). Only articles under the
+article roots above are in scope. Work through them one at a time.
+
+## Step 3 — Find the counterpart
+
+Map source → destination by **section folder + article identity**:
+
+1. Same section folder name in the destination root (see table in Step 1).
+2. Within that folder, match by `title` / `sidebar_label` frontmatter first,
+   then by filename slug, then by body content. Filenames legitimately differ
+   between repos.
+
+Known filename aliases (services-docs ↔ partnercenter-docs) — treat as examples,
+not an exhaustive list; always confirm by title/content:
+
+| services-docs | partnercenter-docs |
+|---|---|
+| `websites/website-support.md` | `websites/vendasta-services-website-support.md` |
+| `websites/website-ordering-guide.md` | `websites/vendasta-services-website-ordering-guide.md` |
+| `websites/website-plugins.md` | `websites/website-plugins-working-with-vendasta-services.md` |
+| `digital-advertising/advertising-intelligence-dashboard-setup-overview.md` | `digital-advertising/advertising-intelligence-dashboard-partner-setup-overview.md` |
+
+If no counterpart is found, go to **Step 5**.
+
+## Step 4 — Produce audience-adapted suggested edits
+
+When a counterpart exists, translate the source change into the destination's
+audience and conventions. **Read `references/audience-transform.md` for the full
+rule set** (branding, voice, link-path and filename differences, MDX imports,
+markdown quirks). In short:
+
+- Preserve the *substance* of the change (facts, steps, policies, timelines).
+- Re-skin for the destination audience: strip brand names for SMB / restore them
+  for Partner; adjust "you" framing (SMB = the business owner; Partner = the
+  partner serving clients).
+- Fix cross-reference link paths and filenames to the destination's slugs.
+- Respect destination-only mechanics: services-docs uses shared MDX snippet
+  imports (e.g. `_optimization-plan-section.mdx`) that do **not** exist in the
+  Partner repo; do not copy those imports across.
+- Obey the destination repo's `CLAUDE.md` (section order, em-dash/`>` rules,
+  image syntax, frontmatter shape).
+
+Apply the edits to the counterpart file **in the destination repo's working
+tree** so they appear as a reviewable `git diff`. Do **not** stage or commit.
+Then show the teammate:
+
+1. A short summary of what changed and how you adapted it for the audience.
+2. The `git diff` of the counterpart file.
+3. Any judgment calls or spots that need a human decision.
+
+Tell the teammate to review both the original and the suggested counterpart, and
+that nothing is committed until they approve.
+
+## Step 5 — One-sided articles (flag and ask)
+
+When a counterpart does not exist:
+
+- **New / edited with no counterpart:** State that no counterpart was found.
+  Assess whether the article looks intentionally audience-specific (partner-only
+  operational content, or SMB-only). Explain your read, then **ask** whether to
+  draft a new counterpart. Only draft it (audience-adapted, into the destination
+  working tree for review) if they say yes.
+- **Deleted with no counterpart, or deleted where a counterpart still exists:**
+  Never delete the counterpart automatically. Report the deletion and **ask**
+  whether the counterpart should also be removed or kept (it may be intentionally
+  one-sided).
+
+## Guardrails
+
+- Suggest only — never `git add`, `git commit`, or `git push`.
+- Never invent facts; carry over only what the source change actually says, then
+  adapt phrasing for the audience.
+- Never delete or create files without explicit confirmation.
+- When unsure whether content is audience-specific, ask rather than guess.

--- a/.claude/skills/sync-vendasta-services-docs/references/audience-transform.md
+++ b/.claude/skills/sync-vendasta-services-docs/references/audience-transform.md
@@ -1,0 +1,92 @@
+# Audience transform reference
+
+How to re-skin a change when moving it between the two repos. The **substance**
+(facts, steps, policies, timelines, numbers) stays identical; only audience,
+voice, branding, and repo mechanics change.
+
+## Direction 1 — Partner → SMB (servicesdocs.io, grey-labeled)
+
+Source: `partnercenter-docs` · Destination: `vendasta-services-docs/docs-site/docs/`
+
+Apply the destination repo's `CLAUDE.md` rules exactly. Key transforms:
+
+- **Strip all brand names.** Remove "Vendasta", "Partner Center", "Business App",
+  product names, vendor names. Replace with generic terms:
+  - "in Partner Center" → "in the platform" / "in your dashboard"
+  - "the Vendasta Services team" → "our team"
+  - product names → the generic capability ("the AI Receptionist", "the listings
+    service") only if not a brand; otherwise describe the function.
+- **Re-aim the voice.** SMB articles speak to the business owner about *their own*
+  business. Partner phrasing like "your clients", "your customers' accounts",
+  "resell" becomes "your business", "your account".
+- **Drop partner-only operational content** (white-labeling instructions,
+  reselling, billing-to-clients, partner training) — usually means the article is
+  partner-only; flag and ask rather than producing a thin SMB version.
+- **Voice/structure:** present tense, second person, no marketing/promo language,
+  no historical phrasing ("formerly", "used to", "legacy"). Follow the required
+  section order in services-docs `CLAUDE.md` when creating a new article.
+- **Admonitions:** `:::info` for tips/context, `:::warning` for
+  limits/requirements.
+- **MDX snippets:** services-docs reuses shared snippets via imports, e.g.
+  `import OptimizationPlanSection from './_optimization-plan-section.mdx';`. If
+  the equivalent content is already covered by such a snippet, reference the
+  snippet instead of duplicating prose.
+
+## Direction 2 — SMB → Partner (docs.vendasta.com, branded)
+
+Source: `vendasta-services-docs` · Destination:
+`partnercenter-docs/docusaurus/docs/vendasta-services/`
+
+Apply the destination repo's `CLAUDE.md` rules exactly. Key transforms:
+
+- **Restore branding** where natural: generic "the platform" → "Partner Center"
+  or "Business App" as appropriate; "our team" → "the Vendasta Services team"
+  when the partner audience expects the named team.
+- **Re-aim the voice.** Partners act *on behalf of their clients*. Where the SMB
+  text says "your business", consider whether the partner reads it as "your
+  client's business" and adjust.
+- **Markdown quirks (Partner repo):**
+  - **Never use the `>` character** — it creates blockquotes. Use "greater than"
+    in prose or `→` for UI navigation paths.
+  - **Never use em dashes (`—`)** — replace with a colon, comma, period, or
+    parentheses.
+  - Sentence-case headings. Proper nouns (Vendasta, Partner Center, Business App,
+    Task Marketplace, product names) stay capitalized.
+  - Images use `<img src={require('./img/name.png').default} ... />` with the
+    standard border/radius/shadow style, stored in an adjacent `img/` folder.
+  - **Never reference specific plan tier names** (Growth, Scale, Starter, Pro).
+    Use "certain plans" / "select plans" and link to
+    `https://www.vendasta.com/pricing`.
+- **Strip MDX snippet imports** that only exist in services-docs
+  (`_optimization-plan-section.mdx`, `_optimization-plan-faq.mdx`, etc.). Inline
+  the equivalent content directly, adapted for partners, since those snippet
+  files do not exist in the Partner repo.
+
+## Cross-reference links
+
+Internal links must point at the **destination repo's** slugs, which often differ:
+
+- Both use relative paths between articles (e.g. `../websites/...`), but the
+  **filename differs** — see the alias table in `SKILL.md`. Example:
+  `../websites/website-support.md` (SMB) ↔
+  `../websites/vendasta-services-website-support.md` (Partner).
+- After rewriting a link, verify the target file actually exists in the
+  destination repo. If the target is a partner-only or SMB-only article with no
+  counterpart, drop the link or replace it with plain text rather than linking to
+  a missing file.
+- Keep external `https://` links as-is unless they are brand-gated (e.g. a
+  partner-only PDF) — in that case adapt or remove for the SMB audience.
+
+## Frontmatter
+
+Carry over `title`, `sidebar_label`, `description`, and tags/keywords, then adapt
+wording for the audience (strip brand names for SMB; the description often mirrors
+the first sentence). Keep `sidebar_position` aligned with the destination folder's
+existing ordering; do not blindly copy the source's position.
+
+## What NOT to change
+
+- Don't alter facts, numbers, timelines, eligibility rules, or step order.
+- Don't add content the source change didn't introduce.
+- Don't "improve" the counterpart beyond the change being synced unless the
+  teammate asks — keep the diff focused and reviewable.


### PR DESCRIPTION
Add a Claude Code skill that produces audience-adapted suggested edits to the counterpart article in the services-docs (SMB) repo when a Vendasta Services article is edited, drafted, or deleted here, and flags articles that exist in only one repo. Suggest-only; never commits or deletes without confirmation.