### PR TITLE
Docs: add FAQ on support ticket merging (VTIC-77)

### DIFF
--- a/docusaurus/docs/getting-started/partner-troubleshooting-guide.mdx
+++ b/docusaurus/docs/getting-started/partner-troubleshooting-guide.mdx
@@ -287,3 +287,9 @@ Support on-Demand handles technical platform issues, while Vendasta Services man
 
 Platform access issues can be caused by browser cache problems, network restrictions, or account permissions. Try clearing your cache first, then generate a HAR file if issues persist. Your network may be blocking specific domains required for platform functionality.
 </details>
+
+<details>
+<summary>Why was my support ticket merged with another ticket?</summary>
+
+If your ticket is related to another open request, a Support Agent may merge it into that ticket. You'll get a message letting you know your ticket was merged, and your conversation continues on the ticket it was merged into.
+</details>


### PR DESCRIPTION
## JIRA

[VTIC-77 — Ticket merging](https://vendasta.jira.com/browse/VTIC-77)

## Classification

- **Type:** Feature behavior change (support ticket lifecycle)
- **Product impact:** Partner-facing only. This is a new capability for Vendasta support agents (merging duplicate tickets), but it has one partner-visible side effect: the ticket requester now gets a notification when their ticket is merged, instead of the ticket simply disappearing.
- **Repo targeted:** Partner Center docs only. Business App was evaluated and does not need an update — see below.

## Summary of changes

Added one FAQ entry to the existing **Partner Troubleshooting Guide** explaining why a partner's support ticket may get merged with another and what happens when it does (confirmation message, conversation continues on the target ticket).

## Existing docs vs. new page

- **Updated existing page:** `docusaurus/docs/getting-started/partner-troubleshooting-guide.mdx`
- **Why no new page:** The guide already has a "Frequently Asked Questions" section covering post-submission ticket behavior (e.g., HAR files, refunds, routing). A single FAQ entry fits cleanly there; there's no existing "ticket lifecycle" page to warrant standing up a new one for this single detail.

## Acceptance criteria coverage

From the story description:
- ✅ "Copy the contents into the target ticket with a response letting the customer know their ticket has been merged" → documented as: requester gets a message confirming the merge, conversation continues on the target ticket.
- ⏭️ "Close the current ticket with an internal note" — this is an internal, agent-facing note, not partner-visible, so it's intentionally omitted from partner-facing docs.
- ⏭️ Double-click merge guard — internal safeguard, not partner-visible, omitted.

## Why Business App was not updated

Searched `businessapp-docs` for any existing "contact support" / ticketing feature for business owners — none exists. Business App is a gray-label product; end users (business owners) don't submit tickets directly to Vendasta support the way partners do, so this change has no Business App-facing surface.

## Visuals

No Figma links or images were provided with this story; documentation is based on the JIRA description and the implementing developer's completion comment only.

## Skills / tools used

- Atlassian MCP (`getJiraIssue`) to pull the story, parent epic, and completion comment
- Explore agents to search both `businessapp-docs` and `partnercenter-docs` for existing related documentation
- Manual edit (no generation skill matched this small FAQ-only change)

## Assumptions & limitations

- The linked code PR (`vendasta/vticket#39`) is outside this session's repo access scope, so documentation is based solely on the JIRA story description and Brent Yates's completion comment, not the diff itself.
- Reviewer: could not confidently resolve Brent Yates's GitHub username from the search results (many ambiguous `byates*` accounts), so no reviewer was auto-assigned. Please assign Brent Yates manually.
- Refinements mentioned in the completion comment (requester-only recipients, `support@` fallback, newest-message threading) are tracked separately in VTIC-114 and are not yet documented, since they aren't implemented yet.

cc @ahnikakuse @haleyserrano @maryam6samadi


---
_Generated by [Claude Code](https://claude.ai/code/session_01UKcYhYRJVA23gWXa1jD7ks)_