### PR TITLE
Docs: Add multi-location web chat widget article (WOW-2515)

### DIFF
--- a/docusaurus/docs/multi-location-business-app/conversations/multi-location-web-chat-widget.md
+++ b/docusaurus/docs/multi-location-business-app/conversations/multi-location-web-chat-widget.md
@@ -1,0 +1,30 @@
+---
+id: multi-location-web-chat-widget
+title: Multi-Location web chat widget
+sidebar_position: 2
+description: Set up a brand-level web chat widget for clients with multiple locations
+---
+
+# Multi-location web chat widget
+
+Businesses with multiple locations can embed a single web chat widget on their main brand website. Website visitors choose a location from within the widget, then connect directly with that location's AI Receptionist.
+
+This widget operates at the brand level — it is separate from each individual location's web chat widget and has its own embed code.
+
+## How it works
+
+The multi-location widget is configured from the group setup page in Multi-Location Business App.
+
+During setup, a table lists each location alongside its **AI Employee** assignment. This column shows which AI Receptionist handles chats for that location. The business owner should confirm the correct AI Receptionist is assigned to each location before going live.
+
+## Get the embed code
+
+The group setup page includes an embed code to install the widget on the brand's main website.
+
+1. On the group setup page, scroll to the embed code section.
+2. Copy the code snippet.
+3. Paste it into the brand website.
+
+## Visitor experience
+
+When a visitor opens the chat widget on the brand website, they see a list of locations. After selecting one, they chat directly with that location's AI Receptionist.


### PR DESCRIPTION
## JIRA

[WOW-2515 — Multi-location refinements](https://vendasta.jira.com/browse/WOW-2515)
Parent epic: [WOW-2401 — Multi-Location Web Chat Widget (MVP)](https://vendasta.jira.com/browse/WOW-2401)

---

## Change classification

**UI / feature behavior change** — Partner-facing (Multi-Location Business App documentation)

---

## Repo

**Partner Center docs** (`vendasta/partnercenter-docs`)

---

## Summary

Created a new documentation page for the multi-location web chat widget in the existing `multi-location-business-app/conversations/` section.

**File added:**
`docusaurus/docs/multi-location-business-app/conversations/multi-location-web-chat-widget.md`

---

## What changed

- **New page created** (no existing multi-location widget docs existed in this section)
- Documents the brand-level web chat widget available to multi-location business clients
- Covers the embed code visible on the group setup page (WOW-2515 refinement #1)
- Documents the **AI Employee** column label in the location selection table (WOW-2515 refinement #2 — renamed from "status")
- Describes the visitor experience for partners to communicate to their clients

---

## Placement reasoning

The new page sits in `multi-location-business-app/conversations/` at `sidebar_position: 2`, alongside the existing Conversations inbox article (`sidebar_position: 1`). The multi-location widget is a distinct feature from the unified inbox and warrants its own page. Partners looking for multi-location conversation features will find it in the same section.

---

## Acceptance criteria coverage

| Criterion | Documented |
|-----------|-----------|
| Embed code visible on group setup page | ✅ "The group setup page includes an embed code to install the widget on the brand's main website" |
| Column title is "AI Employee" (not "status") | ✅ "a table lists each location alongside its **AI Employee** assignment" |
| Brand-level widget with own embed code | ✅ "operates at the brand level — it is separate from each individual location's web chat widget and has its own embed code" |
| Visitor location picker experience | ✅ "When a visitor opens the chat widget on the brand website, they see a list of locations. After selecting one, they chat directly with that location's AI Receptionist." |

---

## Figma / visual inputs

None provided in the JIRA ticket. Documentation based on JIRA description and epic content only.

---

## Skills used

- `pre-push-validation` — frontmatter, tag, and link validation passed

---

## Assumptions / limitations

- Exact navigation path to the group setup page was not specified in the JIRA ticket. The doc describes the feature without step-by-step navigation clicks to avoid documenting incorrect paths.
- Developer on this ticket: Greg Brownell (gbrownell@vendasta.com) — GitHub username not found; please add as reviewer manually if desired.

---

@ahnikakuse @haleyserrano @maryam6samadi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dam5bWWQhbLPmyMwxUFCW8)_