### PR TITLE
docs: add Social trigger section to automation triggers reference

### DIFF
--- a/docusaurus/docs/automations/automation-triggers-reference.mdx
+++ b/docusaurus/docs/automations/automation-triggers-reference.mdx
@@ -77,6 +77,12 @@ Triggers marked **(draft)** are in development and may change or be removed befo
 | --- | --- | --- | --- |
 | There's activity on a campaign email | Starts the workflow when a campaign email is opened or clicked. Open and click events can be differentiated. | Only CTA clicks are counted — you can't differentiate which specific link was clicked. If the account has multiple users, the trigger fires only for the first user to click unless **Run multiple times per account** is enabled. | When a lead clicks an email in a cold-outreach campaign, assign a salesperson and mark the account as a hot lead. |
 
+## Social
+
+| Trigger | Overview | Special Cases | Example Use Cases |
+| --- | --- | --- | --- |
+| A social comment is received | Starts the workflow when a new comment is received on a post published to a connected social network (Instagram, Facebook, or LinkedIn). | You can select which networks the trigger listens to. | As an SMB, reply to social network comments immediately upon receipt. |
+
 ## Fulfillment
 
 | Trigger | Overview | Special Cases | Example Use Cases |


### PR DESCRIPTION
## Summary

Adds a new **## Social** section to the automation triggers reference doc, documenting the **A social comment is received** trigger.

The trigger starts a workflow when a new comment is received on a post published to a connected social network (Instagram, Facebook, or LinkedIn). Partners can select which networks the trigger listens to.

## Changes

- `docusaurus/docs/automations/automation-triggers-reference.mdx`: new `## Social` section modeled after the existing sections, with one trigger row (Trigger / Overview / Special Cases / Example Use Cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)