### PR TITLE
fix(article-verification): update Manage Accounts overview

### DIFF
--- a/docusaurus/docs/accounts/manage-accounts/index.mdx
+++ b/docusaurus/docs/accounts/manage-accounts/index.mdx
@@ -6,9 +6,7 @@ tags: [manage-accounts, account-creation, editing, search-and-filter, product-ma
 keywords: [manage-accounts, create-accounts, edit-accounts, search-accounts, filter-accounts, product-management, delete-accounts]
 ---
 
-# Manage Accounts Overview
-
-## What is manage accounts?
+## What is Manage Accounts?
 
 Manage Accounts is the central hub for business profile administration, billing management, and listing maintenance. Focus on maintaining accurate business information, managing service billing, and ensuring business directory profiles are current and complete.
 
@@ -20,7 +18,7 @@ Manage Accounts is the central hub for business profile administration, billing 
 - **Profile Data Integrity**: Ensure business information accuracy for directory listings and service delivery
 - **Account Lifecycle Management**: Handle account setup, maintenance, and closure processes
 
-## What's included in manage accounts?
+## What's included in Manage Accounts?
 
 - **Business Profile Management**: Create, edit, and maintain comprehensive business directory profiles
 - **Billing and Subscription Management**: Handle product billing, subscription changes, and payment administration
@@ -63,7 +61,7 @@ Required fields include business name, address, phone number, country/region, an
 <details>
 <summary>How do I update an account's address or category?</summary>
 
-Open the account, choose edit, update the fields, and save. See [Edit Accounts](./edit-accounts).
+Open the account, choose `Edit`, update the fields, and save. See [Edit Accounts](./edit-accounts).
 </details>
 
 <details>
@@ -75,7 +73,7 @@ Use product-based filters such as has product, missing product, or status. See [
 <details>
 <summary>Can I activate or change products for an account?</summary>
 
-Yes. Open the account, go to products, then activate or change editions as needed. See [Product Management](./product-management).
+Yes. Open the account, go to `Products`, then activate or change editions as needed. See [Product Management](./product-management).
 </details>
 
 <details>
@@ -99,7 +97,7 @@ Yes. Use date filters for creation date and product filters for active products.
 <details>
 <summary>How do I change the Contact Us contact in bottom left corner of Business App?</summary>
  
-The contact populated in the Contact Us contact is the assigned Salesperson for the account. This can be assigned or updated by an administrator on the Account Page of the business in Partner Center from Business Details > Edit > Administration > Sales.
+The contact populated in the Contact Us contact is the assigned Salesperson for the account. This can be assigned or updated by an administrator on the Account Page of the business in Partner Center from `Business Details` → `Edit` → `Administration` → `Sales`.
   
 </details>
 


### PR DESCRIPTION
## Summary

- Removed duplicate H1 from article body (title already in frontmatter)
- Fixed sentence case on two headings: "manage accounts" → "Manage Accounts" (proper noun)
- Formatted UI element references with backticks: `Edit`, `Products`
- Replaced `>` navigation path with `→` arrows and backtick-formatted UI names

## Needs manual verification before merge

- Confirm the Salesperson assignment path (`Business Details` → `Edit` → `Administration` → `Sales`) is current in the live product

## Test plan

- [ ] Spot-check nav path in live Partner Center
- [ ] Review rendered article in preview

Closes #638

🤖 Generated with [Claude Code](https://claude.com/claude-code)