### PR TITLE
Docs: Document Meta Ads conversion reporting limitation (DOC-368)

### DIFF
--- a/docusaurus/docs/vendasta-services/digital-advertising/advertising-intelligence-dashboard-partner-setup-overview.md
+++ b/docusaurus/docs/vendasta-services/digital-advertising/advertising-intelligence-dashboard-partner-setup-overview.md
@@ -29,6 +29,18 @@ Our Ads team does not update ad management fees. These must be updated by a part
 *   You can designate certain actions as conversions. For example, anything marked as a lead can be counted as a conversion.
 *   Different platforms offer specific metrics. E.g., Facebook pixels can track conversion metrics, while Google Ads can track calls as a separate metric.
 
+#### Meta Ads conversion reporting
+
+Advertising Intelligence only ingests Lead-classified conversions from Meta. A campaign result is counted as a conversion when the campaign uses the **Lead Generation** objective (with an instant form), or when the Lead standard event is tracked via **Meta Pixel** or **Conversions API**.
+
+Campaigns using other objectives — such as Calls Placed, Link Clicks, or Engagement — will show zero conversions in Advertising Intelligence, even if Meta Ads Manager records results for those campaigns.
+
+:::note
+
+For campaigns not optimized for Lead Generation, export data directly from Meta Ads Manager to supplement Advertising Intelligence reports.
+
+:::
+
 ### 4\. ROI Calculation
 
 *   This feature helps estimate the return on investment.


### PR DESCRIPTION
## JIRA

[DOC-368 — New Documentation Request: Meta Ads Conversion Reporting Limitations](https://vendasta.jira.com/browse/DOC-368)

---

## Change Classification

**Feature behavior / known limitation** — documenting an existing, undocumented limitation in how Advertising Intelligence ingests conversion data from Meta Ads.

---

## Scope Decision

**In scope.** The affected page ([Advertising Intelligence Dashboard](https://docs.vendasta.com/vendasta-services/digital-advertising/advertising-intelligence-dashboard-partner-setup-overview)) is Partner Center documentation. The limitation described is relevant to partners managing ad campaigns for their clients through Vendasta Ad Intelligence.

---

## Summary of Changes

Updated `docusaurus/docs/vendasta-services/digital-advertising/advertising-intelligence-dashboard-partner-setup-overview.md`:

- Added a new `#### Meta Ads conversion reporting` subsection under the existing **Conversion Metrics** section (§3)
- Explains that Advertising Intelligence only ingests Lead-classified conversions from Meta
- Clarifies which campaign objectives qualify (Lead Generation with instant form, or Lead standard event via Meta Pixel / Conversions API)
- Notes that campaigns using other objectives (Calls Placed, Link Clicks, Engagement) will show zero conversions even when Meta Ads Manager records results
- Includes a workaround note directing partners to export from Meta Ads Manager to supplement reporting

**Existing docs updated** — no new page created. The Conversion Metrics section was the natural fit for this content.

---

## Placement Reasoning

The limitation is directly relevant to the **Conversion Metrics** section, which already mentions Facebook Pixel conversion tracking. Adding a subsection there keeps the information discoverable in context without requiring partners to look elsewhere.

---

## Acceptance Criteria Coverage

| Criterion | Documented |
|-----------|-----------|
| Only Lead-classified conversions from Meta are ingested | ✅ |
| Qualifying campaign objectives/events for Lead classification | ✅ |
| Non-Lead objectives show zero conversions in Ad Intelligence | ✅ |
| Workaround: export from Meta Ads Manager | ✅ |

---

## Additional Notes

- **Figma/images**: None provided or required — this is a textual behavior clarification.
- **Related code PRs**: This documents an existing platform limitation, not a new feature; no associated engineering PRs were found.
- **Assumptions**: None — content is based entirely on the JIRA description, which was submitted by a partner who encountered the limitation directly (Blue Mountain Marketing).

---

## Reviewers / Stakeholders

CC: @haleyserrano

> Requested by: schanda@vendasta.com

---
_Generated by [Claude Code](https://claude.ai/code/session_01T76WRXPB59X66ZJtAgaZcL)_