### PR TITLE
docs: document Google and Microsoft sign-in and sign-up for Business App

### DIFF
--- a/docusaurus/docs/accounts/manage-business-app/business-app-access.mdx
+++ b/docusaurus/docs/accounts/manage-business-app/business-app-access.mdx
@@ -107,6 +107,22 @@ You can find the login URL in the customer’s account under the Business App se
 2. **Send via secure method** (email, encrypted message, or phone)
 3. **Follow up** to confirm successful login and initial setup
 
+### Sign-in options on the login page
+
+When customers visit their Business App URL, the login page offers a few ways to sign in:
+
+- **Email and password**
+- **Sign in with Google**
+- **Sign in with Microsoft**
+
+When a customer chooses **Sign in with Google** or **Sign in with Microsoft**, they authenticate on the provider's sign-in screen and are matched to their Business App account by the verified email address — so they don't need to remember a separate Business App password. The same options are available when creating an account, so a customer who signs up with Google or Microsoft can return and sign in the same way.
+
+:::info
+Google and Microsoft sign-in match a customer to an account by email address. The email on the Google or Microsoft account must match the email on the customer's Business App user for sign-in to succeed.
+:::
+
+If **Create Account** is enabled, the login page also shows a **Create an account** option so new customers can self-register. See [Self-Signup](./self-signup.mdx) for details.
+
 ## How to configure business app features
 
 ### Dashboard customization

--- a/docusaurus/docs/accounts/manage-business-app/self-signup.mdx
+++ b/docusaurus/docs/accounts/manage-business-app/self-signup.mdx
@@ -32,6 +32,23 @@ Self-signup is designed to reduce friction and get customers into Business App a
 - **Contact email**: The email address for the primary user
 - **Company name**: Used to look up the business via Google Places
 
+### Sign up with Google or Microsoft
+
+Customers can start signup in one of two ways:
+
+- **Enter an email address** directly on the signup form, or
+- **Sign up with Google** or **Sign up with Microsoft** using an existing account
+
+When a customer chooses **Sign up with Google** or **Sign up with Microsoft**, they authorize Business App on Google's or Microsoft's sign-in screen, and their verified email address is used to create the account. Because the account provider has already confirmed the email, the customer skips the separate email verification step and lands in the signup flow right away. They still confirm their company name so the platform can enrich the business profile through Google Places.
+
+:::info
+The email address is the only detail pulled from the Google or Microsoft account — no contacts, calendar, or other data is accessed.
+:::
+
+:::tip
+Social sign-up removes password creation and email verification from the flow, which reduces friction and can improve signup completion. Customers can return later and sign in with the same Google or Microsoft account from your Business App login page.
+:::
+
 ### Automatic business data enrichment
 
 When a customer enters their company name, the system searches Google Places to find their business:
@@ -53,7 +70,7 @@ When a customer completes signup, the platform sets up AI in two ways:
 
 This means the AI is ready to go the moment the customer lands in Business App.
 
-**In the signup flow**, after the customer verifies their email, they're shown a live preview of their AI Receptionist — already trained on the business profile and website data captured during signup. They can chat with it immediately and see how it responds *as their business* before they even reach the Business App homepage. This gives new customers an instant "wow" moment and demonstrates the value of AI from their very first interaction.
+**In the signup flow**, after the customer verifies their email (or signs up with a Google or Microsoft account, which skips verification), they're shown a live preview of their AI Receptionist — already trained on the business profile and website data captured during signup. They can chat with it immediately and see how it responds *as their business* before they even reach the Business App homepage. This gives new customers an instant "wow" moment and demonstrates the value of AI from their very first interaction.
 
 The AI Employee Preview can be turned on or off per market in **Customize Business App** > **Add Your Clients**. See [Add Your Customers Settings](/docs/administration/platform-settings/customize-business-app/add-your-customers-settings#how-do-i-show-new-signups-a-preview-of-their-ai-receptionist) for details.
 
@@ -242,6 +259,12 @@ Navigate to **Partner Center** > **Accounts** > **Manage Business App** > **Cust
 <summary>Can customers sign up without a direct link?</summary>
 
 Yes. Enable the **Show Create Account** option to add a registration link to your Business App login page. Customers can then click **Create Account** to register.
+</details>
+
+<details>
+<summary>Can customers sign up with a Google or Microsoft account?</summary>
+
+Yes. On the signup form, customers can enter an email address or choose **Sign up with Google** or **Sign up with Microsoft**. When they use a Google or Microsoft account, the verified email address on that account is used to create their Business App account, and they skip the separate email verification step. Only the email address is used — no other account data is accessed. Customers can return later and sign in with the same account from your Business App login page.
 </details>
 
 <details>


### PR DESCRIPTION
## What & why

Documents **Microsoft sign-in / sign-up for Business App** (WOW-2189), now available on the Business App login page alongside the existing **Google** option (WARP-1984) and email/password. Neither social option was documented before, so this covers both.

## Changes

- **`business-app-access.mdx`** — new "Sign-in options on the login page" section: email, **Sign in with Google**, **Sign in with Microsoft**. Notes that social sign-in matches a customer to their account by verified email (no separate Business App password), and links to Self-Signup.
- **`self-signup.mdx`** — new "Sign up with Google or Microsoft" subsection + FAQ entry: the verified email creates the account and skips the separate email-verification step; customers can return and sign in the same way. Small consistency fix to the AI Receptionist preview line.

Written in present tense as released. Only the verified email address is used — no other provider data is accessed.

## Notes for reviewers

- Related release note (Confluence, held in draft until launch): "Release: Sign in and sign up for Business App with Microsoft."
- Sign-in itself is handled by the auth/login service + galaxy frontend; this PR is docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
