### PR TITLE
docs: rename Notify an admin to Notify a user and note dynamic user ID support

### DIFF
--- a/docusaurus/docs/automations/automation-steps-reference.mdx
+++ b/docusaurus/docs/automations/automation-steps-reference.mdx
@@ -114,7 +114,7 @@ Steps marked **(draft)** are in development and may change or be removed before 
 
 | Step | Overview | Special Cases | Example Use Cases |
 | --- | --- | --- | --- |
-| Notify an admin | Sends an in-app and email notification to a partner admin. | Limited support for template variables in the message body. | When a high-margin product is deactivated, notify partner admins so they can investigate. |
+| Notify a user | Sends an in-app and email notification to one or more users. The **Users** field accepts a dynamic user ID from a previous step (via **Insert dynamic content**), so notifications follow account ownership instead of a hard-coded recipient. | Limited support for template variables in the message body. | In an account template, notify the account owner pulled from an earlier step so the same automation works across every account. |
 | Notify a salesperson | Sends an in-app and email notification to a salesperson. | Available on account-scoped triggers. Limited support for template variables in the message body. | When an opportunity is created for a French-language client, notify French-fluent salespeople. |
 | Notify a digital agent | Sends an in-app and email notification to a fulfillment agent. | Available on account-scoped triggers. Limited support for template variables in the message body. | When a website-design product is activated, notify a fulfillment agent who can design websites. |
 | Notify all account users | Sends an in-app and email notification to every user on the account. | Available on account-scoped triggers. | When a service interruption is scheduled, notify all users on affected accounts. |


### PR DESCRIPTION
## What & why

The Notifications step previously documented as "Notify an admin" has been renamed to
**"Notify a user"** and now accepts a **dynamic user ID** from a previous automation
step. This lets account templates route notifications to the correct owner instead of
a hard-coded admin — "configure once, deploy everywhere." The steps reference was out
of date on both the name and the new capability.

## Changes

- Renamed **Notify an admin** → **Notify a user** in the Notifications table of
  `automation-steps-reference.mdx`.
- Documented that the **Users** field accepts a dynamic user ID (via **Insert dynamic
  content**), with an account-template example use case.

## Notes

- Single table-row edit — no frontmatter, links, tags, or embeds touched.
- Sits above the existing "Notify a salesperson" / "Notify a digital agent" rows,
  which remain separate steps.