### PR TITLE
Docs: chart/graph responses for Conversations AI (DALE-943)

### DIFF
--- a/docusaurus/docs/business-app/conversations/conversations-ai/index.mdx
+++ b/docusaurus/docs/business-app/conversations/conversations-ai/index.mdx
@@ -54,6 +54,7 @@ The AI employee functions as an automated receptionist with these capabilities:
 - Replies to Facebook and Instagram direct messages
 - Processes web chat interactions on business websites
 - Manages email inquiries through unified Conversations interface
+- Includes chart or graph images alongside text when relevant data is available
 
 ### **Lead Information Collection**
 - Captures contact details from all communication channels
@@ -174,6 +175,9 @@ The AI employee accesses business profile information (location, hours, services
 
 **Q: How will users know if they received a message?**
 New messages appear live in Business App without page refreshing. Users can receive instant email notifications for new messages or daily digest emails.
+
+**Q: Can the AI include charts or images in its responses?**
+Yes. When relevant data is available, the AI can include a chart or graph image with its response instead of describing the numbers in text. Line and bar charts are supported, and they appear inline across all supported channels.
 
 **Q: What websites support web chat?**
 Web chat installs on any website where custom code can be added to the `<head>` element. A WordPress plugin is provided for easy WordPress installation.


### PR DESCRIPTION
## Summary

[DALE-943](https://vendasta.jira.com/browse/DALE-943) — "Support Data Visualization Generation (Charts/Graphs) as Output from AI Assistants." The AI receptionist can now generate a chart or graph image (line or bar) from data it has access to and return it as an image attachment in its response, across Web Chat, Email, SMS, WhatsApp, Facebook, and Instagram. This is a passive response-format enhancement — there is no new setting for partners to configure on behalf of clients.

**Classification:** Feature behavior change (AI response format)
**Repo:** Partner Center (partner/agency facing)

## What changed

- `docusaurus/docs/business-app/conversations/conversations-ai/index.mdx` — added a bullet under **Message Response Automation** and a new FAQ entry (under "Usage & Notifications") covering the new chart/graph response capability.

Existing doc was updated in place; no new page was created.

## Placement reasoning

Researched `docusaurus/docs/ai/`, `docusaurus/docs/business-app/conversations/`, and `docusaurus/docs/conversations/` before writing anything. The `docusaurus/docs/conversations/` tree turned out to document a different, unrelated internal partner-messaging feature, so it was ruled out. `docusaurus/docs/business-app/conversations/conversations-ai/index.mdx` is the precise match — it already documents the AI receptionist's per-channel behavior across exactly the channel set this feature touches, in a "Message Response Automation" section and FAQ. No page currently documents AI response format (text vs. image), so this was a gap rather than a stale claim. A standalone page wasn't justified given the feature is a narrow, non-configurable enhancement to existing response behavior.

## Acceptance criteria coverage

| Acceptance criterion (from ticket) | Covered |
|---|---|
| Chart images returned as attachments in responses (streaming + non-streaming) | ✅ described as appearing "inline" with the response |
| Delivered across channels | ✅ web chat, SMS, WhatsApp, email, Facebook, Instagram covered by "all supported channels" |
| Chart types (line, bar) | ✅ stated explicitly per the resolved RFC scope |
| Backward compatibility | Not called out explicitly — not necessary for a partner-facing capability doc since no existing behavior changes |

Internal implementation details (proto changes, transport chunks, GCS storage, per-channel gating) are out of scope for this doc and were intentionally omitted.

## Visuals

No Figma links were provided on the ticket. Two screenshots attached directly to DALE-943 (2026-07-06) confirm the feature renders correctly in both Inbox and Web Chat; used only to confirm shipped behavior, not transcribed into the doc.

## Skills used

- Manual review against this repo's markdown rules (no `>` character, sentence-case headings) — confirmed no violations introduced.

## Assumptions / limitations

- The exact trigger condition for when the AI generates a chart vs. answers in text isn't spelled out in the ticket beyond "when relevant data is available" — worded conservatively to avoid inventing a configuration option that doesn't exist.
- GitHub access for this automation is scoped to `businessapp-docs` and `partnercenter-docs` only, so the linked engineering PRs (in `ai-assistants`, `conversation`, `galaxy`) could not be inspected to resolve a GitHub reviewer username. All DALE-943 subtasks are assigned to **En Zhou (ezhou@vendasta.com)** in JIRA — please add as reviewer manually if appropriate.

cc @ahnikakuse @haleyserrano @maryam6samadi

---
_Generated by [Claude Code](https://claude.ai/code/session_014eF3wCUhAbK2uwLrow3JWU)_

[DALE-943]: https://vendasta.jira.com/browse/DALE-943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ