### PR TITLE
docs: add Stripe/Vendasta Payments help center content from Guru cleanup

### DIFF
--- a/docusaurus/docs/administration/commerce/vendasta-payments/index.mdx
+++ b/docusaurus/docs/administration/commerce/vendasta-payments/index.mdx
@@ -211,6 +211,23 @@ In supported countries, you can add multiple bank accounts to receive payouts in
 
 By default, payouts will be made to your bank account in your default currency. However, you can add a new payout destination and choose to convert your funds to a different currency before the funds are deposited into a bank account. Stripe may charge a fee for currency conversion; visit the [Stripe Docs](https://stripe.com/docs/payouts) to learn more.
 
+## Understanding your Vendasta Payments Stripe account
+
+When you set up Vendasta Payments, a Stripe account is created and linked to your Vendasta account. This is separate from any personal Stripe account you may already have.
+
+### Vendasta Payments Stripe account vs. personal Stripe account
+
+- Your **Vendasta Payments Stripe account** can only be used within Vendasta. It cannot be used with other platforms.
+- If you have a **personal Stripe account**, that account can be used both inside and outside Vendasta.
+
+### Stripe dashboard access
+
+Partners do not have direct access to the Stripe dashboard. Payment and payout reporting is available in Partner Center under **Commerce > Payments** and **Commerce > Payouts**.
+
+### Changing your business type
+
+If you selected the wrong business type when setting up Vendasta Payments (for example, Company vs. Individual), contact [billingsupport@vendasta.com](mailto:billingsupport@vendasta.com) to have this corrected.
+
 ## Managing account information
 
 ### Update ownership information

--- a/docusaurus/docs/commerce/payments/index.mdx
+++ b/docusaurus/docs/commerce/payments/index.mdx
@@ -63,58 +63,43 @@ Sample email to the Customer showing a failed payment:
 
 ## Billing disputes
 
-If a customer disputes a charge on their credit card statement, you'll be notified via a charge dispute action in the Merchant Portal. Taking care of the dispute is part of the responsibilities that come along with offering credit card payments.
+When a customer disputes a payment, you'll see a "Disputed" status on that payment in Partner Center. You have two options: provide evidence to counter the dispute, or accept the dispute to refund the customer.
 
-This section will show you how to navigate charge disputes, respond to them, and provide evidence to support your case.
+Taking care of disputes is part of the responsibilities that come with offering credit card payments.
 
-### Finding disputes
+### How to respond to a disputed payment
 
-Disputes can be reviewed in your Merchant Portal by navigating to **Disputes** in the left-hand menu. 
+1. In **Partner Center**, go to **Commerce** > **Payments**
+2. Click the disputed payment
+3. Choose your response:
+   - Click **Provide Evidence** to contest the dispute
+   - Click **Accept Dispute** to agree to refund the customer
 
-![Disputes section in the Merchant Portal](./img/commerce/commerce-payments/25680107163543.png)
+### Providing evidence
 
-You'll see a list of all disputes, or individual charges that need attention.
+You'll be presented with a form to submit evidence supporting your case. Enter transaction details such as:
+- Customer name, email, and billing address
+- Product or service details
+- Supporting documents: customer communications, signatures, receipts, or other evidence (maximum 5 MB per file)
 
-### Understanding the Details of a Dispute
+The specific fields will vary based on the reason for the dispute. Click **Submit evidence** when done.
 
-Select a dispute case to view all related information.
+### Accepting a dispute
 
-![Dispute details](./img/commerce/commerce-payments/25680092503703.png)
-
-This includes:
-- **Status** - The current dispute status
-- **Amount** - The amount being disputed
-- **Due By** - The date by which you must respond
-- **Reason** - Why the customer has initiated the dispute
-- **Warning** - An important note that the transaction amount plus a $25 dispute fee will be deducted from your merchant account if you choose not to respond
-
-### Responding to a Dispute
-
-Here's how to properly respond to a dispute:
-
-1. Click the **Respond** button in the upper right corner of the dispute details
-
-![Respond button location](./img/commerce/commerce-payments/25680092509207.png)
-
-2. You'll be presented with a form where you can submit evidence to support your case
-
-![Evidence submission form](./img/commerce/commerce-payments/25680092518039.png)
-
-3. The specific evidence fields to complete will vary based on the reason for the dispute
-4. After completing the form, click **Submit evidence**
+Accepting the dispute confirms you agree to refund the customer. A **$15 dispute fee** applies when you accept a dispute.
 
 ### Possible outcomes
 
-After you've submitted your evidence, there are two possible outcomes:
+After submitting evidence, there are two possible outcomes:
 
-![Dispute outcomes](./img/commerce/commerce-payments/25680107182231.png)
+1. **You win the dispute** — The customer's bank resolves the dispute in your favor and releases the funds back to you
+2. **You lose the dispute** — The bank decides in the customer's favor and the funds are returned to them
 
-1. **You win the dispute** - The customer's bank resolves the dispute in your favor and releases the funds back to you
-2. **You lose the dispute** - The bank decides in the customer's favor and the funds are returned to them
+### Dispute rate
+
+Stripe requires all accounts to keep their overall dispute rate below 1% of total transactions. Accounts approaching this threshold may be contacted to help reduce disputes.
 
 ### Dispute prevention best practices
-
-![Prevention tips](./img/commerce/commerce-payments/25680092522391.png)
 
 To help prevent disputes:
 

--- a/docusaurus/docs/commerce/payments/payment-declines.mdx
+++ b/docusaurus/docs/commerce/payments/payment-declines.mdx
@@ -1,0 +1,29 @@
+---
+title: Why was my payment declined?
+sidebar_label: Payment declines
+sidebar_position: 2
+description: Common reasons for payment declines in Vendasta Payments and what to do about them
+---
+
+# Why was my payment declined?
+
+Payment declines can happen for a number of reasons. Many are controlled by the customer's bank, not by Vendasta or Stripe.
+
+## Card declined — too many attempts
+
+If a customer sees an error related to too many card attempts, the card has exceeded the daily or transactional limit set by their financial institution.
+
+**What to do:**
+- Wait 24 hours and retry with the same card
+- Use a different card or payment method
+- Have the customer contact their bank to adjust their card limits
+
+## Minimum invoice amount
+
+The minimum amount that can be charged through Vendasta Payments is **$1.00 USD**. Invoices below this amount will not process.
+
+## General troubleshooting for declines
+
+If a payment has failed, you can hover over the information icon next to the payment status in **Partner Center > Commerce > Payments** for more details about the specific error.
+
+If the issue persists after following the steps above, contact [billingsupport@vendasta.com](mailto:billingsupport@vendasta.com) for assistance.

--- a/docusaurus/docs/commerce/payouts/index.mdx
+++ b/docusaurus/docs/commerce/payouts/index.mdx
@@ -46,15 +46,19 @@ Your payout status will show:
 
 ## Payout schedule
 
-Your payout schedule is determined by Stripe based on:
-- Your location
-- Currency used
-- Frequency of transactions
-- Other risk assessment criteria
+Your payout schedule is determined by Stripe based on your location, currency, transaction history, and industry — not by Vendasta.
 
 **Timeline expectations:**
-- **First payout:** Within 7 business days of your first payment
-- **Regular payouts:** Between 2 and 7 business days, depending on your account criteria
+- **First payout:** Approximately 7 days after adding your bank account and receiving your first successful payment. Some industries may see a 14-day initial delay.
+- **Regular payouts:** Between 2 and 7 business days after the first payout, on a rolling schedule.
+
+:::info
+Changing your payout setting to "daily" updates your future payout schedule — it does not send a payout immediately.
+:::
+
+:::note
+Vendasta does not control payout timing. If you need faster access to funds, contact your bank to ask about Instant Payout options, subject to your bank's approval.
+:::
 
 <details>
 <summary>What if my payout is delayed or missing?</summary>


### PR DESCRIPTION
## Summary

Addresses four high/medium-priority content gaps identified in the June 2026 Guru cleanup of 27 internal Stripe/Vendasta Payments support cards. These gaps were driving unnecessary ticket volume on topics partners can self-serve.

- **Payout timing** (`commerce/payouts/index.mdx`): Clarified the ~7-day first payout delay (14-day for some industries) and that switching to "daily" does not trigger an immediate payout. Added note that Vendasta does not control payout timing.
- **Disputes** (`commerce/payments/index.mdx`): Rewrote the billing disputes section with current Partner Center navigation, corrected dispute fee to $15, added the Accept Dispute path, documented evidence requirements, and added the 1% dispute rate threshold.
- **Stripe account understanding** (`administration/commerce/vendasta-payments/index.mdx`): Added new section explaining Vendasta Payments Stripe account vs. personal Stripe account, confirmed Partners don't have direct Stripe dashboard access, and documented how to request a business type correction via Support.
- **Payment declines** (`commerce/payments/payment-declines.mdx`): New article covering the "too many attempts" card decline error and the $1.00 USD minimum invoice amount.

## Test plan

- [ ] Review dispute fee amount ($15) against current Stripe/Vendasta policy
- [ ] Confirm Partner Center navigation path for disputes: **Commerce > Payments**
- [ ] Confirm business type correction contact is `billingsupport@vendasta.com`
- [ ] Confirm the 1% dispute rate threshold is still accurate
- [ ] Verify the new `payment-declines.mdx` appears correctly in the sidebar under Payments

🤖 Generated with [Claude Code](https://claude.com/claude-code)