### PR TITLE
Docs: Add Finalize an invoice automation step (TLKM-1907)

### DIFF
--- a/docusaurus/docs/automations/automation-steps-reference.mdx
+++ b/docusaurus/docs/automations/automation-steps-reference.mdx
@@ -147,6 +147,7 @@ Steps marked **(draft)** are in development and may change or be removed before 
 | Create a Snapshot Report | Creates a Snapshot Report for the account or company in scope. | Snapshots typically start as F ratings because web scraping takes time. Add a delay step before using the Snapshot data. | When a new lead is qualified, generate a Snapshot to guide the sales conversation. |
 | Pay an invoice *(draft)* | Records a payment against an invoice. | | |
 | Void an invoice *(draft)* | Voids an open invoice. | | |
+| Finalize an invoice *(draft)* | Moves an invoice from draft to due without charging a payment method or sending a payment email to the customer. Use when payment is collected outside the platform. | Access-controlled — not available by default. | When payment is collected through an external processor, finalize the invoice to mark it due without triggering a platform charge or customer notification. |
 
 ## Tags
 


### PR DESCRIPTION
## JIRA

[TLKM-1907 — \[Zoek\] Build dedicated Finalize endpoint for external payment invoice flow](https://vendasta.jira.com/browse/TLKM-1907)

---

## Change classification

**Feature behavior change** — new automation step added to the Partner Center automation builder UI (frontend task TLKM-1966, now Done).

---

## Repo targeted

**Partner Center** only.

**Business App**: No action required. The SMB end-user invoice experience is unchanged — invoices still move from draft to due as before; the internal payment processing path is transparent to end users.

---

## Summary of changes

Added one new row to the **Sales** section of `docusaurus/docs/automations/automation-steps-reference.mdx`:

| Step | What it does |
|---|---|
| **Finalize an invoice *(draft)*** | Moves an invoice from draft to due without charging a payment method or sending a payment email. For use when payment is collected outside the platform. |

---

## Existing docs updated or new docs created?

**Existing page updated.** The automation steps reference already documents adjacent invoice steps (`Pay an invoice`, `Void an invoice`). The new step fits cleanly in the same table.

No new page was created.

---

## Placement reasoning

The `Finalize an invoice` step sits in the **Sales** section alongside `Pay an invoice *(draft)*` and `Void an invoice *(draft)*` — the three invoice-manipulation steps form a natural group. Marked `*(draft)*` consistent with the other invoice steps, since the endpoint is access-controlled and not in general release.

---

## Acceptance criteria coverage

| Criterion | Documented? |
|---|---|
| New RPC moves invoice from Draft to Due | ✅ — "Moves an invoice from draft to due" |
| No email sent to customer | ✅ — "without … sending a payment email to the customer" |
| No Stripe charge | ✅ — "without charging a payment method" |
| Endpoint is access-controlled | ✅ — "Access-controlled — not available by default" in Special Cases |
| Handoff to Wix automation calls new endpoint | Internal wiring only — no partner-facing doc change needed |
| Regression: existing billing flow unaffected | No doc change needed (existing behavior unchanged) |

---

## Figma / images used

None provided in the ticket.

---

## Skills used

- Manual search of both repos (Explore subagent)
- Repository content read (`automation-steps-reference.mdx`)

---

## Assumptions / limitations

- The `*(draft)*` label is applied consistently with the other invoice steps. If this step has graduated to GA, the label should be removed.
- The "Finalize an invoice" UI label is inferred from the JIRA task name and the pattern of existing steps. The exact label shown in the automation builder UI should be confirmed by the developer.
- No Figma or design assets were available; content is derived entirely from the JIRA acceptance criteria.

---

cc @ahnikakuse @haleyserrano @maryam6samadi

Developer: Redhanya Chandrasekaran (rchandrasekaran@vendasta.com)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mvaap7Y6a1ekr96MckDnSF)_