### PR TITLE
Docs: Note Upgrade available badge on legacy Book appointments capability (VS-1338)

### DIFF
--- a/docusaurus/docs/ai/ai-workforce/ai-voice-receptionist.md
+++ b/docusaurus/docs/ai/ai-workforce/ai-voice-receptionist.md
@@ -124,6 +124,10 @@ The **Book appointments with calendar** capability connects to your integrated c
 
 On the `Book appointments with calendar` panel, use the `Select event link to book with` dropdown to choose which calendar your receptionist should use to determine availability as well as which kind of appointments they can offer.
 
+:::note
+If an AI Employee's configuration shows a **Book appointments** capability with an **Upgrade available** badge, that is a legacy capability being deprecated. Switch to **Book appointments — Voice** (this capability) for the latest features and multi-service booking.
+:::
+
 #### Book multiple services in one session
 
 When configuring **Book appointments with calendar**, you can enable **Book Multiple Services** and choose the service menu/group the AI can book from.
@@ -142,7 +146,7 @@ With multi-service booking enabled, the AI can:
 
 #### Additional Instructions for AI Voice Receptionist
 
-The **Additional Instructions** capability lets you give your AI Voice Receptionist custom guidance to shape its responses, tone, and logic. It sits at the top of the AI’s prompt stack to refine how it interacts with callers. 
+The **Additional Instructions** capability lets you give your AI Voice Receptionist custom guidance to shape its responses, tone, and logic. It sits at the top of the AI's prompt stack to refine how it interacts with callers. 
 
 To add additional instructions, click on the `Additional Instructions` tab in the Capabilities panel. From there you can write plain language instructions to your AI Voice Receptionist. 
 
@@ -198,9 +202,9 @@ For more details on knowledge sources and adding them to the Knowledge Base, see
 
 ## Test and Monitor Your AI Voice Receptionist
 
-Once your AI Voice Receptionist is set up, it’s important to test how it handles real calls and monitor its performance over time. This helps you ensure the AI is providing accurate answers, capturing leads, and delivering a professional experience to your callers. Regular testing and review will also help you spot opportunities to improve your AI’s responses as your business grows.
+Once your AI Voice Receptionist is set up, it's important to test how it handles real calls and monitor its performance over time. This helps you ensure the AI is providing accurate answers, capturing leads, and delivering a professional experience to your callers. Regular testing and review will also help you spot opportunities to improve your AI's responses as your business grows.
 
-### Testing and Reviewing the AI Voice Receptionist’s Responses
+### Testing and Reviewing the AI Voice Receptionist's Responses
 
 Click the `Try it` button on your AI Voice Receptionist's card from <AISparkleIcon /> `AI > AI Workforce` to quickly see the phone number assigned to your AI Voice Receptionist.
 
@@ -218,7 +222,7 @@ You can review call recordings and transcripts of the conversations your AI Voic
 By reviewing the call recording and transcripts regularly, you can see how your AI Voice Receptionist is performing and make adjustments to your configuration as needed. 
 
 :::note  
-If the AI Voice Receptionist is unable to capture a caller’s contact information, those calls may appear without all contact details in your Conversations. 
+If the AI Voice Receptionist is unable to capture a caller's contact information, those calls may appear without all contact details in your Conversations. 
 :::
 
 ---


### PR DESCRIPTION
## JIRA

[VS-1338 — Add "Upgrade available" badge + info icon on legacy Book appointments card](https://vendasta.jira.com/browse/VS-1338)

---

## Change Classification

**UI/UX change** — Visual signal added to the legacy Book appointments capability card for Voice Receptionist legacy users.

**Repo target:** Partner Center (partner-facing docs)

---

## Summary of Documentation Updates

- **File updated:** `docusaurus/docs/ai/ai-workforce/ai-voice-receptionist.md`
- **Change type:** Updated existing documentation (no new page created)
- Added a `:::note` callout within the **Book appointments with your calendar** capability section explaining:
  - An AI Employee configuration may show a **Book appointments** capability marked with an **Upgrade available** badge
  - This is the legacy capability being deprecated
  - Partners should switch to **Book appointments — Voice** (the current capability) for the latest features and multi-service booking

---

## Placement Reasoning

The note is inserted directly within the `#### Book appointments with your calendar` section of the AI Voice Receptionist setup guide — the same location where partners configure the appointment booking capability. Partners who manage legacy Voice Receptionist configurations on behalf of their clients will encounter this badge in this section of the UI.

---

## Acceptance Criteria Coverage

| Criterion | Documented |
|-----------|-----------|
| Voice receptionist legacy users see the legacy card with an "Upgrade available" amber badge | ✅ Note explains this badge may appear |
| Info icon present with approved tooltip copy | ✅ Note directs to the upgraded capability per the tooltip's guidance |
| Legacy card fully hidden for new/Chat/non-active-legacy users | ✅ Framing of the note makes clear it applies only when the badge is present |
| No inline banner or notification strip on the card | N/A — no documentation change needed for this criterion |

---

## Figma / Images

No Figma links provided in the JIRA ticket. One screenshot attachment was present in the ticket but inaccessible via API. Documentation relies on the written acceptance criteria and merged PR description.

---

## Skills Used

- Repository code search (GitHub MCP)
- JIRA issue lookup (Atlassian MCP)
- Merged PR discovery (`vendasta/galaxy#32990`)

---

## Assumptions & Limitations

- "Book appointments — Voice" is used as the new capability name per the tooltip copy in the JIRA ticket. The current docs use "Book appointments with calendar" as the UI label; both names refer to the same capability.
- The badge logic in the merged PR applies to any AI Employee (chat or voice) that still has the legacy `BookAppointmentsWithBookMeNow` capability. In practice, only Voice Receptionist legacy users are affected since Chat users are auto-migrated (tracked in VS-1211).

---

@ahnikakuse @haleyserrano @maryam6samadi

---
_Generated by [Claude Code](https://claude.ai/code/session_016YbUCzjCW4qRGRkLXx8EXN)_