### PR TITLE
docs: document multi-form embed, ::part() CSS, and JS shadow DOM access

### DIFF
--- a/docusaurus/docs/marketing/forms/create-a-form.mdx
+++ b/docusaurus/docs/marketing/forms/create-a-form.mdx
@@ -88,7 +88,6 @@ Click on the **Marketing email consent source** field to open the properties pan
 Now, whenever someone consents to receive more emails, the CRM will automatically update to show if they came from a specific campaign. This lets us know which campaigns are specifically driving more sign-ups to our email list.
 
 For more detailed information on tracking form submissions, see [Track form submissions in GA4](./tracking-form-submissions-ga4.mdx).
-:::
 
 ## Step 4 — Match your form design to your website
 
@@ -182,6 +181,155 @@ You don't have to paste your form embed code into your website to test it! There
 - [CodePen](https://codepen.io/)
 - [JSFiddle](https://jsfiddle.net/)
 - [W3Schools](https://www.w3schools.com/html/html_examples.asp)
+:::
+
+## Embedding multiple forms on a page
+
+You can safely place more than one form embed on the same page. Each form renders inside its own isolated shadow DOM, so styles and scripts from one form never affect another.
+
+Duplicate the `<script>` embed tag for each form you want to display, changing only the `data=` attribute:
+
+```html
+<!-- First form -->
+<script
+  async
+  data-crm-form-widget
+  src="https://www.cdnlinks.vendasta.com/.../custom_form.widget.js"
+  data="YOUR_BASE64_DATA_FORM_1"
+></script>
+
+<!-- Second form -->
+<script
+  async
+  data-crm-form-widget
+  src="https://www.cdnlinks.vendasta.com/.../custom_form.widget.js"
+  data="YOUR_BASE64_DATA_FORM_2"
+></script>
+```
+
+Copy the embed code from the **Embed** tab in the form editor for each form — the `data=` value (a Base64 string) is the only attribute that differs between instances. The `src=` URL stays the same.
+
+:::info Legacy single-form embed
+Older embed codes using `id="__custom_form_widget"` still work for pages with a single form. Upgrade to the `data-crm-form-widget` pattern when you need multiple forms on the same page.
+:::
+
+:::tip Single-page apps
+If your site inserts form embed tags dynamically after the page loads, call `window.CRMFormsInit()` after inserting the tags to trigger initialization without a page reload.
+:::
+
+## Styling forms from the host page
+
+Each form renders inside a shadow DOM for CSS isolation. Standard CSS selectors in your page's stylesheets **cannot** cross the shadow boundary — they have no effect on elements inside the form:
+
+```css
+/* ❌ These selectors do NOT reach inside the form */
+.crm-form-host input { border: 2px solid blue; }
+.crm-form-host label { color: navy; }
+```
+
+Use the CSS [`::part()` pseudo-element](https://developer.mozilla.org/en-US/docs/Web/CSS/::part) to style form elements from outside the shadow root:
+
+```css
+/* ✅ ::part() crosses the shadow DOM boundary */
+.crm-form-host::part(input) {
+  border: 2px solid #3b82f6;
+  border-radius: 6px;
+}
+
+.crm-form-host::part(label) {
+  font-weight: 600;
+  color: #1d4ed8;
+}
+
+.crm-form-host::part(submit-button) {
+  background-color: #2563eb !important;
+  color: white;
+  border-radius: 999px;
+  padding: 10px 28px;
+}
+```
+
+### Available part names
+
+| Part name | What it targets |
+|-----------|----------------|
+| `form` | The form container element |
+| `input` | All input, textarea, and select elements |
+| `label` | All field labels |
+| `submit-button` | The submit button |
+| `section-button` | Next/back buttons on multi-section forms |
+| `{type}-input` | Input by field type, e.g. `email-input`, `text-input` |
+| `{type}-label` | Label by field type, e.g. `email-label` |
+| `{fieldId}-input` | A specific field's input element |
+| `{fieldId}-label` | A specific field's label |
+| `consent-input` | Consent checkbox inputs |
+| `consent-field-label` | Label above a consent field group |
+| `consent-description` | Consent field description text |
+| `promo-card` | Promo section cards |
+| `success-page` | Success page container shown after submission |
+| `success-icon` | Checkmark icon on the success page |
+| `success-heading` | Heading on the success page |
+| `success-body` | Body text on the success page |
+
+### Scoping styles to a specific form instance
+
+When multiple forms are on the same page, you can scope `::part()` rules to one specific form using its form ID as an additional part name. The form ID is the `FormConfigID-...` value visible in your embed code.
+
+```css
+/* Style inputs only in the contact form */
+.crm-form-host::part(FormConfigID-abc123 input) {
+  border-color: #7c3aed;
+  border-radius: 12px;
+}
+
+/* Style the submit button only in the newsletter form */
+.crm-form-host::part(FormConfigID-xyz456 submit-button) {
+  background-color: #059669 !important;
+}
+```
+
+:::tip Finding your form ID
+Your form ID appears in the embed code from the form editor. It follows the pattern `FormConfigID-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`. You can also inspect the rendered page in browser DevTools and look for the host element: `<div class="crm-form-host" data-form-id="FormConfigID-...">`.
+:::
+
+## Interacting with forms using JavaScript
+
+Because each form renders inside a shadow root, `document.querySelector()` alone cannot reach elements inside it. Use the host element's `shadowRoot` property to query inside the shadow tree.
+
+### Selecting a form instance
+
+Each form's host element has the class `crm-form-host` and a `data-form-id` attribute. Use these to target a specific form when multiple are on the page:
+
+```javascript
+// Select a specific form by its form ID
+const host = document.querySelector('[data-form-id="FormConfigID-abc123"]');
+const shadowRoot = host?.shadowRoot;
+```
+
+### Pre-filling field values
+
+Once you have the shadow root, query and set values the same way you would with normal DOM elements:
+
+```javascript
+const host = document.querySelector('[data-form-id="FormConfigID-abc123"]');
+const shadowRoot = host?.shadowRoot;
+if (!shadowRoot) return;
+
+// Pre-fill a text input by its name attribute
+const nameInput = shadowRoot.querySelector('input[name="contactName"]');
+if (nameInput) {
+  nameInput.value = 'Jane Smith';
+}
+
+// Select an option in a dropdown
+const sourceSelect = shadowRoot.querySelector('select[name="leadSource"]');
+if (sourceSelect) {
+  sourceSelect.value = 'website';
+}
+```
+
+:::info Initialization timing
+Forms load asynchronously. Run any JavaScript that reads or writes form fields after the form has rendered — for example, in response to a user interaction. Avoid running pre-fill logic immediately on page load before the form's shadow root exists.
 :::
 
 ## Frequently asked questions

--- a/docusaurus/docs/marketing/forms/create-a-form.mdx
+++ b/docusaurus/docs/marketing/forms/create-a-form.mdx
@@ -242,7 +242,7 @@ Use the CSS [`::part()` pseudo-element](https://developer.mozilla.org/en-US/docs
 }
 
 .crm-form-host::part(submit-button) {
-  background-color: #2563eb !important;
+  background-color: #2563eb;
   color: white;
   border-radius: 999px;
   padding: 10px 28px;
@@ -284,7 +284,7 @@ When multiple forms are on the same page, you can scope `::part()` rules to one 
 
 /* Style the submit button only in the newsletter form */
 .crm-form-host::part(FormConfigID-xyz456 submit-button) {
-  background-color: #059669 !important;
+  background-color: #059669;
 }
 ```
 


### PR DESCRIPTION
## Summary

- Adds three new sections to `create-a-form.mdx` covering the latest widget capabilities (v0.11.0–v0.12.0):
  - **Embedding multiple forms on a page** — explains the `async data-crm-form-widget` tag pattern, with notes for legacy embeds and SPAs (`window.CRMFormsInit()`)
  - **Styling forms from the host page** — explains the shadow DOM CSS boundary, introduces `::part()` with a full reference table of available part names, and shows per-instance scoping via form ID
  - **Interacting with forms using JavaScript** — shows how to access the shadow root, select a form by `data-form-id`, and pre-fill field values
- Fixes a stray `:::` closing directive that had no matching opener

## Test plan

- [ ] Review rendered output in local dev server (`npm run start` from `docusaurus/`)
- [ ] Check that code blocks, tables, and callouts render correctly
- [ ] Verify all three new sections appear in the sidebar/TOC

🤖 Generated with [Claude Code](https://claude.com/claude-code)