### PR TITLE
Docs: Reorg settings to use the left menu (AUT-4405)

### DIFF
--- a/docusaurus/docs/automations/automation-permissions-error.mdx
+++ b/docusaurus/docs/automations/automation-permissions-error.mdx
@@ -28,7 +28,7 @@ An automation runs on behalf of whoever turned it on. If that person's access ch
 ## How to fix it
 
 1. Open the automation showing the banner.
-2. Go to the **Settings** tab.
+2. In the left menu, select **Advanced**.
 3. Click **Transfer Permissions**.
 4. Sign in and approve the requested permissions.
 

--- a/docusaurus/docs/automations/creating-and-configuring-automations.mdx
+++ b/docusaurus/docs/automations/creating-and-configuring-automations.mdx
@@ -1,6 +1,6 @@
 ---
 title: Creating and configuring automations
-description: Learn how to create, configure, and manage automation settings including entry settings, error handling, and duplication.
+description: Learn how to create, configure, and manage automation settings including entry settings, error handling, permissions, and duplication.
 sidebar_position: 2
 ---
 
@@ -10,7 +10,7 @@ This guide covers the complete process of creating automations and configuring t
 
 ## Automation settings
 
-Several settings can be configured for each automation you create. You can access these settings in the **Settings** tab in your automation.
+Several settings can be configured for each automation you create. You can access these settings in the **Advanced** section of the left menu in your automation.
 
 ![Automation Settings Tab](./img/automations/automation-settings-tab.jpg)
 
@@ -35,6 +35,12 @@ You can have many steps in an automation workflow. If at any point a step fails 
 **Options:**
 - **Ignore the error and continue the automation**: If a step fails, the automation will log an error (viewable in the Activity table) and move on to the next step of the workflow.
 - **Stop that specific automation run**: If a step fails, the automation run will completely stop for that account. The automation will not move on to the next step of the workflow. You may manually resume the run from any step in the workflow from the automation activity section.
+
+### Permissions
+
+An automation runs on behalf of whoever turned it on. If that person's access changes — for example, they're deactivated, their role changes, or their consent is revoked — the automation stops processing new triggers until someone re-authorizes it.
+
+To transfer permissions to your own profile, click **Transfer Permissions** and sign in to approve the requested access. See [Fixing "Automation requires valid permissions to run"](./automation-permissions-error.mdx) for the full troubleshooting steps.
 
 ### Timezone configuration
 

--- a/docusaurus/docs/automations/troubleshooting-automations.mdx
+++ b/docusaurus/docs/automations/troubleshooting-automations.mdx
@@ -18,7 +18,7 @@ Automations only run when the toggle at the top-right of the automation editor i
 
 ### 2. The entry setting is "Run once per account"
 
-By default, an automation only runs the first time the trigger conditions are met for a given account. If you need it to run every time, change **Entry settings** in the automation's **Settings** tab to **Run every time**.
+By default, an automation only runs the first time the trigger conditions are met for a given account. If you need it to run every time, change **Entry settings** in the automation's **Advanced** section to **Run every time**.
 
 ### 3. A previous step threw an error and stopped the run
 


### PR DESCRIPTION
## JIRA
[AUT-4405: Reorg settings to use the left menu](https://vendasta.jira.com/browse/AUT-4405)

## Classification
UI/UX change — the automation Settings tab is reorganized into a left-menu **Advanced** section that groups entry settings, error handling, and permissions.

## Repo targeted
Partner Center (Automations docs)

## Summary of documentation updates
- `docusaurus/docs/automations/creating-and-configuring-automations.mdx`: Updated the settings navigation reference from the **Settings** tab to the **Advanced** section (left menu); added a new **Permissions** subsection (grouped with Entry settings and Error handling per the ticket's acceptance criteria), sourced from the existing permissions-error article; updated the frontmatter description.
- `docusaurus/docs/automations/automation-permissions-error.mdx`: Updated the "How to fix it" steps to reference the **Advanced** section instead of the **Settings** tab.
- `docusaurus/docs/automations/troubleshooting-automations.mdx`: Updated an Entry-settings navigation reference from the **Settings** tab to the **Advanced** section.

## Existing vs. new docs
Updated existing documentation only. No new page was created — the reorg fits cleanly into the existing settings article, and the Permissions concept already had a home in the existing troubleshooting article.

## Placement reasoning
All three edited files already documented the pre-reorg **Settings** tab and/or the permissions/re-authorization flow, so updates were made in place rather than creating a new article.

## Acceptance criteria coverage
- ✅ "Move Settings to the new sub-tab structure" — all navigation references to the old **Settings** tab now point to the **Advanced** section in the left menu.
- ✅ "The Advanced section includes the Entry settings, Error handling, and Permissions" — added a **Permissions** subsection to `creating-and-configuring-automations.mdx` alongside the existing Entry settings and Error handling subsections, cross-linked to the full permissions troubleshooting guide.
- N/A "Use Galaxy" — a design-system implementation detail with no documentation impact.

## Figma / images
The ticket included screenshots as Jira attachments, but they're behind Jira authentication and weren't accessible from this session. I relied on the ticket's text and acceptance criteria plus existing docs. The `./img/automations/automation-settings-tab.jpg` screenshot referenced in `creating-and-configuring-automations.mdx` may now be out of date if the visual tab structure changed — flagging for a follow-up since I can't capture new screenshots without product access.

## Skills used
None of the repo's slash-command skills matched this task directly; changes were made by directly editing the affected articles and manually re-checking frontmatter, links, and closed tags against this repo's content guidelines (no `>` characters, closed `:::`/tags, etc.).

## Assumptions / limitations
- The **Permissions** content added here is based entirely on the existing "Transfer Permissions" flow already documented in `automation-permissions-error.mdx` — no new functionality was invented.
- Did not change the literal in-product banner copy quoted in `automation-permissions-error.mdx` ("...in the settings tab...") since that's a direct quote of in-app text and I have no confirmation the banner copy itself was updated — only the navigation instructions below it.
- Could not verify the GitHub PR(s) linked to this Jira story to identify a reviewer — this session's GitHub access is scoped to the `businessapp-docs` and `partnercenter-docs` repos only, not the engineering repo where the linked code PRs live. No reviewer was requested; please assign one manually.

---
@ahnikakuse @haleyserrano @maryam6samadi

---
_Generated by [Claude Code](https://claude.ai/code/session_01TH9mHWfisamFBpGhZPg76T)_