### PR TITLE
Docs: Remove "create invoice from order" workflow (MT-3552)

### DIFF
--- a/docusaurus/docs/administration/my-account/my-team/permissions.mdx
+++ b/docusaurus/docs/administration/my-account/my-team/permissions.mdx
@@ -86,7 +86,7 @@ Allows the admin to create and see multi-location groups.
 
 When using Vendasta Payments, this permission allows the admin to:
 
-- Create an invoice from a Sales Order or from **Commerce** → **Invoices**
+- Create an invoice from **Commerce** → **Invoices**
 - Set retail pricing under **Marketplace** → **Products** → **Product info**
 - Access Subscriptions, Invoices, Payments, Payouts, credit notes, default billing settings, and tax rates
 

--- a/docusaurus/docs/commerce/invoices/create-and-apply-tax-rates.mdx
+++ b/docusaurus/docs/commerce/invoices/create-and-apply-tax-rates.mdx
@@ -68,28 +68,6 @@ The tax rates that you have defined will be automatically applied to Shopping Ca
 
 Note that if no tax rates for a given region have been created, purchases and sales orders conducted through the Shopping Cart by customers located in the region will not have a tax rate applied to them.
 
-### Taxes on Sales Orders and the invoice gap
-
-Tax rates configured for an account's location will appear in the **Retail Summary** section of a Sales Order. However, when you **create an invoice from a Sales Order**, those taxes do **not** automatically carry over to the invoice.
-
-This happens because the Sales Order stores the tax *rate* (a percentage), but the invoice requires a specific *tax ID* (the named tax rate you created in Administration > Tax Rates). Since the tax ID isn't stored on the order itself, the invoice builder cannot apply it automatically.
-
-**What to do:**
-
-When creating an invoice from a Sales Order:
-
-1. Open the invoice after it is generated
-2. For each taxable line item, click the **⋮** menu and select **Set Item Tax**
-3. Choose the appropriate tax rate from your configured list
-4. Review the total and send or charge the invoice
-
-**If taxes aren't appearing on your Sales Order at all:**
-
-- Confirm the account has a complete address (city, state/province, country, postal code)
-- Confirm you have created a tax rate for that location in **Administration > Tax Rates**
-- Tax rates apply based on the account's address — if the address is missing or in an unconfigured region, no tax is shown 
-
-
 ## Video Walkthrough
 
 <iframe src="//www.loom.com/embed/7a58fd36374a4d4ab706ed9b4f5ac829" width="560" height="315" frameborder="0" allowfullscreen></iframe>

--- a/docusaurus/docs/commerce/invoices/create-and-send-invoices.mdx
+++ b/docusaurus/docs/commerce/invoices/create-and-send-invoices.mdx
@@ -52,8 +52,6 @@ The minimum invoice amount is **$1.00**. Attempting to charge or send an invoice
 
 Invoices can also be created at any time when viewing an individual account in **Partner Center → Manage Accounts** by clicking the Options **⋮** menu next to the **Open Business App** button.
 
-Invoices can be generated from an order in **Partner Center → Sales → Orders** by viewing an order and clicking the **Create Invoice** button.
-
 ### Sending or charging an invoice
 
 <img src={require('./img/commerce/invoices/send-invoice.jpg').default} alt="Sending an invoice" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />

--- a/docusaurus/docs/commerce/invoices/index.mdx
+++ b/docusaurus/docs/commerce/invoices/index.mdx
@@ -7,7 +7,7 @@ sidebar_position: 3
 
 # Invoices
 
-Create, send, and manage invoices from **Partner Center** → **Commerce** → **Invoices**. Invoices let you request and collect payment for products and services—either as one-off bills or from recurring subscriptions. You can create invoices manually, from an account's invoice tab, or from an order; subscription renewals can also generate invoices automatically. How invoices behave (including whether customers can pay online) depends on whether you have [Vendasta Payments](/commerce/payments/setting-up-vendasta-payments) set up.
+Create, send, and manage invoices from **Partner Center** → **Commerce** → **Invoices**. Invoices let you request and collect payment for products and services—either as one-off bills or from recurring subscriptions. You can create invoices manually or from an account's invoice tab; subscription renewals can also generate invoices automatically. How invoices behave (including whether customers can pay online) depends on whether you have [Vendasta Payments](/commerce/payments/setting-up-vendasta-payments) set up.
 
 ## Why use Invoices?
 
@@ -46,7 +46,7 @@ No. Once an invoice is sent, it can't be edited. You can **Resend Invoice** to t
 <details>
 <summary>Where do invoices come from?</summary>
 
-Invoices can be created manually from **Commerce** → **Invoices** or from an account's invoice tab, or from an order (**Create Invoice** on the order). They can also be generated automatically from [subscription renewals](/commerce/subscriptions/subscription-management). See [Create and Manage Invoices](./create-and-send-invoices.mdx).
+Invoices can be created manually from **Commerce** → **Invoices** or from an account's invoice tab. They can also be generated automatically from [subscription renewals](/commerce/subscriptions/subscription-management). See [Create and Manage Invoices](./create-and-send-invoices.mdx).
 </details>
 
 <details>


### PR DESCRIPTION
## JIRA

[MT-3552 – Clean up backend for removed "create invoice" from order workflow](https://vendasta.jira.com/browse/MT-3552)

## Change Classification

**Feature removal / UI change** — Partner Center only. The "Create invoice" kabob menu item has been removed from Sales Orders in the Unified Orders pages. This PR removes all documentation references to that workflow.

## Repo

**Partner Center** (`partnercenter-docs`)

> Business App docs are not affected — this is a partner-facing feature.

---

## Summary of Documentation Updates

**Existing docs updated** (no new pages created):

| File | Change |
|---|---|
| `commerce/invoices/create-and-send-invoices.mdx` | Removed sentence describing how to generate an invoice from an order via the "Create Invoice" button |
| `commerce/invoices/index.mdx` | Removed "or from an order" from the creation methods description and from the "Where do invoices come from?" FAQ answer |
| `commerce/invoices/create-and-apply-tax-rates.mdx` | Removed the "Taxes on Sales Orders and the invoice gap" section, which documented a workaround specific to the now-removed invoice-from-order workflow |
| `administration/my-account/my-team/permissions.mdx` | Removed "from a Sales Order or" from the "Can manage retail billing" permission description |

## Placement Reasoning

All changes are surgical removals from existing pages. No new pages or sections were created — the removed feature had no standalone article and was referenced inline across four files.

## Acceptance Criteria Coverage

| AC | Documented |
|---|---|
| Sales Orders no longer have the option to manually create a draft Invoice from order items | ✅ All references to "Create invoice" from the order kabob menu have been removed |
| The "Create invoice" kabob menu item no longer exists on Unified Order pages | ✅ Removed from `create-and-send-invoices.mdx`, `index.mdx`, `permissions.mdx`, and the tax rates "invoice gap" section |

## Visuals Used

No Figma links or images were provided in the JIRA ticket. Changes are based on the AC text and the removal of a UI entry point confirmed by linked PRs ([sales-orders#1859](https://github.com/vendasta/sales-orders/pull/1859), [vendastaapis#9520](https://github.com/vendasta/vendastaapis/pull/9520)).

## Skills Used

- `pre-push-validation` — confirmed all modified files pass frontmatter, tag, and link validation

## Assumptions / Limitations

None. The AC was unambiguous: the "Create invoice" option is removed. Partners can still create invoices manually from **Commerce → Invoices** or from an account's invoice tab, as noted in the updated copy.

---

@ahnikakuse @haleyserrano @maryam6samadi

---
_Generated by [Claude Code](https://claude.ai/code/session_01NEou6c9UNKXQq2o8UXdcKB)_