### PR TITLE
docs(administration): apply Guru cleanup recommendations for Administration section

### DIFF
--- a/docusaurus/docs/administration/data-management/crm-objects/index.mdx
+++ b/docusaurus/docs/administration/data-management/crm-objects/index.mdx
@@ -57,6 +57,27 @@ You can fill custom fields:
 
 ![Data Entry for Custom Fields](../img/administration/data-management/custom-fields-data-entry.jpg)
 
+## Account fields vs. company fields: sync behavior
+
+Custom fields can be created for different object types. When working with **accounts** and **companies**, sync behavior differs in an important way:
+
+- **Account fields** sync bidirectionally with linked company records — updates on the account appear on the company, and vice versa.
+- **Company fields** do not sync down to accounts — data entered on a company's custom fields will not appear on linked account records.
+
+If you need data to flow between accounts and companies, define the field as an **account** field.
+
+### Archive a duplicate field
+
+If you have created duplicate custom fields, archive the extras to keep your field list clean:
+
+1. Go to **Partner Center** → **Administration** → **Custom Fields**
+2. Select **Account** from the tabs at the top
+3. Search for the duplicate field
+4. Click **⋮** next to the field name
+5. Select **Archive**
+
+Archived fields are hidden from new records but their data is retained.
+
 ## Frequently asked questions
 
 <details>
@@ -69,4 +90,10 @@ No. Custom fields created in Partner Center are for use in Partner Center only. 
 <summary>Is there a character limit for the field description?</summary>
 
 Yes. The limit is 4000 characters.
+</details>
+
+<details>
+<summary>Why don't my company-level custom fields appear on accounts?</summary>
+
+Company fields and account fields sync differently. Company fields do not sync down to account records. If you need data to appear on both the account and the company, create the field as an **account** field — account fields sync bidirectionally with linked companies.
 </details>

--- a/docusaurus/docs/administration/my-account/my-team/index.mdx
+++ b/docusaurus/docs/administration/my-account/my-team/index.mdx
@@ -138,6 +138,21 @@ The team member will receive an email with instructions to set or reset their pa
 </TabItem>
 </Tabs>
 
+## Viewing team member login activity
+
+Partner Center logs activity for each team member, which is useful for troubleshooting access issues or investigating suspicious login behavior.
+
+To view activity for a specific user:
+
+1. Go to **Partner Center > Administration > My Team**
+2. Click the team member's name, or click **⋮** → **View profile**
+3. Navigate to the **User activity** tab
+
+The activity log shows:
+- Successful logins
+- Failed login attempts
+- Password resets
+
 ## Seat Limits
 
 Seats are people at your company who will be able to use Vendasta. This can include salespeople, marketers, fulfillment professionals, and administrators. Be sure to check how many Team Member seats your subscription tier has available, as you may be charged for additional seats if they go over their limit of free seats. This is usually displayed in a banner at the top of the 'My Team' page.

--- a/docusaurus/docs/administration/my-account/my-team/permissions.mdx
+++ b/docusaurus/docs/administration/my-account/my-team/permissions.mdx
@@ -133,3 +133,20 @@ Salesperson permissions control access to Proposals, Inbox, Leaderboard, Pricing
 
 - **All orders** – Salesperson can see all orders.
 - **Orders assigned to the user** – Salesperson only sees orders assigned to them.
+
+## Troubleshooting: why can't an admin see a certain area?
+
+If an admin reports they cannot see a feature or section that another admin can access, the most likely cause is different permission settings — not a bug.
+
+### How to check and update an admin's permissions
+
+1. Go to **Partner Center** → **Administration** → **My Team**
+2. Find the affected admin
+3. Click **⋮** → **Edit member**
+4. If the **Admin** checkbox is checked, click **Show more permissions** to see the full list
+5. Compare their settings to an admin who does have access and adjust as needed
+6. Click **Save**
+
+:::note
+Only admins with the **Can create and manage admins** permission can view or modify another user's permissions.
+:::

--- a/docusaurus/docs/crm/salespeople/index.mdx
+++ b/docusaurus/docs/crm/salespeople/index.mdx
@@ -163,6 +163,37 @@ If either layer doesn't match, the salesperson won't see the company — even if
 
 **Fix:** Update either the salesperson's market assignments or the Company's market so they match. Once they do, the salesperson will be able to see the Company in their CRM view.
 
+## Find a salesperson ID
+
+Each salesperson has a unique ID that may be needed when working with the Vendasta API or when troubleshooting with Vendasta Support.
+
+To find a salesperson's ID:
+
+1. Go to **Partner Center > Administration > My Team**
+2. Click **⋮** next to the salesperson's name
+3. Select **Edit Salesperson**
+4. Look at the URL in your browser — the salesperson ID appears at the end of the URL
+
+## Add a booking link to Snapshot Reports
+
+You can add a salesperson's meeting booking URL to their Snapshot Reports so prospects can schedule time directly from the report.
+
+:::note
+The salesperson must have a meeting scheduler set up (such as Calendly or Microsoft Bookings) before adding this link.
+:::
+
+1. Go to **Partner Center > Administration > My Team**
+2. Click **⋮** next to the salesperson's name
+3. Select **Edit Salesperson**
+4. Enter the booking URL in the **Book a Meeting** field
+5. Click **Save**
+
+The booking link will appear on any Snapshot Report created or regenerated after saving. It will not appear on previously generated reports.
+
+## Salesperson access to Vendasta support
+
+Salespeople cannot contact Vendasta Support directly. If a salesperson needs to escalate an issue, they must ask a Partner Center admin to contact support on their behalf.
+
 ## Administration and management
 
 Manage your salespeople by going to **Partner Center > Administration > My Team**. This centralized management interface provides all the tools needed to maintain accurate salesperson information and ensure proper system access across your organization.

--- a/docusaurus/docs/getting-started/partner-troubleshooting-guide.mdx
+++ b/docusaurus/docs/getting-started/partner-troubleshooting-guide.mdx
@@ -12,6 +12,32 @@ This space contains guides which will aid you in troubleshooting some issues you
 Please note there is no guarantee these actions will resolve your issue so if after troubleshooting you still experience issues please submit a ticket to [support@vendasta.com](mailto:support@vendasta.com)
 :::
 
+## Common issue: Login issues and platform slowness
+
+### Explanation
+
+Login failures and platform slowness are usually caused by browser-related issues rather than a platform outage.
+
+### Issue
+
+- Cannot log in or login page won't load
+- Stuck on a loading spinner after entering credentials
+- Platform is unusually slow or unresponsive
+
+### Fix
+
+1. **Check the Vendasta status page** — Visit [status.vendasta.com](https://status.vendasta.com) to rule out an active outage before troubleshooting your browser.
+
+2. **Clear your browser cache and cookies** — Cached data can interfere with login. See the [Cache and Cookies section](#common-issue-cache--cookies) below for steps.
+
+3. **Disable browser extensions** — Ad blockers, Dark Mode tools, and password managers can block platform resources. Disable all extensions and try again.
+
+4. **Try incognito or private browsing mode** — Extensions are typically disabled in incognito mode, which helps isolate whether an extension is the cause.
+
+5. **Try a different browser** — If the issue only occurs in one browser, the problem is browser-specific. Chrome is recommended for the Vendasta platform.
+
+6. **If the issue persists** — Contact [support@vendasta.com](mailto:support@vendasta.com) with details about what you're seeing.
+
 ## Common issue: Cache & Cookies
 
 ### Explanation


### PR DESCRIPTION
## Summary

Updates five existing articles based on findings from the Guru Administration section audit (34 cards reviewed):

- **Salespeople** — added salesperson ID lookup steps, Snapshot Report booking link setup (with note about regeneration requirement), and clarification that salespeople cannot contact Vendasta Support directly
- **Permissions** — added troubleshooting section explaining how to diagnose and fix mismatched admin access (the most common source of "why can't my admin see X?" tickets)
- **My Team** — promoted the user activity FAQ entry to a full section with clearer navigation steps
- **CRM Objects** — added account vs. company field sync behavior explanation and archive instructions for duplicate fields
- **Partner Troubleshooting Guide** — added login issues and platform slowness section covering status page check, disabling browser extensions, incognito mode, and trying a different browser

## Test plan

- [ ] Verify all five updated pages render correctly in local dev (`npm run start`)
- [ ] Confirm booking link note and salesperson ID steps are accurate against live platform
- [ ] Confirm sync behavior description matches actual platform behavior (account fields ↔ company; company fields do not sync down)

🤖 Generated with [Claude Code](https://claude.com/claude-code)