### PR TITLE
Docs: Add in-person meeting audio recording (CRMAAS-2937)

### DIFF
--- a/docusaurus/docs/crm/my-meetings/record-in-person-meeting.mdx
+++ b/docusaurus/docs/crm/my-meetings/record-in-person-meeting.mdx
@@ -1,0 +1,44 @@
+---
+title: Record an In-Person Meeting
+sidebar_label: Record an In-Person Meeting
+description: Capture in-person meeting audio from the My Meetings page and upload it to the CRM for AI-powered analysis.
+tags: [meetings, crm, recording, audio, in-person]
+keywords: [record meeting, in-person meeting, audio recording, meeting capture, crm recording]
+sidebar_position: 8
+---
+
+# Record an In-Person Meeting
+
+You can record audio from in-person meetings directly on the My Meetings page. Once saved, the recording is uploaded to the CRM and processed for AI-powered analysis.
+
+## How to start recording
+
+**On mobile:** Tap the red **Record** button on the My Meetings page.
+
+**On desktop:** Click the menu in the page header and select **Record audio**.
+
+The recorder opens and begins capturing audio.
+
+## While recording
+
+While the recorder is open, you can:
+
+- **Pause / Resume** — temporarily stop and restart the recording
+- **Cancel** — discard the recording and close the recorder
+- **Stop & Save** — stop recording and move to the review step
+
+## Review and save
+
+After stopping the recording, a preview opens where you can:
+
+- Use the **playback controls** to play, skip back 5 seconds, or skip forward 5 seconds
+- Adjust the **playback speed** (0.5×, 1×, 1.5×, or 2×)
+- Update the **file name** (defaults to the date and time of the recording)
+- Select the **contact** to link the recording to (required)
+
+When you're ready:
+
+- **Save** — uploads the recording to the CRM and triggers analysis
+- **Discard** — removes the recording and closes the preview
+
+Once saved, the recording is processed through the same AI analysis pipeline as other meeting recordings.


### PR DESCRIPTION
## JIRA

[CRMAAS-2937 — Add ability to record audio to my meeting page](https://vendasta.jira.com/browse/CRMAAS-2937)

## Change Classification

**UI / Feature behavior change** — New audio recording capability added to the My Meetings page in the CRM.

## Target Repo

**Partner Center** (partner/reseller-facing documentation)

---

## Summary of Changes

| File | Action |
|------|--------|
| `docusaurus/docs/crm/my-meetings/record-in-person-meeting.mdx` | **New** — Full article documenting the in-person audio recording workflow |

---

## What Was Documented

Users can now record audio from in-person meetings directly on the My Meetings page:

- **On mobile:** Red Record FAB button opens the recorder
- **On desktop:** Header dropdown → Record audio
- **While recording:** Pause/Resume, Cancel, or Stop & Save
- **Review step:** Waveform preview with playback controls (skip ±5s), speed options (0.5×–2×), file name field, required contact link
- **Save:** Uploads the recording and triggers the same AI analysis pipeline as other meeting recordings

---

## Placement Reasoning

A new standalone page was created because:
- The existing recording docs (Notetaker/bot recording, Record a live meeting for online meetings) cover a different workflow
- This is a distinct in-person audio capture flow that would confuse readers if merged into bot-related pages
- Placed in the existing `docusaurus/docs/crm/my-meetings/` folder at `sidebar_position: 8` — directly after the "Record a Live Meeting" article (position 7), grouping all recording-related content together

---

## Acceptance Criteria Coverage

| AC | Documented |
|----|-----------|
| Record button on My Meetings page (mobile) | ✅ |
| Recorder pops up | ✅ |
| Play, pause, cancel, complete controls | ✅ (mapped to actual button labels from code: Pause/Resume, Cancel, Stop & Save; play in preview step) |
| Recordings stored and uploaded | ✅ |
| Desktop support (from follow-up PR #33024) | ✅ — included since implementation extends to desktop via header dropdown |

---

## Figma / Visual Inputs

The Figma mock linked in JIRA (Claude.ai design) was not accessible. Documentation is based on accepted PR descriptions (#32916, #33024) authored by @ivan-antosh, which provided complete implementation detail.

## Skills Used

None — content generated directly from PR descriptions and JIRA acceptance criteria.

## Assumptions / Limitations

- Button labels (Pause/Resume, Cancel, Stop & Save, Discard, Save) sourced from PR #32916 implementation description — considered authoritative
- No screenshots included as none were available without Figma access; the feature is ready to review visually by the dev reviewer
- The JIRA AC said "mobile only" but PR #33024 extended the feature to desktop; documentation reflects the shipped implementation

---

@ahnikakuse @haleyserrano @maryam6samadi

---
_Generated by [Claude Code](https://claude.ai/code/session_01J8yXhzwPoHVPQ4fBTer4vR)_