### PR TITLE
Docs: Add order PDF documentation (MT-4042)

### DIFF
--- a/docusaurus/docs/commerce/orders/index.mdx
+++ b/docusaurus/docs/commerce/orders/index.mdx
@@ -23,6 +23,7 @@ Create, manage, and process sales orders with tools for order workflows, payment
 - **[Order Configuration and Administration](./order-configuration-and-administration.mdx)** – Configure order workflows, salesperson and admin permissions, fulfillment forms, email notifications, and order settings in **Administration** → **Order Settings**.
 - **[Working with packages](./how-to-work-with-packages.mdx)** – Bundle products in orders and retail subscriptions, distribute pricing across items, manage setup fees, and set visibility and mixed billing frequencies.
 - **[Item billing terms](./item-billing-terms.mdx)** – Set start dates and renewal limits on line items to schedule activation, define contract length, and automate billing and deactivation with Vendasta Payments.
+- **[Order PDF](./order-pdf.mdx)** – Generate and download a PDF summary of any order, including order form answers and fulfillment form responses.
 
 ## Get started
 

--- a/docusaurus/docs/commerce/orders/order-pdf.mdx
+++ b/docusaurus/docs/commerce/orders/order-pdf.mdx
@@ -1,0 +1,46 @@
+---
+id: order-pdf
+title: Order PDF
+sidebar_label: Order PDF
+description: Generate and download a PDF summary of any order, including order form answers and fulfillment form responses.
+tags: [commerce, orders, pdf, fulfillment-forms]
+keywords: [order pdf, download order, order export, fulfillment form pdf, order form pdf]
+---
+
+# Order PDF
+
+Admins can generate a downloadable PDF summary of any sales order. The PDF captures the full order record — including product details, order form answers, and fulfillment form responses — in a format suitable for archiving and reference.
+
+:::info
+Order PDF generation is available to admin users only.
+:::
+
+## What the PDF includes
+
+The order PDF contains:
+
+- **Order details** — order ID, products, pricing, and status
+- **Order form answers** — responses submitted for any order form fields (custom, common, and extra) on each product
+- **Fulfillment form answers** — responses submitted through the fulfillment form for each product
+
+Only answered fields appear. Unanswered optional fields are omitted.
+
+## How field answers display
+
+Form answers are formatted to be human-readable:
+
+| Field type | Display format |
+|---|---|
+| Checkbox | Yes or No |
+| File upload | Filename (e.g. `proposal.pdf`) |
+| User picker | Full name and email (e.g. `Jane Smith (jane@example.com)`) |
+| Dropdown | Selected label — applies to both single and multi-select |
+| Text | Text content |
+
+Long text answers are capped at 3,000 characters. Answers exceeding this limit are truncated and end with `… [truncated]`.
+
+## Fulfillment form data
+
+Fulfillment form answers are fetched at the time the PDF is generated. Each product's fulfillment form is retrieved independently.
+
+If a product's fulfillment form data cannot be retrieved, that product's fulfillment section is skipped and the rest of the PDF still generates normally.


### PR DESCRIPTION
## JIRA

[MT-4042 – Improve order forms and fulfillment forms display in PDF](https://vendasta.jira.com/browse/MT-4042)
Epic: [MT-4039 – Order PDF Generation](https://vendasta.jira.com/browse/MT-4039)

---

## Change classification

**UI/UX change** — Improvements to how order form fields and fulfillment form responses render inside the order PDF.

**Repo targeted:** Partner Center (admin-facing feature; Business App end users do not generate order PDFs)

---

## Summary of documentation changes

### New page created
`docusaurus/docs/commerce/orders/order-pdf.mdx`

Introduces the Order PDF feature, covering:
- What the PDF contains (order details, order form answers, fulfillment form answers)
- How each field type displays in the PDF (checkbox → Yes/No, file → filename, user picker → name + email, dropdown → label, text → text content)
- The 3,000-character truncation behaviour for long text answers
- Graceful degradation: if a product's fulfillment form data cannot be retrieved, that product's section is skipped and the rest of the PDF still generates

### Existing page updated
`docusaurus/docs/commerce/orders/index.mdx`

Added a bullet linking to the new Order PDF page in the "What's in this section" list.

---

## Placement reasoning

The `commerce/orders/` folder is the established home for all order-related documentation. No existing page covered PDF generation, so a dedicated page was created rather than appending to an existing one. The new page sits alongside the other order detail pages (creating, processing, payments, configuration).

---

## Acceptance criteria coverage

| Criteria | Documented |
|---|---|
| Improved label/answer formatting for field types | ✅ How field answers display table |
| Handle long text values gracefully (wrapping/truncation) | ✅ 3,000-character cap noted |
| Fulfillment form data display (fetched from order-fulfillment service) | ✅ Fulfillment form data section |
| Consistent styling with the rest of the PDF | N/A — internal rendering detail, not user-facing |
| Show all form fields the admin can see | ✅ Answered fields appear; unanswered optional fields omitted |

---

## Figma / images

No Figma links or images were provided in the JIRA ticket. No screenshots added to this PR.

**Known limitation:** The exact UI path for triggering PDF generation was not available in the source material. The page documents what the PDF contains and how it behaves, but does not include a step-by-step "how to download" flow. This should be added once the UI navigation is confirmed.

---

## Skills used

- `pre-push-validation` — validated frontmatter, tags, and internal links before committing

---

## Assumptions

- Order PDF generation is available to admin users only (confirmed by epic description)
- The PR was found via GitHub search (`hxdxri` — Haidari Alhaidari)

---

@ahnikakuse @haleyserrano @maryam6samadi

---
_Generated by [Claude Code](https://claude.ai/code/session_01BiU5F7jvAu59MbfTKrjS8J)_