### PR TITLE
Docs: Safeguard CRM delete with typed confirmation (CRMAAS-2997)

### DIFF
--- a/docusaurus/docs/crm/companies/index.mdx
+++ b/docusaurus/docs/crm/companies/index.mdx
@@ -286,7 +286,7 @@ Bulk deletion is **permanent and cannot be undone**. Any notes attached to delet
 3. Use filters or search to narrow to the records you want to delete.
 4. Click the top-left checkbox to select all visible records.
 5. Click **Actions** > **Delete**.
-6. Confirm the deletion.
+6. In the confirmation modal, type `Delete` and confirm.
 
 Repeat for additional batches if you need to delete more than 100 companies.
 

--- a/docusaurus/docs/crm/contacts/index.mdx
+++ b/docusaurus/docs/crm/contacts/index.mdx
@@ -295,7 +295,7 @@ Bulk deletion is **permanent and cannot be undone**. Export any records you may 
 3. Use filters or search to narrow to the records you want to delete.
 4. Click the top-left checkbox to select all visible records.
 5. Click **Actions** > **Delete**.
-6. Confirm the deletion.
+6. In the confirmation modal, type `Delete` and confirm.
 
 Repeat for additional batches if you need to delete more than 100 contacts.
 

--- a/docusaurus/docs/crm/lists/index.mdx
+++ b/docusaurus/docs/crm/lists/index.mdx
@@ -126,7 +126,7 @@ These triggers allow you to automate workflows, such as sending follow-up emails
 ![Delete List](./img/crm/lists/delete-list.jpg)
 
 **3. Confirm the deletion:**
-- A modal will pop up. Clicking `Delete` will allow you to delete the list.
+- In the confirmation modal, type `Delete` and click `Delete` to confirm.
 
 ## Frequently asked questions
 


### PR DESCRIPTION
## JIRA

[CRMAAS-2997 — Safeguard the delete button with additional input](https://vendasta.jira.com/browse/CRMAAS-2997)

---

## Change classification

**UI / UX change** — Delete modals in the CRM now require users to type `Delete` before confirming a delete action, preventing accidental data loss.

**Repo:** Partner Center (partner/reseller documentation)

---

## Summary of changes

Updated delete confirmation steps across three CRM pages to reflect the new typed-input requirement:

| File | Change |
|------|--------|
| `crm/lists/index.mdx` | Step 3 of "How do I delete a list?" updated: old text described clicking `Delete`; new text instructs users to type `Delete` in the confirmation modal before clicking. |
| `crm/contacts/index.mdx` | Step 6 of "Bulk deleting contacts" updated from "Confirm the deletion." → "In the confirmation modal, type `Delete` and confirm." |
| `crm/companies/index.mdx` | Step 6 of "Bulk deleting companies" updated from "Confirm the deletion." → "In the confirmation modal, type `Delete` and confirm." |

---

## Existing docs updated or new docs created?

**Existing docs updated only.** No new pages created.

---

## Placement reasoning

The delete safeguard is a cross-cutting change that applies to every CRM delete flow. Changes were applied surgically to the existing confirmation steps in each file, without restructuring or duplicating content.

---

## Acceptance criteria coverage

| AC | Documented |
|----|-----------|
| On the delete modal, ask user to type "Delete" before performing the action | ✅ Reflected in all three updated files |
| i18n support | No user-facing documentation required — this is an implementation concern only |

---

## Figma / images used

No Figma links or images were provided in the JIRA ticket.

---

## Skills used

None — changes were targeted and surgical; no generation skills required.

---

## Assumptions / limitations

- Code PRs for this ticket are in `vendasta/galaxy`, which is outside the documentation repo scope. The implementing developer could not be identified. Please add them as a reviewer manually.
- The typed confirmation applies to all CRM delete actions. This PR covers the three pages most likely to be consulted by partners performing deletions. If additional pages describe CRM delete flows, they may also need updating.

---

@ahnikakuse @haleyserrano @maryam6samadi

---
_Generated by [Claude Code](https://claude.ai/code/session_012MPnt7Vk6xEBP8R9GkLnAE)_