### PR TITLE
docs: remove expectation brochure references + simplify import page

### DIFF
--- a/docusaurus/docs/vendasta-services/expectations/index.mdx
+++ b/docusaurus/docs/vendasta-services/expectations/index.mdx
@@ -1,15 +1,15 @@
 ---
 id: expectations
 title: Expectations
-description: "Service expectations, timelines, and process details for Vendasta Services: brochures, expectations by service, and where to find resources and forms."
+description: "Service expectations, timelines, and process details for Vendasta Services: expectations by service, and where to find resources and forms."
 sidebar_position: 1
 tags: [vendasta-services, expectations, timelines, fulfillment, order-forms]
-keywords: [expectations, timelines, brochures, fulfillment forms, pre-launch, order confirmation, project tracking]
+keywords: [expectations, timelines, fulfillment forms, pre-launch, order confirmation, project tracking]
 ---
 
 # Expectations
 
-Vendasta Services delivers managed work across listings, reputation, social, blogs, websites, and digital ads. This section explains what to expect after you order: confirmation and timelines, pre-launch and post-launch calls, project tracking in Business App, and where to find expectation brochures and fulfillment forms so you can prepare and share details with your team and clients.
+Vendasta Services delivers managed work across listings, reputation, social, blogs, websites, and digital ads. This section explains what to expect after you order: confirmation and timelines, pre-launch and post-launch calls, project tracking in Business App, and where to find fulfillment forms so you can prepare and share details with your team and clients.
 
 ## Overview
 
@@ -26,7 +26,7 @@ Requirements differ by product: some need Business App connections, external cre
 ## What's Included
 
 - [Expectations by service within Vendasta Services](./expectations-by-service-within-vendasta-services.md) – Table and definitions: order confirmation, pre-launch/post-launch calls, direct-to-customer communication, project tracking, connections, credentials, Digital Agency access, business days to launch
-- [Where to find resources, expectations, and forms](./where-to-find-resources-expectations-and-forms.md) – Marketplace product details and assets, expectation brochures in-platform or on the unbranded site, and fulfillment forms (Required Forms on product pages)
+- [Where to find resources, expectations, and forms](./where-to-find-resources-expectations-and-forms.md) – Marketplace product details and assets, and fulfillment forms (Required Forms on product pages)
 
 ## FAQ
 
@@ -49,9 +49,7 @@ All services show a tracker in **Business App** → **Projects** with tasks, exp
 </details>
 
 <details>
-<summary>Where can I find expectation brochures and fulfillment forms?</summary>
+<summary>Where can I find fulfillment forms?</summary>
 
-**Brochures:** In Partner Center go to **Marketplace** → **Discover Products**, open the product page, then **Screenshots & Files** and look for files with “Expectation” in the title. You can also use the [Expectation Brochures page](https://examples.yourdigitalagents.com/expectation-brochures/) on the unbranded site.
-
-**Fulfillment forms:** In **Marketplace** → **Discover Products**, open the product page and use the **Required Forms** section on the right. See [Where to find resources, expectations, and forms](./where-to-find-resources-expectations-and-forms.md).
+In **Marketplace** → **Discover Products**, open the product page and use the **Required Forms** section on the right. See [Where to find resources, expectations, and forms](./where-to-find-resources-expectations-and-forms.md).
 </details>

--- a/docusaurus/docs/vendasta-services/expectations/where-to-find-resources-expectations-and-forms.md
+++ b/docusaurus/docs/vendasta-services/expectations/where-to-find-resources-expectations-and-forms.md
@@ -15,21 +15,12 @@ These steps are laid out to help equip you with plenty of resources and informat
 3.  Check the box for Services
 4.  Click into any service you want to learn more about
 5.  Read through product information, find FAQs, and check out add-ons
-6.  Click Screenshots & Files to find marketing images, sales decks, and expectation brochures
+6.  Click Screenshots & Files to find marketing images and sales decks
 7.  Click the Start Selling button in the top right corner to add to your store
 
 ### **Familiarize yourself with the service expectations**
 
-Expectation brochures are documents provided by Vendasta Services that break down the timelines, details, and deliverables that you can expect after ordering. You can also check out the [Expectations by Service guide](./expectations-by-service-within-vendasta-services.md) to get a high-level overview and reference for expectations across all product lines. 
-
-You can find expectation brochures inside of the platform:
-
-1.  Go to Partner Center > Marketplace > [Discover Products](https://partners.vendasta.com/marketplace/products)
-2.  Go to the product page for the Vendasta Services product for which you want more expectation information
-3.  Click Screenshots & Files
-4.  Look for a file with **Expectation** in the title
-
-Or you can access them on the Vendasta Services [unbranded website](https://examples.yourdigitalagents.com/) and click Expectation Brochures. 
+To understand the timelines, details, and deliverables you can expect after ordering, check out the [Expectations by Service guide](./expectations-by-service-within-vendasta-services.md) for a high-level overview and reference across all product lines.
 
 ### Review the fulfillment forms
 

--- a/docusaurus/docs/vendasta-services/sales-marketing-assets/index.mdx
+++ b/docusaurus/docs/vendasta-services/sales-marketing-assets/index.mdx
@@ -15,7 +15,7 @@ Vendasta Services provides rebrandable sales materials, product-level marketing 
 
 Sales and marketing assets are resources you can use to sell and advertise Vendasta Services:
 
-- **Marketing information by product** – In the Marketplace, each product page has **Screenshots and Files** with sales decks, expectation brochures, and other assets. Quick links are available for key products (listings, social, MatchCraft Managed Ads, templated website).
+- **Marketing information by product** – In the Marketplace, each product page has **Screenshots and Files** with sales decks and other assets. Quick links are available for key products (listings, social, MatchCraft Managed Ads, templated website).
 - **Rebrandable sales deck** – A full deck showcasing Vendasta Services product categories. You can use it as-is, remove or adjust slides, or pull images and copy into your own materials. It pairs with the Vendasta Go-to-Market Playbook.
 - **Marketing videos** – Unbranded videos for Blogs, Digital Ads, Google Business Profile Optimization, Local Listings Management, Review Responses & Requests, Social Posting, and Website Creation. They cover what customers can expect (e.g. timelines) and best practices; each has a download link.
 
@@ -30,7 +30,7 @@ Sales and marketing assets are resources you can use to sell and advertise Venda
 <details>
 <summary>Where do I find marketing assets for a product?</summary>
 
-Go to **Partner Center** → **Marketplace** → **Discover Products**, open the product page, then click **Screenshots and Files** at the top. You’ll find marketing images, sales decks, and expectation brochures. See [Marketing information by product](./marketing-information-by-product.md).
+Go to **Partner Center** → **Marketplace** → **Discover Products**, open the product page, then click **Screenshots and Files** at the top. You’ll find marketing images and sales decks. See [Marketing information by product](./marketing-information-by-product.md).
 </details>
 
 <details>

--- a/docusaurus/docs/vendasta-services/websites/website-import-and-export.md
+++ b/docusaurus/docs/vendasta-services/websites/website-import-and-export.md
@@ -13,34 +13,7 @@ If you have an existing WordPress website and would like to move it onto Vendast
 
 You will also gain access to Vendasta Services’ Website Support team when we import a site with Website Support+ activated _(3-month commitment)_.
 
-## **Website Support+ includes:**
-
-*   Access to the team for technical support
-*   Minor changes to the website's appearance, such as:
-    *   Fonts
-    *   Colors
-    *   Media (images, videos, icons)
-    *   Text updates
-    *   Contact form fields and settings
-    *   Reorganization or duplication of existing sections
-*   Change a third-party contact form to a CRM form so submissions flow into your CRM as leads
-*   Backend updates are completed quarterly to ensure WordPress stability
-*   Updates to plugins and themes upon request
-*   Health checks to website upon request
-*   Uptime monitoring and urgent support if your website goes offline
-*   Upload up to 3 blog posts per month (content must be provided)
-*   AI Chat Receptionist installation
-
-
-### **AI Chat Receptionist**
-
-At no additional cost, our team will install the AI Chat Receptionist on your new website build or with an imported website. This includes:
-*   Web chat code added to the website
-*   Basic test (open chat, confirm a message can be sent)
-*   Add brand colours to the AI Chat Receptionist
-
-This service is not a full end-to-end configuration of the AI Chat Receptionist, and is only for basic code installation. If you need advanced features such as full brand configuration beyond basic brand colours, SMS messaging, voice calls, or custom conversation flows, please explore our [AI Receptionist Setup & Support](../ai-workforce/ai-receptionist.md) service.
-
+For the full list of what Website Support+ covers, see the [Website Support](./vendasta-services-website-support.md) article.
 
 ## **What benefits are there when importing a site through Vendasta Services?**
 
@@ -102,8 +75,6 @@ _Please note that a site can take up to 72 hours to fully propagate. During this
 *   Compatibility issues with WordPress Hosting Pro
 
 If our Website Support+ team is unable to support the website in question, we will email you to let you know that we are unable to support this site and explain why we had to reject it.
-
-**See also:** [Website Import & Support Vetting Expectations Brochure](https://examples.yourdigitalagents.com/wp-content/uploads/2023/05/Website-Import-Support-Vetting_-Expectations-Guide.pdf)
 
 ## Custom add-on delivery times
 

--- a/docusaurus/docs/vendasta-services/working-with-our-team/index.mdx
+++ b/docusaurus/docs/vendasta-services/working-with-our-team/index.mdx
@@ -16,7 +16,7 @@ Vendasta Services is Vendasta’s in-house fulfillment vendor. This section cove
 Working with the team means knowing who to reach, where to find resources, and how to align on process and branding:
 
 - **Contacts** – **Vendasta Services** (marketingservices@yourdigitalagents.com, 1-866-378-8031) for products, fulfillment, and active projects. **Vendasta Sales** and **Onboarding** for sales and onboarding. **Support on Demand** (support@vendasta.com) for the Vendasta platform (Partner Center, Business App, Social Marketing).
-- **Resources by product** – Expectation brochures, website frameworks and forms, digital ads proposal requests, and social content questionnaires are linked from the resource overview. Presale questions can go to Vendasta Services with your sales rep CC’d.
+- **Resources by product** – Website frameworks and forms, digital ads proposal requests, and social content questionnaires are linked from the resource overview. Presale questions can go to Vendasta Services with your sales rep CC’d.
 - **Training webinars** – Vendasta Services hosts partner-only webinars (Getting Started, Websites, Digital Ads, Social & Long-form Content, Listings & Reputation AI). Session links are on the [Webinar calendar](http://www.vendasta.com/webinar).
 - **White-label communications** – Default contact is unbranded (marketingservices@yourdigitalagents.com, 1-866-378-8031). If you prefer non-client-facing communication, provide your own contact information on the order and fulfillment forms.
 

--- a/docusaurus/docs/vendasta-services/working-with-our-team/vendasta-services-resource-overview.md
+++ b/docusaurus/docs/vendasta-services/working-with-our-team/vendasta-services-resource-overview.md
@@ -35,7 +35,6 @@ This article provides an overview of Vendasta's teams and resources, which are h
 * **Phone:** For all inquiries regarding projects managed by the Marketing Services team or to speak with a specific agent, contact **1-866-378-8031**. This line is exclusively for partners with active Marketing Services products and is monitored Monday through Friday from 8:00 AM to 5:00 PM CST.
 * **Presale Questions:** Reach out to [marketingservices@yourdigitalagents.com](mailto:marketingservices@yourdigitalagents.com) and CC your Vendasta Sales Representative for coordinated assistance.
 * **Examples of Services:**
-    * **Expectation Brochures:** [https://examples.yourdigitalagents.com/expectation-brochures/](https://examples.yourdigitalagents.com/expectation-brochures/)
     * **Social Posts and Websites:** [https://examples.yourdigitalagents.com/](https://examples.yourdigitalagents.com/)
 
 ### Websites


### PR DESCRIPTION
Removes every "expectation brochure" reference from the Vendasta Services docs and simplifies the website import page.

## Changes
- **Import article** – replaced the duplicated "Website Support+ includes" list with a link to the Website Support article, and removed the "See also: Expectations Brochure" link.
- **Expectations section** – removed brochure mentions/links from `index.mdx` and reworked `where-to-find-resources-expectations-and-forms.md` to drop the brochure how-to (kept fulfillment forms + the Expectations by Service guide).
- **Working with Our Team** – removed the brochure mention and the Expectation Brochures resource link.
- **Sales & Marketing Assets** – removed brochure mentions from the overview and FAQ.

Builds clean; no broken links introduced.

Note: branched from `vs-organizing`, so this PR also carries the navbar/branding and CRM-forms commits from PR #614.

🤖 Generated with [Claude Code](https://claude.com/claude-code)