### PR TITLE
fix(redirect): add redirect for /bulk-import-business-app-accounts

### DIFF
--- a/docusaurus/docusaurus.config.ts
+++ b/docusaurus/docusaurus.config.ts
@@ -307,6 +307,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           { from: '/business-app/administration/email-configuration-notifications-management', to: '/business-app/administration' },
           { from: '/business-app/administration/email-configuration', to: '/business-app/administration' },
           { from: '/business-app/administration/email-history', to: '/business-app/administration' },
+          { from: '/bulk-import-business-app-accounts', to: '/accounts/manage-accounts/create-accounts' },
           { from: '/business-app/administration/files', to: '/accounts/manage-accounts/files' },
           { from: '/accounts/manage-business-app/files', to: '/accounts/manage-accounts/files' },
           { from: '/business-app/administration/projects', to: '/accounts/manage-business-app/projects' },


### PR DESCRIPTION
## Summary

- The URL `/bulk-import-business-app-accounts/` was returning a 404
- Added a redirect to `/accounts/manage-accounts/create-accounts`, which is the current page covering bulk account creation in Business App

## Test plan

- [ ] Verify `https://docs.vendasta.com/bulk-import-business-app-accounts/` redirects to `https://docs.vendasta.com/accounts/manage-accounts/create-accounts` after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)