### PR TITLE
docs: verify and update 5 flagged review-due articles

### DIFF
--- a/docusaurus/docs/marketing/email-settings/email-authentication/adding-spf-dkim-dmarc-records-cpanel-namecheap.mdx
+++ b/docusaurus/docs/marketing/email-settings/email-authentication/adding-spf-dkim-dmarc-records-cpanel-namecheap.mdx
@@ -5,18 +5,16 @@ description: Learn how to add SPF, DKIM, and DMARC Records to your domain using 
 sidebar_position: 2
 ---
 
-# Add SPF, DKIM, and DMARC Records (cPanel Namecheap)
-
 This guide will walk you through the process of adding SPF, DKIM, and DMARC records to your domain using cPanel with Namecheap as your domain host.
 
-## Before You Begin
+## Before you begin
 
 To follow this guide, you will need:
 - A domain purchased through Namecheap
 - Access to your cPanel account
 - The SPF, DKIM, and DMARC record values provided by your email service provider
 
-## Adding DNS Records in cPanel
+## Adding DNS records in cPanel
 
 ### Step 1: Log into your Namecheap account
 
@@ -24,52 +22,52 @@ Start by logging into your Namecheap account at [namecheap.com](https://www.name
 
 ### Step 2: Access cPanel
 
-1. Navigate to "Domain List" in your dashboard
-2. Find the domain you want to modify and click "Manage"
-3. Select the "Advanced DNS" tab
+1. Navigate to `Domain List` in your dashboard
+2. Find the domain you want to modify and click `Manage`
+3. Select the `Advanced DNS` tab
 
 ![Navigate to Advanced DNS in Namecheap](../img/cpanel-namecheap-guide/image1.jpg)
 
-### Step 3: Add SPF Record
+### Step 3: Add SPF record
 
 The SPF (Sender Policy Framework) record helps prevent email spoofing by specifying which mail servers are authorized to send email from your domain.
 
-1. In the "Host Records" section, click "Add New Record"
-2. Select "TXT Record" from the dropdown menu
-3. For the "Host" field, enter @ (representing your root domain)
-4. For the "Value" field, enter your SPF record (typically looks like `v=spf1 include:_spf.mailgun.org ~all`)
-5. Set TTL (Time to Live) to "Automatic"
-6. Click "Save Changes"
+1. In the `Host Records` section, click `Add New Record`
+2. Select `TXT Record` from the dropdown menu
+3. For the `Host` field, enter @ (representing your root domain)
+4. For the `Value` field, enter your SPF record (typically looks like `v=spf1 include:_spf.mailgun.org ~all`)
+5. Set TTL (Time to Live) to `Automatic`
+6. Click `Save Changes`
 
 ![Add SPF Record](../img/cpanel-namecheap-guide/image2.jpg)
 
-### Step 4: Add DKIM Record
+### Step 4: Add DKIM record
 
 DKIM (DomainKeys Identified Mail) adds a digital signature to your emails to verify they haven't been tampered with.
 
-1. Click "Add New Record"
-2. Select "TXT Record" from the dropdown menu
-3. For the "Host" field, enter your DKIM selector (often provided by your email service provider, e.g., `mail._domainkey`)
-4. For the "Value" field, enter your DKIM value (typically a long string beginning with `v=DKIM1;`)
-5. Set TTL to "Automatic"
-6. Click "Save Changes"
+1. Click `Add New Record`
+2. Select `TXT Record` from the dropdown menu
+3. For the `Host` field, enter your DKIM selector (often provided by your email service provider, e.g., `mail._domainkey`)
+4. For the `Value` field, enter your DKIM value (typically a long string beginning with `v=DKIM1;`)
+5. Set TTL to `Automatic`
+6. Click `Save Changes`
 
 ![Add DKIM Record](../img/cpanel-namecheap-guide/image3.jpg)
 
-### Step 5: Add DMARC Record
+### Step 5: Add DMARC record
 
 DMARC (Domain-based Message Authentication, Reporting & Conformance) tells receiving servers what to do with emails that fail SPF or DKIM verification.
 
-1. Click "Add New Record"
-2. Select "TXT Record" from the dropdown menu
-3. For the "Host" field, enter `_dmarc`
-4. For the "Value" field, enter your DMARC policy (e.g., `v=DMARC1; p=none; rua=mailto:dmarc@yourdomain.com`)
-5. Set TTL to "Automatic"
-6. Click "Save Changes"
+1. Click `Add New Record`
+2. Select `TXT Record` from the dropdown menu
+3. For the `Host` field, enter `_dmarc`
+4. For the `Value` field, enter your DMARC policy (e.g., `v=DMARC1; p=none; rua=mailto:dmarc@yourdomain.com`)
+5. Set TTL to `Automatic`
+6. Click `Save Changes`
 
 ![Add DMARC Record](../img/cpanel-namecheap-guide/image4.jpg)
 
-### Step 6: Verify Your Records
+### Step 6: Verify your records
 
 After adding all your records, your DNS management page should show all three records (SPF, DKIM, and DMARC) as shown below:
 
@@ -84,7 +82,7 @@ If you encounter issues with your email authentication after setting up these re
 3. Use an online SPF/DKIM validator tool to check your configuration
 4. Contact your email service provider for assistance
 
-## Additional Tips
+## Additional tips
 
 - Start with a cautious DMARC policy (`p=none`) to monitor without affecting email delivery
 - Regularly check your DMARC reports to ensure everything is working correctly
@@ -92,7 +90,7 @@ If you encounter issues with your email authentication after setting up these re
 
 ![Final DNS Configuration](../img/cpanel-namecheap-guide/image6.jpg)
 
-## Next Steps
+## Next steps
 
 After successfully setting up your SPF, DKIM, and DMARC records, you should:
 

--- a/docusaurus/docs/marketing/email-settings/email-authentication/adding-spf-dkim-dmarc-records-godaddy.mdx
+++ b/docusaurus/docs/marketing/email-settings/email-authentication/adding-spf-dkim-dmarc-records-godaddy.mdx
@@ -1,45 +1,43 @@
 ---
-title: Guide - add SPF, DKIM, and DMARC records (GoDaddy)
+title: Add SPF, DKIM, and DMARC records (GoDaddy)
 sidebar_label: Add SPF, DKIM, DMARC Records (GoDaddy)
 sidebar_position: 1
 description: Learn how to add SPF, DKIM, and DMARC records on GoDaddy to improve email deliverability
 ---
 
-# Guide - Add SPF, DKIM, & DMARC Records (GoDaddy)
-
 Before proceeding with the instructions below, follow this first and then continue with this guide: [Connect Domain](../connecting-domains)
 
-## Add SPF Record
+## Add SPF record
 
 When adding the verification records to your GoDaddy domain, note that GoDaddy will automatically add .yourdomain.com to the end of any hostnames added. While our records include your domain in the hostname, it should be removed before adding it to your DNS records. 
 
-A hostname in our system that reads **@.yourdimain.com** would sinmply be added as **@** to your DNS records.
+A hostname in our system that reads `@.yourdomain.com` would simply be added as `@` to your DNS records.
 
 1. Go to your GoDaddy account
 2. Navigate to your Domain section
 3. Click on Manage DNS
 4. Look for the DNS records management section
-5. Add the required SPF records found in Partner Center > Marketing > Email Settings > SPF. This will be a TXT record.
+5. Add the required SPF records found in `Partner Center` → `Marketing` → `Email Settings` → `SPF`. This will be a TXT record.
 
-## Adding DKIM Records
-
-1. Go to your GoDaddy account
-2. Navigate to your Domain section
-3. Click on Manage DNS
-4. Look for the DNS records management section
-5. Add the required SPF records found in Partner Center > Marketing > Email Settings > DKIM. There are three seperate records to be added as CNAME records.
-
-## Adding DMARC Record
+## Adding DKIM records
 
 1. Go to your GoDaddy account
 2. Navigate to your Domain section
 3. Click on Manage DNS
 4. Look for the DNS records management section
-5. Add the required SPF records found in Partner Center > Marketing > Email Settings > DMARC. This will be added a TXT record.
+5. Add the required DKIM records found in `Partner Center` → `Marketing` → `Email Settings` → `DKIM`. There are three separate records to be added as CNAME records.
+
+## Adding DMARC record
+
+1. Go to your GoDaddy account
+2. Navigate to your Domain section
+3. Click on Manage DNS
+4. Look for the DNS records management section
+5. Add the required DMARC records found in `Partner Center` → `Marketing` → `Email Settings` → `DMARC`. This will be added as a TXT record.
 
 ## Validate your DNS records
 
 - DNS changes can take up to 48 hours to propagate throughout the internet
-- From Partner Center > Marketing > Email Settings check if the email domain has a green check mark beside it. This will indicate that the records have been successfully validated.
+- From `Partner Center` → `Marketing` → `Email Settings` check if the email domain has a green checkmark beside it. This indicates that the records have been successfully validated.
 - If you're experiencing issues with email deliverability after adding these records, please wait at least 48 hours before troubleshooting further
 - For additional help with email configuration, contact GoDaddy support or refer to their documentation

--- a/docusaurus/docs/marketing/email-settings/email-settings-requirements.mdx
+++ b/docusaurus/docs/marketing/email-settings/email-settings-requirements.mdx
@@ -5,15 +5,13 @@ sidebar_label: Email Settings Requirements
 sidebar_position: 2
 ---
 
-# Email settings requirements
-
 To successfully send marketing emails through the Vendasta platform, you must meet several technical and legal requirements.
 
-## Technical Requirements
+## Technical requirements
 
-### Custom Domain Email Required
+### Custom domain email required
 
-Under **Partner Center > Marketing > Email Settings** are DNS authentication settings that help ensure your emails are delivered successfully and avoid spam filters.
+Under `Partner Center` → `Marketing` → `Email Settings` are DNS authentication settings that help ensure your emails are delivered successfully and avoid spam filters.
 
 **Domain Requirements:**
 - **Custom Domain Required** - You must have a custom domain email address (e.g., yourname@yourbusiness.com)
@@ -30,7 +28,7 @@ You cannot use authentication records with free email providers such as:
 
 If you don't own a custom domain, consider purchasing one through a domain registrar such as GoDaddy, Namecheap, or your hosting provider. A custom domain allows you to create professional email addresses and implement proper email authentication.
 
-### DNS Authentication Records
+### DNS authentication records
 
 You must configure these authentication records in your DNS:
 - **SPF (Sender Policy Framework)** - Authorizes Vendasta to send emails on behalf of your domain
@@ -39,9 +37,9 @@ You must configure these authentication records in your DNS:
 
 Learn how to set up these records in [Email Authentication](/marketing/email-settings/email-authentication).
 
-## Legal Compliance Requirements
+## Legal compliance requirements
 
-### CAN-SPAM Law Compliance
+### CAN-SPAM law compliance
 
 All commercial emails sent through the platform must comply with CAN-SPAM Act requirements:
 
@@ -57,16 +55,16 @@ All commercial emails sent through the platform must comply with CAN-SPAM Act re
 - **Unsubscribe Option** - Every email must include a working unsubscribe mechanism
 - **Honor Opt-Outs** - Unsubscribe requests must be processed within 10 business days
 
-### Required Business Information
+### Required business information
 
-Configure your business information in **Partner Center > Administration > Customize > Partner Defaults**:
+Configure your business information in `Partner Center` → `Administration` → `Customize` → `Partner Defaults`:
 
 - **Business Name** - Legal business name or DBA
 - **Complete Mailing Address** - Street address, city, state, ZIP code, country
 - **Contact Information** - Business phone number and email address
 - **Sender Details** - Default "From" name and email address for campaigns
 
-## User Verification Requirements
+## User verification requirements
 
 All users sending emails must have verified email addresses:
 - **Email Verification** - All platform users must verify their email addresses
@@ -75,20 +73,20 @@ All users sending emails must have verified email addresses:
 
 Learn more about [Email Verification](/administration/my-account/my-team/email-verification) requirements.
 
-## Email Content Requirements
+## Email content requirements
 
-### Size Limitations
+### Size limitations
 - **HTML Character Limit** - Email templates cannot exceed 32,000 characters of HTML source code
 - **Template Optimization** - Keep content concise and optimize images for faster loading
 - **Error Handling** - Emails exceeding the limit will fail to send with a character count error
 
-### Content Best Practices
+### Content best practices
 - **Professional Design** - Use clean, professional email templates
 - **Mobile Optimization** - Ensure emails display properly on mobile devices
 - **Clear Call-to-Actions** - Include clear, compelling calls-to-action
 - **Relevant Content** - Send targeted, valuable content to your audience
 
-## Getting Started Checklist
+## Getting started checklist
 
 Before sending your first campaign:
 

--- a/docusaurus/docs/marketing/email-settings/update-email-settings.mdx
+++ b/docusaurus/docs/marketing/email-settings/update-email-settings.mdx
@@ -22,10 +22,10 @@ To prevent emails from being sent on someone's behalf unintentionally, email ser
 
 To update email campaign settings:
 
-1. Go to **Partner Center** > **Marketing** > **[Email Settings](https://partners.vendasta.com/campaign-settings)**.  
+1. Go to `Partner Center` → `Marketing` → [`Email Settings`](https://partners.vendasta.com/campaign-settings).  
 2. Enter the correct Email 'Send As' Information for your campaigns. 
    :::note
-   **Note:** When a salesperson is assigned to an account, the salesperson's email address and name will be used instead of these settings.
+   **Note:** When a salesperson is assigned to an account, the salesperson's email address and name is used instead of these settings.
    :::
 3. Verify the SPF, DKIM, and DMARC Validations under your domain. A green circle with a checkmark means that the record is validated correctly; a red circle with an exclamation mark means that the record is invalid.
 4. For each invalid record, update your DNS record with the correct entries. For assistance, you can contact your DNS service provider.
@@ -52,7 +52,7 @@ To update email campaign settings:
   Update settings
 </a>
 
-### **Important Notes**
+## Important notes
 
 Setting Vendasta as a trusted service provider does not guarantee that emails will not be flagged as spam. To ensure your emails are delivered successfully, check the content and subject lines of your emails. Make sure to avoid:
 

--- a/docusaurus/docs/marketing/forms/index.mdx
+++ b/docusaurus/docs/marketing/forms/index.mdx
@@ -11,28 +11,28 @@ Forms let you capture leads, qualify prospects, and trigger automated follow-ups
 
 ## What you can build
 
-- **Lead generation forms**: Capture contact information that automatically creates CRM records. Start with ready-to-use templates including Lead Generation, Newsletter Signup, or the new Acquisition Widget template for complex lead workflows.
+- **Lead generation forms**: Capture contact information that automatically creates CRM records. Start with ready-to-use templates including Lead Generation, Newsletter Signup, or the Acquisition Widget template for complex lead workflows.
 - **Multi-step forms with sections**: Organize longer forms into sections for better user experience. Perfect for detailed intake forms, qualification questionnaires, or multi-part applications.
 - **File upload forms**: Collect documents, images, or proofs of work directly through your forms. Files automatically attach to contact and company records with AI-generated summaries.
 - **Automated workflow forms**: Trigger complete automation sequences when forms are submitted - create accounts, generate snapshot reports, start campaigns, assign salespeople, and activate products automatically.
 
 ## Quick start guide
 
-### Create from Template
-1. Go to **Marketing → Forms**
-2. Click **Create form** and browse available templates
-3. Select **Use template** to generate a form with pre-configured fields and automations
+### Create from template
+1. Go to `Marketing` → `Forms`
+2. Click `Create form` and browse available templates
+3. Select `Use template` to generate a form with pre-configured fields and automations
 4. Complete setup by configuring the linked automation (add campaigns, assign salespeople, etc.)
 
-### Design and Customize
+### Design and customize
 1. Add or customize fields using the drag-and-drop builder
-2. Use **Design with AI** - upload a website screenshot and describe your needs
-3. Organize complex forms using **Sections** for better user flow
-4. Add **File Upload** fields for document collection
+2. Use `Design with AI` - upload a website screenshot and describe your needs
+3. Organize complex forms using `Sections` for better user flow
+4. Add `File Upload` fields for document collection
 
-### Automate and Publish
-1. Configure automations in the **Automations tab** to handle submissions automatically
-2. Toggle the automation **on** to activate your workflow
+### Automate and publish
+1. Configure automations in the `Automations` tab to handle submissions automatically
+2. Toggle the automation `on` to activate your workflow
 3. Embed on your website or share a direct link
 
 ## Field types and form building
@@ -65,7 +65,7 @@ Configure how your form behaves:
 
 ## Automation and workflows
 
-Forms now include powerful automation capabilities that activate automatically when forms are submitted:
+Forms include automation capabilities that activate automatically when forms are submitted:
 
 - **Complete lead workflows**: Create accounts, generate snapshot reports, and start campaigns in one flow
 - **CRM automation**: Auto-create contacts and companies with enriched data
@@ -76,8 +76,8 @@ Forms now include powerful automation capabilities that activate automatically w
 - **External integrations**: Send data to external systems via webhooks
 - **Analytics tracking**: Monitor performance in Google Analytics
 
-### Acquisition Widget replacement
-The new **Acquisition Widget template** provides the same powerful functionality as the legacy Acquisition Widget but with simpler setup and more flexibility. It includes pre-configured automations for lead capture, company enrichment, and follow-up sequences.
+### Acquisition Widget template
+The **Acquisition Widget template** provides pre-configured automations for lead capture, company enrichment, and follow-up sequences, with simple setup and flexible configuration.
 
 ## Guides and resources
 
@@ -95,7 +95,7 @@ The new **Acquisition Widget template** provides the same powerful functionality
 ## Frequently asked questions
 
 <details>
-<summary>Can I add these new features to my existing forms?</summary>
+<summary>Can I add file uploads, sections, or AI design to my existing forms?</summary>
 
 Yes! You can update any existing form to include file uploads, sections, automations, or AI design without starting from scratch.
 
@@ -125,21 +125,21 @@ Absolutely. Any automation trigger using the form submission from the specific f
 <details>
 <summary>How do I prevent spam submissions?</summary>
 
-Enable reCAPTCHA in Form settings. See [reCAPTCHA setup](./recaptcha-key.mdx) for complete instructions.
+Enable reCAPTCHA in `Form settings`. See [reCAPTCHA setup](./recaptcha-key.mdx) for complete instructions.
 
 </details>
 
 <details>
 <summary>Can I customize the form appearance?</summary>
 
-Yes! Use **Design with AI** for quick styling by uploading a website screenshot, or write custom CSS for full control. Forms are mobile-responsive by default.
+Yes! Use `Design with AI` for quick styling by uploading a website screenshot, or write custom CSS for full control. Forms are mobile-responsive by default.
 
 </details>
 
 <details>
 <summary>What's the difference between the Acquisition Widget template and other templates?</summary>
 
-The Acquisition Widget template provides a setup similar to the original Acquisition Widget, with pre-configured automations for lead capture, company enrichment, and follow-up campaigns. It's perfect for users migrating from Acquisition Widgets.
+The Acquisition Widget template includes pre-configured automations for lead capture, company enrichment, and follow-up campaigns, so you don't need to build the automation logic manually.
 
 </details>
 


### PR DESCRIPTION
## Summary
- Verified 5 articles flagged for review (173 days since last update): update-email-settings, email-settings-requirements, forms overview, and the two SPF/DKIM/DMARC provider guides (cPanel/Namecheap, GoDaddy)
- Fixed heading casing, UI/navigation-path formatting (backtick + arrow), duplicate H1s, evergreen-style violations, a prohibited term, and grammar issues throughout
- Reconciled the GoDaddy article with an upstream teammate's rewrite (pulled in via merge) that replaced hardcoded SPF/DKIM values with instructions to pull records directly from Partner Center, and my formatting fixes are layered on top
- One item was left as-is per author review: the cPanel/Namecheap guide's SPF example value (`_spf.mailgun.org`) differs from the `sendgrid.net` example in the parent Email Authentication article, but it's explicitly a generic placeholder per that article's own prerequisites, not a blocking accuracy issue

## Test plan
- [ ] Spot check `docs/marketing/email-settings/update-email-settings.mdx` renders correctly, including the `Important notes` heading fix
- [ ] Spot check `docs/marketing/forms/index.mdx` Acquisition Widget section reads correctly after the evergreen rewrite
- [ ] Spot check the GoDaddy article for the merged content (Partner Center-sourced records, no missing screenshot references)

Closes #686
Closes #687
Closes #688
Closes #689
Closes #690

🤖 Generated with [Claude Code](https://claude.com/claude-code)