### PR TITLE
docs: creating web chat widgets and assigning AI employees

### DIFF
--- a/docusaurus/docs/ai/ai-workforce/custom-ai-employees.md
+++ b/docusaurus/docs/ai/ai-workforce/custom-ai-employees.md
@@ -138,9 +138,14 @@ Once tested, deploy your Custom AI Employee:
 
 **Web Chat:**
 
-- Assign your Custom AI Employee to a web chat widget
-- Requires Conversations AI Standard, Pro, or Premium
-- See [Web Chat Setup](../../business-app/conversations/web-chat/index.mdx) for details
+Assign your Custom AI Employee to a web chat widget so it handles conversations with website visitors:
+
+1. Go to **Conversations** → **Settings**, then click **Manage widgets** on the **Web Chat** card.
+2. On the **Web Chat configuration** page, click **New Web Chat** (or open an existing widget to edit it).
+3. In the **AI employee** card, click **Select employee**, choose your Custom AI Employee, and click **Ok**.
+4. Click **Next** to save, then install the widget on your site.
+
+Requires Conversations AI Standard, Pro, or Premium. See [Web Chat Setup](../../conversations/ai-assisted-web-chat-widget.mdx) for details.
 
 **Automations:**
 
@@ -220,7 +225,7 @@ Your Custom AI Employee is automatically available in the AI Workforce tab after
 
 ### Web Chat
 
-Assign your Custom AI Employee to a web chat widget to provide specialized chat experiences for website visitors.
+Assign your Custom AI Employee to a web chat widget to provide specialized chat experiences for website visitors. Go to **Conversations** → **Settings** → **Manage widgets**, open a widget, then use **Select employee** in the **AI employee** card to assign it. A widget uses one AI employee at a time, but the same employee can be assigned to multiple widgets.
 
 **Benefits:**
 
@@ -228,7 +233,7 @@ Assign your Custom AI Employee to a web chat widget to provide specialized chat 
 - Interactive knowledge navigation for website visitors
 - Lead capture and resource discovery
 
-For setup instructions, see [Web Chat Setup](../../business-app/conversations/web-chat/index.mdx).
+For setup instructions, see [Web Chat Setup](../../conversations/ai-assisted-web-chat-widget.mdx).
 
 ### Automations
 

--- a/docusaurus/docs/conversations/ai-assisted-web-chat-widget.mdx
+++ b/docusaurus/docs/conversations/ai-assisted-web-chat-widget.mdx
@@ -21,6 +21,36 @@ This powerful widget is similar to the Conversations AI version you can sell to 
 
 ![AI-assisted web chat widget interface](img/partner-center-inbox/ai-web-chat-widget.jpg)
 
+## Create and manage web chat widgets
+
+You can run more than one web chat widget and assign a different AI employee to each — for example, a sales widget on your pricing page and a support widget on your help page.
+
+1. In Partner Center, go to **Conversations** → **Settings** to open the **Conversations settings** page.
+2. On the **Web Chat** card, click **Manage widgets** to open the **Web Chat configuration** page. This page lists every widget along with its **Assigned Employees**, **Status**, and **Widget type**.
+3. Click **New Web Chat** to create a widget, then give it a **Widget name** to identify it internally.
+
+From the **Web Chat configuration** page you can also manage existing widgets using the `⋮` menu on each row:
+
+- **Edit**: change the widget's AI employee, messages, or appearance
+- **Embed**: copy the installation code for your site
+- **Delete**: remove a widget you no longer use
+
+:::note
+The **System** widget is the built-in Chat Receptionist widget and can't be deleted. Widgets you create yourself are marked **Standard**.
+:::
+
+## Assign an AI employee
+
+Each web chat widget is handled by one assigned AI employee — either the ready-to-use Chat Receptionist or a custom AI employee you've built.
+
+1. Open the widget from the **Web Chat configuration** page (click its name, or use the `⋮` menu and choose **Edit**).
+2. In the **AI employee** card, click **Select employee**.
+3. In the **Select employee** dialog, choose the Chat Receptionist or one of your custom AI employees, then click **Ok**.
+4. Click **Configure** on the **AI employee** card to adjust that employee's knowledge, personality, or capabilities.
+5. Click **Next** to save the widget.
+
+A widget can have only one AI employee at a time, but the same employee can be assigned to multiple widgets. If a widget shows a **No assigned employee** warning, assign one before installing it. To build a specialized employee, see [Creating Custom AI Employees](../ai/ai-workforce/custom-ai-employees.md).
+
 ## Widget Actions
 Widget actions allow you to create direct links that automatically open the web chat widget with predefined messages. This is perfect for email campaigns, landing pages, support pages, or any scenario where you want to direct visitors to start a chat with a specific message.
 


### PR DESCRIPTION
## Why

A teammate couldn't find how to **add a web chat widget** or **assign a custom AI employee** to one. The AI web chat widget article covered installation and widget actions but never explained creating/managing widgets or assigning an employee, and the Custom AI Employees article only said assignment was "possible" with no steps.

## What changed

Verified the real UI against the `galaxy` frontend (`libs/conversation/inbox`) and added the missing steps:

**`conversations/ai-assisted-web-chat-widget.mdx`**
- New **Create and manage web chat widgets** section: **Conversations → Settings → Web Chat → Manage widgets → New Web Chat**, plus the per-row **Edit / Embed / Delete** menu and System vs Standard widget types.
- New **Assign an AI employee** section: **AI employee** card → **Select employee** → Chat Receptionist or a custom AI employee → **Ok**.

**`ai/ai-workforce/custom-ai-employees.md`**
- Replaced the two vague "assign to a web chat widget" pointers with concrete assignment steps.
- Fixed the **Web Chat Setup** links, which pointed to a non-existent `business-app/conversations/web-chat/index.mdx` path, to the AI web chat widget article in this repo.

## Notes
- Uses `→` for UI paths per repo convention (no `>` blockquotes).
- Labels are taken verbatim from the product's i18n strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)