### PR TITLE
fix: correct Local SEO free/paid source counts in training doc

### DIFF
--- a/docusaurus/training/products/local-seo-listings/Manage-Listings-with-Local-SEO.mdx
+++ b/docusaurus/training/products/local-seo-listings/Manage-Listings-with-Local-SEO.mdx
@@ -138,7 +138,7 @@ A breakdown of features across the three listings products: Local SEO, Listing D
 
 | Feature | Local SEO | Listing Distribution | Listing Sync Pro |
 |--------|:---------:|:--------------------:|:-----------------:|
-| Free sync to four listing sources (Google Business Profile, Facebook, Instagram, X) | ✔️ | ✔️ | ✔️ |
+| Free sync to two listing sources (Google Business Profile, Facebook) | ✔️ | ✔️ | ✔️ |
 | My Listing (Free landing page) | ✔️ | ✔️ | ✔️ |
 | Google Business Profile insights | ✔️ | ✔️ | ✔️ |
 | Update and edit business information to sync across sources from one platform | ✔️ | ✔️ | ✔️ |
@@ -155,9 +155,9 @@ A breakdown of features across the three listings products: Local SEO, Listing D
 - **Control of how you appear online** — More control over presentation
 - **Ability to manage duplicate suppression** — Reduce duplicate or incorrect listings
 
-**Free sources (Local SEO)**
+**Local SEO tiers**
 
-The freemium version of Local SEO includes only **Google Business Profile** and **Facebook**. The other sources (Instagram, X, etc.) are available on the Local SEO paid edition.
+Local SEO standard (free) syncs to **2 sources**: **Google Business Profile** and **Facebook**. Local SEO Pro (paid) syncs to **6 sources**: Google Business Profile, Facebook, Instagram, X, Apple, and Bing.
 
 
 ## Step 5: Apply the sales and upsell strategy (4 min)
@@ -188,7 +188,7 @@ Practice the upsell conversation: Lead with the customer activity data you revie
 <FlipCardGrid>
   <FlipCard front="Business Profile" back="Where to make updates. Edits sync across sources from one platform." subtext="Edit hub" />
   <FlipCard front="Data Aggregators" back="Listing Distribution sends data to Data Axle, Neustar Localeze, Foursquare." subtext="3 aggregators" />
-  <FlipCard front="Free Sources" back="Local SEO free tier: Google Business Profile and Facebook only." subtext="Freemium" />
+  <FlipCard front="Local SEO Tiers" back="Standard (free): Google, Facebook. Pro (paid): adds Instagram, X, Apple, Bing—6 sources total." subtext="Freemium vs Pro" />
   <FlipCard front="Upsell" back="Hook on Local SEO value, upsell Distribution and Sync Pro." subtext="Strategy" />
 </FlipCardGrid>
 
@@ -205,7 +205,7 @@ Practice the upsell conversation: Lead with the customer activity data you revie
     { type: "whicharea", principle: "Where would you learn about tracking how customers find listings and what they do?", correctArea: "📊 Customer Activity Tracking", explanation: "Customer Activity Tracking covers how, where, and what customers do." },
     { type: "fillblank", principle: "Listing Distribution sends business data directly to Data Axle, Neustar Localeze, and ___.", before: "", answer: "Foursquare", after: "", hint: "The third primary aggregator named alongside Data Axle and Localeze.", explanation: "Product Tiers lists the three aggregators as Data Axle, Neustar Localeze, and Foursquare." },
     { type: "match", instruction: "Match each product tier to a key feature.", pairs: [{ term: "Local SEO", definition: "Free sync to Google, Facebook; My Listing; insights" }, { term: "Listing Distribution", definition: "Business data sync to Data Axle, Localeze, Foursquare" }, { term: "Listing Sync Pro", definition: "Protection from third party changes; duplicate suppression" }], explanation: "Each tier adds features: Local SEO = base, Distribution = aggregators, Sync Pro = protection and control." },
-    { type: "sort", instruction: "Sort these into Local SEO free sources vs paid sources.", items: [{ label: "Google Business Profile", correctBucket: "free" }, { label: "Facebook", correctBucket: "free" }, { label: "Instagram", correctBucket: "paid" }, { label: "X", correctBucket: "paid" }], buckets: [{ id: "free", label: "Local SEO Free" }, { id: "paid", label: "Local SEO (paid)" }], explanation: "Freemium includes only Google Business Profile and Facebook." },
+    { type: "sort", instruction: "Sort these into Local SEO standard (free) sources vs Local SEO Pro (paid) sources.", items: [{ label: "Google Business Profile", correctBucket: "free" }, { label: "Facebook", correctBucket: "free" }, { label: "Instagram", correctBucket: "paid" }, { label: "X", correctBucket: "paid" }, { label: "Apple", correctBucket: "paid" }, { label: "Bing", correctBucket: "paid" }], buckets: [{ id: "free", label: "Local SEO Standard" }, { id: "paid", label: "Local SEO Pro" }], explanation: "Standard includes only Google Business Profile and Facebook (2 sources). Pro adds Instagram, X, Apple, and Bing for 6 total." },
     { type: "mcq", question: "What is a common misconception among business owners about their listings?", options: ["Listings are too expensive", "Their information is accurate across all sources", "They need multiple platforms", "Listings don't matter"], correctIndex: 1, explanation: "There is often a misconception that business information is accurate across listing sources—it usually isn't." },
     { type: "truefalse", statement: "Listing Sync Pro includes protection from third party changes.", correct: true, explanation: "Listing Sync Pro adds protection from unauthorized edits." },
     { type: "whicharea", principle: "Where would you learn about Data Axle, Localeze, and Foursquare?", correctArea: "📦 Product Tiers", explanation: "Product Tiers covers Listing Distribution and the three aggregators." },


### PR DESCRIPTION
Manage-Listings-with-Local-SEO.mdx stated the free tier synced to four sources (Google, Facebook, Instagram, X), contradicting the FlipCard and Introduction-to-Listing-Management.mdx, which both state the free tier only covers two. Corrected the table, tier summary, FlipCard, and quiz to reflect: Local SEO standard (free) = 2 sources (Google, Facebook); Local SEO Pro (paid) = 6 sources (adds Instagram, X, Apple, Bing).