### PR TITLE
Docs: Update Vibe integrations to include CRM connector (VIBE-53)

### DIFF
--- a/docusaurus/docs/ai/vibe.md
+++ b/docusaurus/docs/ai/vibe.md
@@ -54,7 +54,7 @@ Attach images to prompts to show Vibe what you want. Use the microphone button t
 Paste any public URL into Vibe and it will scaffold a new application inspired by that site's layout and structure. This gives you a head start when you want to recreate or remix an existing design without starting from a blank canvas.
 
 ### Integrations
-Vibe connects to Vendasta platform services including Forms, analytics, and authentication. You can build applications that embed contact forms for lead capture, feedback, and more — all platform-native, already connected to your instance with no manual embed or configuration step.
+Vibe connects to Vendasta platform services including Forms, analytics, authentication, and CRM. You can build applications that embed contact forms, surface live contacts and pipeline data, gate content behind sign-in, and more — all platform-native, already connected to your instance with no manual embed or configuration step.
 
 ### AI image generation
 Generate custom images directly within the application using Gemini. Describe the image you want, and Vibe creates and embeds it in the project.


### PR DESCRIPTION
## JIRA

[VIBE-53 — CRM MCP Connector](https://vendasta.jira.com/browse/VIBE-53)

---

## Change Classification

**Feature behavior change** — New CRM connector added to Vibe. The Partner Center Vibe overview page listed available integrations; CRM has been added to that list.

**Repo:** Partner Center (partner/reseller-facing documentation)

---

## Summary of Changes

| File | Action |
|------|--------|
| `docusaurus/docs/ai/vibe.md` | **Updated** — Integrations section updated to include CRM |

### Change detail

The `### Integrations` section previously read:

> Vibe connects to Vendasta platform services including Forms, analytics, and authentication.

Updated to:

> Vibe connects to Vendasta platform services including Forms, analytics, authentication, and CRM. You can build applications that embed contact forms, surface live contacts and pipeline data, gate content behind sign-in, and more — all platform-native, already connected to your instance with no manual embed or configuration step.

---

## Placement Reasoning

The Partner Center Vibe page (`docusaurus/docs/ai/vibe.md`) is a high-level overview that refers partners to the Business App Help Center for full documentation. The Integrations section is the correct location to enumerate available connectors. No new page was needed — this is a minor update to an existing list.

---

## Acceptance Criteria Coverage

The Partner Center article is a summary overview. The detailed connector documentation lives in the Business App repo (see companion PR in vendasta/businessapp-docs). This change ensures the integrations enumeration in the Partner Center overview stays current.

---

## Figma / Images

No Figma links or images provided. No visual changes required for this update.

---

## Skills Used

- Repository search (code search across partnercenter-docs)
- Existing `vibe.md` read as base for targeted edit

---

## Assumptions & Limitations

- No linked GitHub PRs were found on VIBE-53, so no code author could be identified for reviewer assignment.
- The Partner Center page intentionally defers deep documentation to the Business App Help Center, so only the integrations list was updated here.

---

@ahnikakuse @haleyserrano @maryam6samadi

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5omPJf4NzuTdM7RAJ1RAN)_