### PR TITLE
Docs: Replace Vendasta Academy links with Platform Training (ITC-306)

### DIFF
--- a/docusaurus/docs/commerce/invoices/index.mdx
+++ b/docusaurus/docs/commerce/invoices/index.mdx
@@ -66,5 +66,5 @@ Create tax rates in **Partner Center** → **Administration** → **Tax Rates** 
 If you can't find what you're looking for in this section:
 
 - [Ask the community](https://www.facebook.com/groups/vendasta)
-- [Take a course](https://academy.vendasta.com/)
+- [Take a course](/learn/)
 - [Give product feedback](https://roadmap.vendasta.com)

--- a/docusaurus/docs/index.mdx
+++ b/docusaurus/docs/index.mdx
@@ -88,7 +88,7 @@ New to Vendasta? Here are your essential next steps:
 
 - **[Intro to Vendasta](getting-started)** - Start here to learn how to get the most out of your Vendasta experience.
 - **[Partner Center Access](https://partners.vendasta.com/dashboard)** - Log in to your Partner Center dashboard
-- **[Vendasta Academy](https://academy.vendasta.com/)** - Take courses to master the platform
+- **[Platform Training](/learn/)** - Take courses to master the platform
 
 {/* Resource showcase (two-card section) */}
 <div className="container homepage-bottom-section">


### PR DESCRIPTION
## JIRA

[ITC-306 – Support Learning Group with transition away from 306learning](https://vendasta.jira.com/browse/ITC-306)

---

## Change Classification

**Configuration / system behavior** — `academy.vendasta.com` has been retired as a standalone learning platform. It now shows a transition message and auto-redirects to the Vendasta documentation site. Docs that linked to the old Academy URL needed updating.

**Repo:** Partner Center docs only. Business App docs had zero references to `academy.vendasta.com`.

---

## Summary of Changes

Two files updated; no new pages created.

| File | Change |
|------|--------|
| `docusaurus/docs/index.mdx` | Replaced `Vendasta Academy` → `Platform Training` in Quick Start Resources; URL updated from `https://academy.vendasta.com/` to `/learn/` |
| `docusaurus/docs/commerce/invoices/index.mdx` | Updated `Take a course` link from `https://academy.vendasta.com/` to `/learn/` |

The training content (formerly at academy.vendasta.com) lives in this repo under `docusaurus/training/` and is served at `/learn/`. Both links now point to the correct internal destination.

---

## Placement Reasoning

Changes made in-place within existing sections — no structural or navigation changes required. The Academy references sat in a freestanding bullet list and a "Need more help?" footer; swapping the URL and label was sufficient.

---

## Acceptance Criteria Coverage

| Criterion | Documentation action |
|-----------|---------------------|
| Disable PC-based SSO for academy.vendasta.com | Internal IT change — no user-facing doc needed |
| Disable Google-based SSO for academy.vendasta.com | Internal IT change — no user-facing doc needed |
| Create landing page for academy.vendasta.com that auto-forwards to documentation | Stale links to the old Academy URL updated to `/learn/` |

---

## Figma / Visuals

None provided or applicable.

---

## Skills Used

- GitHub code search to locate all `academy.vendasta.com` references across both repos

---

## Assumptions & Limitations

- No linked code PRs were attached to ITC-306, so no developer reviewer could be identified. Reviewer defaulting to docs team.
- The `/learn/` path was confirmed from `docusaurus/training/index.mdx` internal link structure.

---

@ahnikakuse @haleyserrano @maryam6samadi

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFVTGAVzRYLCJPUrvwo6QW)_