### PR TITLE
docs: daily article verification batch — June 16

### DIFF
--- a/docusaurus/docs/accounts/multilocation-groups/create-multilocation-groups.mdx
+++ b/docusaurus/docs/accounts/multilocation-groups/create-multilocation-groups.mdx
@@ -263,12 +263,12 @@ Billing can be configured as centralized (one bill for the entire group) or dist
 <details>
 <summary>Can I create sub-groups within a multilocation group?</summary>
 
-Many systems support hierarchical group structures, allowing you to create regional or operational sub-groups within larger corporate groups for better organization and management.
+Partner Center supports hierarchical group structures, allowing you to create regional or operational sub-groups within larger corporate groups for better organization and management.
 </details>
 
 <details>
 <summary>What permissions do I need to create multilocation groups?</summary>
 
-Creating multilocation groups typically requires administrative permissions and may require approval for enterprise-level account structuring. Check with your system administrator about permission requirements. You will also need to be on a Premium subscription or higher to access multilocation groups.
+Creating multilocation groups requires administrative permissions in Partner Center. You will also need to be on a Premium subscription or higher to access multilocation groups.
 </details>
 

--- a/docusaurus/docs/snapshot-report/snapshot-report-ai-chat.mdx
+++ b/docusaurus/docs/snapshot-report/snapshot-report-ai-chat.mdx
@@ -25,13 +25,13 @@ AI Chat helps visitors instantly understand the value of their report. It enable
 ## How to enable or disable AI Chat
 ![AI Receptionist settings screen with the enable toggle](./img/snapshot-report-ai-chat-2.png)
 1. Log in to Partner Center with an admin account.
-2. Navigate to `AI` → `AI Workforce` → `AI Receptionist`.
+2. Navigate to `AI` → `AI Workforce` → `Chat Receptionist`.
 3. Find the widget with your white-labeled name.
 4. Click `Settings`.
 5. Use the toggle in the top-right corner to turn the chat on or off.
 
 ## How to customize the welcome message and appearance
-1. Go to the same `AI Receptionist` settings screen.
+1. Go to the same `Chat Receptionist` settings screen.
 2. Scroll to `Appearance` or `Welcome Message`.
 3. Edit the greeting to reflect your brand tone.
 4. Adjust colors, fonts, and buttons to match your branding.
@@ -39,13 +39,13 @@ AI Chat helps visitors instantly understand the value of their report. It enable
 
 ## How to customize widget behavior
 ![Capabilities section in AI Receptionist settings](./img/snapshot-report-ai-chat-3.png)
-1. In `AI Receptionist`, go to `Capabilities`.
+1. In `Chat Receptionist`, go to `Capabilities`.
 2. Click `Snapshot Report Insights`.
 3. Customize the prompt instructions to guide how the AI should respond:
    - Suggest specific packages
    - Ask follow-up questions
    - Provide next steps
-4. Do **not** remove the **Important Requirements** section to maintain AI comprehension of the report.
+4. Do **not** remove the `Important Requirements` section to maintain AI comprehension of the report.
 
 ## How to view conversations
 ![Conversations section showing AI Chat history with source link](./img/snapshot-report-ai-chat-4.png)

--- a/docusaurus/docs/snapshot-report/snapshot-report-analytics.mdx
+++ b/docusaurus/docs/snapshot-report/snapshot-report-analytics.mdx
@@ -282,21 +282,3 @@ Local businesses may score lower in national analysis because they're optimized 
 Use grade calculations to create urgency (showing poor performance), demonstrate expertise (explaining methodology), provide clear roadmaps (focusing on lowest grades), and show realistic improvements (explaining how grades can improve with specific actions).
 </details>
 
-## Screenshots or videos
-
-### Grade calculation breakdown
-Detailed view of how overall scores are calculated from individual section grades.
-
-![Overall Score](./img/snapshot-report/grade-calculations/overall-score.jpg)
-
-### Competitive analysis interface
-Screenshots showing competitor data analysis and comparison features.
-
-![Viewing competitor snapshot reports](./img/snapshot-report/competitor-data/competitors-snapshot-reports.jpg)
-
-### Dynamic component integration
-Email marketing integration showing how to include specific grades in campaigns.
-
-![Insert Dynamic Component](./img/snapshot-report/grades-dynamic-component.jpg)
-
----

--- a/docusaurus/docs/snapshot-report/snapshot-report-management.mdx
+++ b/docusaurus/docs/snapshot-report/snapshot-report-management.mdx
@@ -107,7 +107,7 @@ When a Snapshot Report is refreshed, the new report completely replaces the old 
 - **Report Refresh**: $2 per report (separate from creation)
 - **Automatic Email Campaigns**: Standard fees apply for reports created or refreshed
 
-#### Subscription Allocations
+#### Subscription allocations
 Some subscription tiers include a number of 'free' Snapshot Reports that can **only** be used for:
 - Creating new Snapshot Reports for prospecting purposes
 - **Not applicable** for refreshing existing reports


### PR DESCRIPTION
## Summary

- **Create multilocation groups**: Replaced vague "Many systems support" with "Partner Center supports" in sub-groups FAQ; removed audience-mismatched "Check with your system administrator" and hedging language from permissions FAQ
- **AI Chat in Snapshot Report**: Corrected navigation path from `AI Receptionist` → `Chat Receptionist` in 3 locations; converted `**Important Requirements**` from bold to inline code
- **Snapshot Report Analytics and Grading**: Removed duplicate "Screenshots or videos" section at the bottom (images already shown inline in the article body)
- **Maximize Snapshot Report value**: Fixed heading sentence case ("Subscription Allocations" → "Subscription allocations")

## Test plan

- [ ] Confirm that Partner Center supports hierarchical sub-groups within multilocation groups (line 267 of create-multilocation-groups.mdx)
- [ ] Confirm appointment booking capability is under `AI` → `AI Workforce` → `Chat Receptionist` → `Capabilities` in the live product

Closes #624
Closes #622
Closes #619
Closes #620

🤖 Generated with [Claude Code](https://claude.com/claude-code)