### PR TITLE
docs: apply Guru Payments cleanup recommendations to existing articles

### DIFF
--- a/docusaurus/docs/administration/commerce/vendasta-payments/index.mdx
+++ b/docusaurus/docs/administration/commerce/vendasta-payments/index.mdx
@@ -230,6 +230,34 @@ If you selected the wrong business type when setting up Vendasta Payments (for e
 
 ## Managing account information
 
+### Update your business name
+
+There are two separate business name settings for Vendasta Payments, and they control different things:
+
+| Setting | What it controls | Where to change it |
+|---|---|---|
+| **Stripe legal business name** | Your legal name for payouts, compliance, and tax reporting | Stripe Dashboard > Settings > Account details |
+| **Partner Center display name** | The name shown to clients on invoice payment screens and credit card statements | `Partner Center` > `Administration` > `Business Profile` |
+
+Keeping these two settings aligned avoids confusion where clients see a different name when paying an invoice than they expect.
+
+**To update your legal business name in Stripe:**
+
+1. Log in to your Stripe account via the link in `Administration` > `Vendasta Payments` > `Manage Account`
+2. Go to **Settings > Account details**
+3. Update the **Legal business name** field
+4. Save your changes
+
+:::warning
+Changing your legal business name in Stripe may trigger an identity re-verification review. Payouts may be briefly paused while Stripe reviews the change.
+:::
+
+**To update the name shown on client invoice payment screens:**
+
+1. Navigate to `Partner Center` > `Administration` > `Business Profile`
+2. Update the **Business name** field
+3. Save your changes
+
 ### Update ownership information
 To replace ownership details in your payment account:
 

--- a/docusaurus/docs/commerce/credit-notes/index.mdx
+++ b/docusaurus/docs/commerce/credit-notes/index.mdx
@@ -116,3 +116,33 @@ Yes, you can issue credit notes on an invoice paid through ACH or PADs, but only
 
 No, but refunds over $1000 will require Support on-Demand to issue the refund. Please submit SMB refund requests over $1000 to support@vendasta.com.
 </details>
+
+<details>
+<summary>Can I cancel or reverse a payment after it has been made?</summary>
+
+No — once a payment has been processed, it cannot be cancelled. To return funds to a client, issue a credit note on the paid invoice and select **Refund payment method** as the refund type. The refund will appear on the client's statement within **5–10 business days**.
+
+</details>
+
+<details>
+<summary>What should I do if I get an error when creating a credit note?</summary>
+
+Common causes of credit note errors:
+
+- **Credit amount exceeds the invoice total** — The credit note amount cannot be greater than the original invoice amount minus any previously issued credit notes on that invoice. Reduce the credit amount and try again.
+- **Invoice is not in a refundable state** — Credit notes can only be issued on invoices with a **Due** or **Paid** status. Void or Draft invoices are not eligible.
+- **ACH/PAD payment not yet settled** — For invoices paid by ACH or Pre-Authorized Debit, the payment must fully settle before a refund credit note can be issued. Wait until the payment status shows as settled, then retry.
+
+If you continue to see errors after checking these conditions, contact [support@vendasta.com](mailto:support@vendasta.com).
+
+</details>
+
+<details>
+<summary>What is the difference between "Refund payment method" and "Refund manually"?</summary>
+
+When issuing a credit note on a **paid invoice**, you are asked to choose a refund type:
+
+- **Refund payment method** — Automatically initiates a refund to the client's original payment method (credit card or bank account). The client receives the funds within 5–10 business days. Use this for standard refunds.
+- **Refund manually** — Records the credit note in the platform without sending funds through Stripe. Use this when you are issuing the refund outside of Vendasta Payments (for example, by cheque or cash), and you want to keep your records accurate.
+
+</details>

--- a/docusaurus/docs/commerce/invoices/create-and-send-invoices.mdx
+++ b/docusaurus/docs/commerce/invoices/create-and-send-invoices.mdx
@@ -40,7 +40,7 @@ The minimum invoice amount is **$1.00**. Attempting to charge or send an invoice
 :::
 
 - Click **New → Invoice** and select an account to create a draft invoice
-- Select a **Due date** for the invoice 
+- Select a **Due date** for the invoice. The due date controls the date displayed to the client on the invoice — it does not determine when payment is collected. If you use automatic charging, payment is collected immediately when the invoice is charged, regardless of the due date.
 - Select a **User** (recipient) for the invoice
 - Click **Add Item** to add an individual product to the invoice. You can add any product that you're currently selling in your Marketplace, or type any text into the text box to represent a line item that does not exist in your Marketplace
   - If the product you select already has a retail price set, it will automatically populate the Unit Price and currency for that item. The price and currency can also be overwritten on an individual invoice (note that invoices can currently only accept payments in USD and CAD)
@@ -148,6 +148,10 @@ For Partners with multiple markets, repeat the same steps under the '**Markets**
 
 <details>
 <summary>Can I delete an invoice?</summary>
+
+**Draft invoices** can be deleted using the Options **⋮** menu on the invoice.
+
+**Sent or paid invoices** cannot be deleted — they are financial records. If you need to reverse the charge on a paid invoice, [issue a credit note](/commerce/credit-notes) instead. If a sent invoice was created in error and has not been paid, void it by selecting **Change invoice status → Void** from the Options **⋮** menu.
 
 Currently, Partners cannot retract or delete an invoice that has already been sent.
 
@@ -281,6 +285,36 @@ If a package shows an unexpected price when added to an invoice, it may not have
 <summary>Where can I find the payment link for an invoice?</summary>
 
 The payment link can be found for any sent invoice from **Partner Center → Commerce → Click the three dots to the left of the desired invoice → Copy payment link**. Draft invoices do not have a payment link.
+
+</details>
+
+<details>
+<summary>Why isn't my invoice email sending to my client?</summary>
+
+If an invoice email is not being received by your client, check the following:
+
+1. **Invoice status** — Only invoices in **Open (Due)** status can be sent. Draft invoices cannot be emailed until they are sent.
+2. **Valid email address** — Confirm the contact on the account has a valid, correctly formatted email address.
+3. **Recipient selection** — When clicking **Send Invoice**, ensure you have selected at least one recipient from the list.
+4. **Spam or junk folder** — Ask the client to check their spam or junk folder, as invoice emails can sometimes be filtered.
+
+If the client has previously unsubscribed from platform emails, their address may be suppressed. In that case, they will need to contact [support@vendasta.com](mailto:support@vendasta.com) to be re-subscribed.
+
+</details>
+
+<details>
+<summary>The date filter seems to be missing invoices from the last day of my selected range</summary>
+
+This is a known behavior. When filtering invoices by date range, the end date is treated as exclusive — meaning invoices dated on the last day of the range may not appear. To work around this, set your end date one day later than your intended range. For example, to see all invoices through June 30, set the end date to July 1.
+
+</details>
+
+<details>
+<summary>Why doesn't the net amount on my invoice report match after issuing a credit note?</summary>
+
+Credit notes are reported separately from invoices. An invoice export from **Commerce > Invoices > Export as CSV** shows gross invoice amounts only — it does not deduct credit notes from the totals.
+
+To calculate accurate net revenue, export both your invoices and your credit notes separately, then subtract the credit note totals from your invoice totals.
 
 </details>
 

--- a/docusaurus/docs/commerce/payouts/index.mdx
+++ b/docusaurus/docs/commerce/payouts/index.mdx
@@ -95,3 +95,26 @@ A [reserve](https://support.stripe.com/topics/reserves) is a portion of your fun
 
 Vendasta Payments currently supports these countries: US, CA, AU, GB, NZ, CZ. If your billing contact country setting is outside these six, you will see "Vendasta Payments is currently unsupported in your area."
 </details>
+
+<details>
+<summary>Why is my payout amount lower than expected?</summary>
+
+Your payout represents the net amount after the following are deducted from your Stripe balance:
+
+- **Stripe processing fees** — Charged per transaction (e.g., credit card fees, ACH fees). These are deducted before funds are added to your balance.
+- **Refunds issued** — Any refunds you have issued to clients reduce your available balance.
+- **Chargebacks** — Disputed payments that were decided in the client's favor are deducted, along with any associated dispute fees.
+- **Reserves** — Stripe may hold a portion of your funds temporarily as a reserve to cover potential risk. Check your Stripe dashboard for details.
+
+To review the breakdown of a specific payout, navigate to **Partner Center > Commerce > Payouts** and click the payout to see its transaction details.
+
+</details>
+
+<details>
+<summary>What happens to my payouts if my account is suspended?</summary>
+
+If your Vendasta Payments account is suspended, payouts are paused until the suspension is resolved. Funds already in your Stripe balance are held and will be released once the account is back in good standing.
+
+To resolve a suspension, contact [billingsupport@vendasta.com](mailto:billingsupport@vendasta.com) for assistance.
+
+</details>


### PR DESCRIPTION
## Summary

Applies content gaps identified in the Vendasta Payments (Merchant Services) Guru cleanup to four existing Help Center articles. All five recommendations were of type "Create new article" but the content maps cleanly into articles that already exist — this approach avoids fragmentation.

**Files changed:**
- **Credit Notes** — Added FAQs: cancelling a processed payment, credit note error troubleshooting, and difference between "Refund payment method" vs "Refund manually"
- **Invoices** — Clarified that due dates are display-only (not when payment is charged); added FAQs: invoice email not sending, date filter missing last-day edge case, credit note net reporting discrepancy; improved the "Can I delete an invoice?" FAQ to distinguish draft vs paid invoices
- **Payouts** — Added FAQs: why a payout amount may be lower than expected (fees/refunds/chargebacks/reserves), and what happens to payouts when an account is suspended
- **Vendasta Payments setup** — Added "Update your business name" section distinguishing Stripe legal name (payouts/compliance) from Partner Center display name (shown to clients on invoice payment screens)

## Test plan

- [ ] Spot-check each updated article renders correctly in a local Docusaurus dev server (`cd docusaurus && npm run start`)
- [ ] Confirm all internal links (e.g. `/commerce/credit-notes`) resolve
- [ ] Verify no blockquote `>` characters were introduced (per CLAUDE.md)
- [ ] SME review: confirm Stripe legal name re-verification warning is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)