### PR TITLE
fix: update webchat lead capture fields in training to match docs

### DIFF
--- a/docusaurus/training/platform/business-app/Attract-Convert-and-Engage-Customers-with-Business-App-Pro.mdx
+++ b/docusaurus/training/platform/business-app/Attract-Convert-and-Engage-Customers-with-Business-App-Pro.mdx
@@ -68,7 +68,7 @@ The local search grid provides invaluable visibility for clients' keyword rankin
 
 **Read**
 
-The **AI-powered webchat** in Business App captures leads by providing instant answers and collecting contact details (name and phone number) for follow-up. The AI Assistant's primary goal is to capture a lead while being helpful and answering questions. It's designed to be a knowledgeable, friendly representative of a business and deliver a great first impression.
+The **AI-powered webchat** in Business App captures leads by providing instant answers and collecting contact details (first name, last name, email, phone, and address) for follow-up. The AI Assistant's primary goal is to capture a lead while being helpful and answering questions. It's designed to be a knowledgeable, friendly representative of a business and deliver a great first impression.
 
 
 ## Step 3: Engage customers with AI social content (3 min)


### PR DESCRIPTION
Training described only "name and phone number" but docs list five fields: first name, last name, email, phone, and address.