### PR TITLE
Learn: the builder track (Path 5)

### DIFF
--- a/docusaurus/training/builder/advanced-automations.mdx
+++ b/docusaurus/training/builder/advanced-automations.mdx
@@ -1,11 +1,132 @@
 ---
 title: "Advanced automations"
-sidebar_position: 5
-description: "Data expressions, custom objects, and automations that earn the name."
+sidebar_position: 6
+description: "Trigger scope, guarded triggers, activities over notes, custom objects, and data expressions: automations that run start to finish without a person in the middle."
 ---
 
-:::info Content coming soon!
-This part of the learning path is being built. Check back shortly.
+import KnowledgeCheck from "@site/src/components/KnowledgeCheck";
+import CourseProgressBar from "@site/src/components/CourseProgressBar";
+import SectionFeedback from "@site/src/components/SectionFeedback";
+import InlineHighlighter from "@site/src/components/InlineHighlighter";
+import MarkComplete from "@site/src/components/MarkComplete";
+import LessonHeader from "@site/src/components/LessonHeader";
+import LessonFooter from "@site/src/components/LessonFooter";
+import FlipCard, { FlipCardGrid } from "@site/src/components/FlipCard";
+
+<InlineHighlighter courseId="advanced-automations" site="vendasta_learn">
+
+<CourseProgressBar courseId="advanced-automations" site="vendasta_learn" />
+
+<LessonHeader
+  difficulty="Advanced"
+  time="about 11 minutes"
+  pathName="The builder track"
+  step={6}
+  totalSteps={8}
+  outcomes={[
+    "Match a trigger's scope to the record you are acting on",
+    "Guard a trigger so it fires exactly when you intend",
+    "Log engagement as an activity other automations can act on",
+    "Model business data with a custom object",
+  ]}
+/>
+
+## An automation that runs without you
+
+An automation earns the name when it runs from trigger to finish with no one in the middle. If it needs someone to paste a value or click approve halfway through, it is a manual process wearing a costume. This step is about the pieces that let an automation carry real work on its own, and the ones that keep it from misfiring.
+
+## The trigger decides what you can do
+
+Every automation starts with a trigger, and the trigger quietly sets the rules for everything after it. A trigger scoped to a contact gives you contact steps; one scoped to a company gives you company steps; a trigger with no scope is more limited than either. Match the trigger to the thing you are acting on, and the steps you need are there.
+
+This is worth saying plainly because it is the most common snag in the builder: when a step you expect is missing, it is almost always because the trigger's scope does not reach it. Change the trigger, and the step appears.
+
+## Guard the trigger
+
+A trigger with no condition fires on every matching event. Create a single test contact to see what happens, and it fires on that one too. So guard it. Add a condition, on the record's source or a tag, so the automation runs on exactly the records you mean and no others.
+
+Conditions can be grouped with "and" and "or" for finer aim. A guarded trigger is the whole difference between an automation you trust to run unattended and one you feel you have to watch.
+
+<FlipCardGrid>
+  <FlipCard front="Trigger" back="The event that starts the workflow. Its scope decides which steps you can use." subtext="Start" />
+  <FlipCard front="Condition" back="The guard that decides whether to run on this record. Without it, the trigger fires on everything." subtext="Guard" />
+  <FlipCard front="Action" back="A step the workflow takes: send, create, log, wait. They run top to bottom." subtext="Do" />
+</FlipCardGrid>
+
+## Log activities, not notes
+
+When your automation records that something happened, make it an activity, not a note dropped into a field. An activity is anchored in time, and, more importantly, other automations can trigger on it. A value hidden in a message field is invisible to the rest of your system; an activity is something the platform can act on later. Building on activities is what lets one automation hand off cleanly to the next.
+
+## Model what the business tracks: custom objects
+
+Contacts and companies cover most of the CRM, but not everything a business runs on. A veterinary clinic tracks a pet: the pet has its own name, its vaccination record, its chip number. That is a custom object, a record type you define with its own fields, separate from any field on the contact. Custom objects power automations and smart lists the same way built-in records do, and you can bulk-import them from a spreadsheet to get started.
+
+## Shape a value mid-flow: data expressions
+
+Sometimes the value you receive is not quite the value you need to pass on: a first and last name to combine, one field to pull out of a larger payload, a number to reformat. A data expression reshapes it in the middle of the workflow. They are compact by design, with a length limit, and they fail softly: a missing field returns an empty result rather than crashing the run, so a small mistake never takes the whole automation down. When you need the full syntax, [the data expressions guide](/automations/data-expressions) has it.
+
+:::tip Try it now
+Take one automation you run, or want to. Write the single condition that would keep it from firing on the wrong record: a source, a tag, a field value. That one line is what turns a noisy automation into a reliable one.
 :::
 
-**What you will learn here:** Data expressions, custom CRM objects, and the automation patterns that run start to finish without a person in the middle.
+<SectionFeedback courseId="advanced-automations" site="vendasta_learn" section="content" />
+
+<KnowledgeCheck courseId="advanced-automations" site="vendasta_learn"
+  sessionSize={3}
+  intro="Three quick questions on trigger scope, guarding a trigger, and modeling data."
+  questions={[
+    {
+      type: 'mcq',
+      question: 'While building an automation, the step you want is not in the list. What is the most likely reason?',
+      options: [
+        'The automation limit for your account was reached',
+        'The trigger\'s scope does not reach that kind of step',
+        'The step is only available on a paid tier',
+        'The automation needs to be saved first'
+      ],
+      correctIndex: 1,
+      explanation: 'A trigger\'s scope, no scope, account, company, or contact, decides which steps are available. A missing step almost always means the trigger scope does not match the action.'
+    },
+    {
+      type: 'mcq',
+      question: 'You want an automation to run only on leads that came from a specific web form. What makes that reliable?',
+      options: [
+        'A condition on the record source or a tag',
+        'A longer wait step at the start',
+        'Running it manually each morning',
+        'Removing the trigger so it fires less often'
+      ],
+      correctIndex: 0,
+      explanation: 'An unguarded trigger fires on everything, including test records. A condition on source or tag is the guard that makes it run on exactly the records you mean.'
+    },
+    {
+      type: 'mcq',
+      question: 'Why record an engagement as an activity instead of a note in a field?',
+      options: [
+        'Notes cost more to store than activities',
+        'Activities are anchored in time and other automations can trigger on them',
+        'Notes cannot be edited once written',
+        'Activities are the only thing that appears on a contact'
+      ],
+      correctIndex: 1,
+      explanation: 'A value buried in a field is invisible to the rest of your system. An activity is anchored in time and triggerable, so the next automation can act on it.'
+    },
+    {
+      type: 'mcq',
+      question: 'A clinic needs to track each pet, with its own vaccination and chip records, separate from the owner. That is...',
+      options: [
+        'A custom field added to the owner\'s contact',
+        'A tag applied to the owner\'s contact',
+        'A custom object with its own fields',
+        'A note logged on the owner\'s contact'
+      ],
+      correctIndex: 2,
+      explanation: 'A distinct thing the business tracks, with its own fields, is a custom object, not a field or a tag on the contact. Custom objects power automations and smart lists like built-in records do.'
+    }
+  ]}
+/>
+
+<LessonFooter to="/learn/builder/the-builder-lab" pathName="The builder track" step={6} totalSteps={8} />
+
+</InlineHighlighter>
+<MarkComplete courseId="advanced-automations" site="vendasta_learn" />

--- a/docusaurus/training/builder/authenticate-and-first-api-call.mdx
+++ b/docusaurus/training/builder/authenticate-and-first-api-call.mdx
@@ -1,0 +1,137 @@
+---
+title: "Authenticate and make your first API call"
+sidebar_position: 4
+description: "Service accounts, scopes, and your first contact upsert against the CRM API, controlling how records match and update."
+---
+
+import KnowledgeCheck from "@site/src/components/KnowledgeCheck";
+import CourseProgressBar from "@site/src/components/CourseProgressBar";
+import SectionFeedback from "@site/src/components/SectionFeedback";
+import InlineHighlighter from "@site/src/components/InlineHighlighter";
+import MarkComplete from "@site/src/components/MarkComplete";
+import LessonHeader from "@site/src/components/LessonHeader";
+import LessonFooter from "@site/src/components/LessonFooter";
+
+<InlineHighlighter courseId="authenticate-and-first-api-call" site="vendasta_learn">
+
+<CourseProgressBar courseId="authenticate-and-first-api-call" site="vendasta_learn" />
+
+<LessonHeader
+  difficulty="Advanced"
+  time="about 12 minutes"
+  lab
+  pathName="The builder track"
+  step={4}
+  totalSteps={8}
+  outcomes={[
+    "Create a service account and use it as your integration's identity",
+    "Request the right scopes when you generate a token",
+    "Push a contact into the CRM with an upsert",
+    "Control how records match and which fields get overwritten",
+  ]}
+/>
+
+## Your code, reaching in
+
+The last step sent an AI Employee out to other systems. This step is the other direction: your own code reaching into the platform, to push a contact into the CRM or pull data back out. It starts where every real integration starts, at the wall of authentication: proving to the platform that your code is allowed to act.
+
+This is the step most builders get stuck on first, so it is worth going slowly. Nothing here is hard once the pieces have names.
+
+## A service account is your code's identity
+
+When a person signs in, they prove who they are. Your code needs the same thing, and it uses a service account: an identity that belongs to your integration rather than to a person. You create one in the platform, and from then on your code acts as that account.
+
+A service account can hold many permissions, but it does not use them all at once. It asks for the specific ones it needs, when it needs them. Those permissions are called scopes.
+
+## Scopes: ask for exactly what the job needs
+
+A scope is a single permission, like reading contacts or writing contacts. When your code gets its token, it names the scopes that call requires, and nothing more. Pushing a contact needs a contact-write scope; reading one back needs only a read scope, and most products offer a read-only variant for exactly that.
+
+The discipline worth building early: request the narrowest scopes that do the job. It is safer, and it makes what your integration can do obvious to anyone who looks later.
+
+One honest note. The service-account screen inside the platform is spare on its own. You read it next to the API reference at [developers.vendasta.com](https://developers.vendasta.com), which lists the real scope names. Pairing the screen with the reference is how this work is meant to be done, not a sign you are missing something.
+
+## Get a token
+
+An access token is the proof your code carries on every call. You generate it from your service account, naming the scopes you want. If the names are right, the token comes back ready to use. If one is wrong, the response tells you which name it did not recognize, so you correct it and try again. Keep the token where the rest of your code cannot leak it, the same way you would treat any password.
+
+## Your first call: the contact upsert
+
+The most common first call a builder makes is pushing a contact into the CRM, and the platform makes it one call, not two. It is an upsert: create the contact if it is new, update it if it already exists. You do not look first and branch; you send the contact and let the platform decide.
+
+What decides "already exists" is a match key. Email is the common choice, with phone as a fallback. Choose your match key deliberately, because it is what keeps you from creating a second copy of a contact you already have.
+
+Two behaviors are worth knowing before you send anything:
+
+- By default, an update only fills fields that are empty. A value already in the record stays put.
+- When you do want to replace a value, you mark that field to overwrite. Reach for it deliberately, because overwrite is also how good data gets erased by a stale import.
+
+Phone numbers are forgiving: send them in whatever format you have, and the platform normalizes them on the way in, so what lands stays consistent.
+
+The exact request, field by field, lives in the [CRM API reference](https://developers.vendasta.com). This step is the shape of it, so that reference reads like confirmation instead of a foreign language.
+
+:::tip Try it now
+In a sandbox account, generate a token with a contact-write scope and upsert one contact by email. Then send the same contact again with a different phone number, and check the record: did it match the contact you already had instead of creating a second one, and did your overwrite choice behave the way you expected? That one loop is authentication, scopes, and upsert semantics learned in a single sitting.
+:::
+
+<SectionFeedback courseId="authenticate-and-first-api-call" site="vendasta_learn" section="content" />
+
+<KnowledgeCheck courseId="authenticate-and-first-api-call" site="vendasta_learn"
+  sessionSize={3}
+  intro="Three quick questions on scopes, the upsert, and how records match and update."
+  questions={[
+    {
+      type: 'mcq',
+      question: 'What is a scope, and when do you request it?',
+      options: [
+        'A permission, requested when you generate a token',
+        'A user login, requested once when you sign in',
+        'A billing tier, requested from your account manager',
+        'A rate limit, requested per call you make'
+      ],
+      correctIndex: 0,
+      explanation: 'A scope is a single permission. Your code names the scopes it needs at the moment it generates a token, and asks for no more than the job requires.'
+    },
+    {
+      type: 'mcq',
+      question: 'You upsert a contact whose email already matches a contact in the CRM. What happens?',
+      options: [
+        'A second contact is created with the same email',
+        'The existing contact is updated, not duplicated',
+        'The call is rejected as a duplicate',
+        'A merge review is queued for you to approve'
+      ],
+      correctIndex: 1,
+      explanation: 'Upsert means create-or-update in one call. When the match key finds an existing contact, that contact is updated, which is exactly why choosing the match key well matters.'
+    },
+    {
+      type: 'mcq',
+      question: 'You upsert a contact and send a new value for a field that already has one. By default, what happens to the existing value?',
+      options: [
+        'It is replaced with the new value automatically',
+        'The whole record is skipped to be safe',
+        'It stays, unless you mark that field to overwrite',
+        'Both values are kept as a list'
+      ],
+      correctIndex: 2,
+      explanation: 'By default an update only fills empty fields. To replace a value that is already there, you mark that specific field to overwrite, and you do it deliberately.'
+    },
+    {
+      type: 'mcq',
+      question: 'Your token request fails. What is the fastest first thing to check?',
+      options: [
+        'Whether the platform is down for maintenance',
+        'Whether your subscription tier is high enough',
+        'Whether you exceeded a rate limit',
+        'Whether a scope name you requested was recognized'
+      ],
+      correctIndex: 3,
+      explanation: 'A wrong scope name is a common cause, and the token response tells you which name it did not recognize. Fix the name and request again.'
+    }
+  ]}
+/>
+
+<LessonFooter to="/learn/builder/webhooks-and-platform-events" pathName="The builder track" step={4} totalSteps={8} />
+
+</InlineHighlighter>
+<MarkComplete courseId="authenticate-and-first-api-call" site="vendasta_learn" />

--- a/docusaurus/training/builder/beyond-the-platform.mdx
+++ b/docusaurus/training/builder/beyond-the-platform.mdx
@@ -1,11 +1,125 @@
 ---
 title: "Beyond the platform"
-sidebar_position: 7
-description: "The developer surface: scopes, the event catalog, and building as a vendor."
+sidebar_position: 8
+description: "Where the platform ends: the build-tier line, keeping logic in the platform, the developer surface, productizing in Vendor Center, and the walls that are not technical."
 ---
 
-:::info Content coming soon!
-This part of the learning path is being built. Check back shortly.
+import KnowledgeCheck from "@site/src/components/KnowledgeCheck";
+import CourseProgressBar from "@site/src/components/CourseProgressBar";
+import SectionFeedback from "@site/src/components/SectionFeedback";
+import InlineHighlighter from "@site/src/components/InlineHighlighter";
+import MarkComplete from "@site/src/components/MarkComplete";
+import LessonHeader from "@site/src/components/LessonHeader";
+import LessonFooter from "@site/src/components/LessonFooter";
+
+<InlineHighlighter courseId="beyond-the-platform" site="vendasta_learn">
+
+<CourseProgressBar courseId="beyond-the-platform" site="vendasta_learn" />
+
+<LessonHeader
+  difficulty="Advanced"
+  time="about 8 minutes"
+  pathName="The builder track"
+  step={8}
+  totalSteps={8}
+  outcomes={[
+    "Recognize when a task is genuinely build-tier work",
+    "Keep changeable logic in the platform, not in your code",
+    "Find your way around the developer surface",
+    "Know what it takes to turn a build into a product",
+  ]}
+/>
+
+## Where the platform ends
+
+By now you handle almost all of this yourself: fields and objects, automations, custom tools, the API, webhooks. Custom code is the rest: reshaping data, reconciling records that do not match, or validating a messy feed before it lands. That is real development work, and it is exactly what the solution architecture team is for.
+
+Knowing that line is not a limit on you. It is what lets you move fast on everything you can do yourself and get help fast on the few things you cannot, instead of spending a week discovering a task was never a configuration in the first place.
+
+## Put the logic in the platform, not your code
+
+One principle will save you more grief than any other. When the platform is what sends a request or runs a workflow, let the platform hold the logic that decides who gets it. A rule written into a setting, a tag, or a condition can be changed by anyone on your team in a minute. The same rule buried in custom code needs a developer every time it changes.
+
+Build so the everyday adjustments live where everyday people can reach them. Code is for the work only code can do, not for a business rule that will change the first time a client asks.
+
+## The developer surface
+
+When the connect tier runs out, [developers.vendasta.com](https://developers.vendasta.com) is where you go next: the full API reference, the OAuth scopes with their read-only variants, and a browsable catalog of the platform events you can receive. The CRM API is the flagship there, with the fullest coverage.
+
+One split is worth knowing. The platform APIs, for working inside accounts, sit behind a subscription. The vendor APIs, for building products to distribute, do not. Which one you reach for depends on whether you are integrating for your own clients or building something to sell.
+
+## Productize what you built
+
+If a build turns out to be worth selling, Vendor Center is where it becomes a product. You enable the integration, define how it connects, and distribute it through the Marketplace under the model you set. Rolling one build across many accounts at once is what account templates are for.
+
+This is genuinely technical territory, and the platform says so plainly: it is meant for people comfortable with these concepts, with developers.vendasta.com as the reference. That is the honest handoff, and it is the same one you now know how to make in the other direction.
+
+## Not every wall is technical
+
+One last thing the field teaches. Sometimes the API exists, the connection works, and the data still cannot move, because an agreement says so. Some data is licensed in a way that forbids exporting it, no matter what is technically possible. Check that boundary before you design around it, so you never build something you are not allowed to ship.
+
+:::tip Try it now
+Think of the last thing that stopped you. Ask the question from the first step: could a setting or a no-code tool already do it, or does it truly need custom code? If it needs code, write the one-paragraph version you would hand off: the outcome you want, one concrete example, and what you have already tried. That paragraph is the difference between a fast answer and a slow one.
 :::
 
-**What you will learn here:** The developers.vendasta.com surface: OAuth scopes and read-only variants, the event catalog, vendor requirements, and the CRM API as the flagship.
+<SectionFeedback courseId="beyond-the-platform" site="vendasta_learn" section="content" />
+
+<KnowledgeCheck courseId="beyond-the-platform" site="vendasta_learn"
+  sessionSize={3}
+  intro="Three quick questions on the build-tier line, where logic should live, and productizing a build."
+  questions={[
+    {
+      type: 'mcq',
+      question: 'A task needs custom code to reconcile records from two systems that do not match. What is the right move?',
+      options: [
+        'Force it with a glue tool and hope it holds',
+        'Hand it to solution architecture as developer work, with a clear example',
+        'Add more custom fields until it lines up',
+        'Tell the client it cannot be done'
+      ],
+      correctIndex: 1,
+      explanation: 'Reshaping and reconciling mismatched data is real development work. Hand it off with a specific, reproducible ask.'
+    },
+    {
+      type: 'mcq',
+      question: 'A business rule will change often. Where should it live to stay maintainable?',
+      options: [
+        'In custom code, so it is precise',
+        'In a platform setting or condition anyone can change',
+        'In a document the team refers to',
+        'In the API token configuration'
+      ],
+      correctIndex: 1,
+      explanation: 'A rule in a setting or condition can be changed by anyone in a minute. The same rule in code needs a developer every time. Keep changeable logic where everyday people can reach it.'
+    },
+    {
+      type: 'mcq',
+      question: 'You want to turn a build into a product other partners can buy. Where does that happen?',
+      options: [
+        'The CRM',
+        'The Marketplace checkout',
+        'Vendor Center',
+        'The automations builder'
+      ],
+      correctIndex: 2,
+      explanation: 'Vendor Center is where a build becomes a product: you enable the integration, define how it connects, and distribute it through the Marketplace.'
+    },
+    {
+      type: 'mcq',
+      question: 'The API exists for the data you want to export, but you still cannot move it. What is the most likely reason?',
+      options: [
+        'The API is temporarily rate-limited',
+        'Your token is missing a scope',
+        'A data or licensing agreement forbids exporting it',
+        'The data is too large to send'
+      ],
+      correctIndex: 2,
+      explanation: 'Not every wall is technical. Some data is licensed so it cannot leave the platform, regardless of what an API allows. Check that boundary before you design an export.'
+    }
+  ]}
+/>
+
+<LessonFooter to="/learn/products" pathName="The builder track" step={8} totalSteps={8} nextPathName="Product courses" />
+
+</InlineHighlighter>
+<MarkComplete courseId="beyond-the-platform" site="vendasta_learn" />

--- a/docusaurus/training/builder/capabilities-in-depth.mdx
+++ b/docusaurus/training/builder/capabilities-in-depth.mdx
@@ -1,11 +1,141 @@
 ---
 title: "Capabilities in depth"
 sidebar_position: 2
-description: "The full anatomy of a capability, for builders."
+description: "Designing a capability from the outcome, writing instructions that stay reliable, and trimming what does not earn its place."
 ---
 
-:::info Content coming soon!
-This part of the learning path is being built. Check back shortly.
+import KnowledgeCheck from "@site/src/components/KnowledgeCheck";
+import CourseProgressBar from "@site/src/components/CourseProgressBar";
+import SectionFeedback from "@site/src/components/SectionFeedback";
+import InlineHighlighter from "@site/src/components/InlineHighlighter";
+import MarkComplete from "@site/src/components/MarkComplete";
+import LessonHeader from "@site/src/components/LessonHeader";
+import LessonFooter from "@site/src/components/LessonFooter";
+import FlipCard, { FlipCardGrid } from "@site/src/components/FlipCard";
+
+<InlineHighlighter courseId="capabilities-in-depth" site="vendasta_learn">
+
+<CourseProgressBar courseId="capabilities-in-depth" site="vendasta_learn" />
+
+<LessonHeader
+  difficulty="Advanced"
+  time="about 9 minutes"
+  pathName="The builder track"
+  step={2}
+  totalSteps={8}
+  outcomes={[
+    "Design a capability from the outcome, not the click-by-click steps",
+    "Write capability instructions that stay reliable under real traffic",
+    "Decide what belongs in a capability and what belongs in knowledge",
+    "Trim an over-built capability without losing what it does",
+  ]}
+/>
+
+## What a capability is
+
+A capability is a single skill you switch on for an AI Employee: capture a lead, book an appointment, look something up and answer from it. Each one is a set of instructions, sometimes with a tool attached. The AI reads the situation in front of it and reaches for the capability that fits.
+
+That is the line between a capability and knowledge. Knowledge is what the AI Employee knows, the facts it looks up when a question calls for them. A capability is what it does, the behavior you want in a given moment. Facts go in knowledge; behavior goes in a capability. Keeping that split clean is most of what makes an AI Employee predictable.
+
+The useful way to think about writing one: you are briefing a new team member. You would not hand a new hire a hundred rules on their first day. You would tell them what the job is, when to do it, and what a good result looks like. A capability is the same brief, written down once.
+
+## Design from the outcome
+
+Start from the result you want, not the steps to get there. "A booked appointment on the right calendar, with the customer's name and reason for the visit" is an outcome. "Click the calendar, then pick a time, then..." is a script, and the AI does not need your script. Name the destination and the guardrails, and let the AI find the path.
+
+Vague instructions produce vague behavior. Compare these two versions of the same instruction:
+
+- Vague: "Get the order number."
+- Specific: "Ask for the order number from the customer's message. Order numbers are eight to ten digits and may include letters. If it is missing, ask once before moving on."
+
+The second one tells the AI where the value comes from, what it looks like, and what to do when it is not there. That is the difference between a capability that works on the thousandth conversation and one that drifts on the second.
+
+## The three parts of a reliable capability
+
+Every capability worth trusting has the same three parts. Flip each one to see what it does:
+
+<FlipCardGrid>
+  <FlipCard front="Instruction" back="What the skill does and when to reach for it. Written like a brief to a new hire, not a script." subtext="Behavior" />
+  <FlipCard front="Guardrail" back="The line it must not cross. 'Quote only published prices.' Keeps a confident answer from becoming a wrong one." subtext="Boundary" />
+  <FlipCard front="Trigger" back="The situation that tells the AI to use this skill instead of another. Vague triggers make skills collide." subtext="When" />
+</FlipCardGrid>
+
+Get these three right and the capability behaves. Most capabilities that misfire are missing one of them: no guardrail, so it invents; no clear trigger, so it fires at the wrong moment.
+
+## Trim what does not earn its place
+
+Everything you tell an AI Employee lands in one working memory, and it all competes for attention. Long, overlapping instructions do not make an employee smarter; they cross wires. A capability that tries to do three jobs does all three worse than three capabilities doing one each.
+
+So write short and specific, then cut. If a sentence does not change what the AI does, it is noise. If a capability has grown a second job, split it. The goal is not the most detailed instruction, it is the one that produces the same right behavior every time.
+
+:::tip Try it now
+Take a capability you have built, or one you want to. Write its outcome in a single sentence: what result does it produce? If you cannot say it in one sentence, the capability is doing too much, and that is your signal to split it.
 :::
 
-**What you will learn here:** The complete capability model: prompt structure, tool attachment, and the patterns that make custom capabilities reliable.
+## Tighten it by watching it work
+
+A capability is rarely right on the first try, and it does not need to be. You let it run, watch where it drifts, and tighten the instruction that let it drift. That loop is the craft, not a sign something went wrong.
+
+Test in a sandbox where nothing is at stake, and try the messy inputs on purpose: the missing field, the wrong format, the customer who asks two things at once. When an answer surprises you, the [Explanation view](/ai/ai-capabilities) shows what the AI actually did, so you tighten the real cause instead of guessing. When you are ready to write one from scratch, [this guide walks through the full capability builder](/ai/ai-capabilities/creating-custom-capabilities).
+
+<SectionFeedback courseId="capabilities-in-depth" site="vendasta_learn" section="content" />
+
+<KnowledgeCheck courseId="capabilities-in-depth" site="vendasta_learn"
+  sessionSize={3}
+  intro="Three quick questions on capability versus knowledge, designing from the outcome, and why shorter wins."
+  questions={[
+    {
+      type: 'mcq',
+      question: 'A client\'s hours and prices change often. Where should that information live?',
+      options: [
+        'In the capability instructions, restated in full each time',
+        'In knowledge, where the AI looks it up when a question needs it',
+        'In the trigger condition for every capability',
+        'In a guardrail on the booking capability'
+      ],
+      correctIndex: 1,
+      explanation: 'Facts the AI looks up belong in knowledge. Behavior belongs in a capability. Hours and prices are facts, so they live in knowledge and stay easy to update.'
+    },
+    {
+      type: 'mcq',
+      question: 'You are writing a capability that books appointments. What is the outcome-first way to start?',
+      options: [
+        'List every button the AI should click, in order',
+        'Describe the result you want, plus the guardrails around it',
+        'Paste the full calendar documentation into the instruction',
+        'Write one rule for every situation you can imagine'
+      ],
+      correctIndex: 1,
+      explanation: 'Design from the outcome. Name the result and the limits; the AI finds the path. A click-by-click script is the thing you do not need to write.'
+    },
+    {
+      type: 'mcq',
+      question: 'An AI Employee\'s single capability keeps giving inconsistent answers. Its instruction is three paragraphs covering booking, refunds, and complaints. What is the likely fix?',
+      options: [
+        'Add more detail to the existing instruction',
+        'Move the whole instruction into knowledge instead',
+        'Split it into separate capabilities, one job each',
+        'Remove the guardrails so it has more freedom'
+      ],
+      correctIndex: 2,
+      explanation: 'One capability doing three jobs crosses wires in a single working memory. Split it so each capability does one job, and each does it reliably.'
+    },
+    {
+      type: 'mcq',
+      question: 'What does a guardrail add to a capability?',
+      options: [
+        'The situation that tells the AI when to use the skill',
+        'The line the AI must not cross, so a confident answer stays correct',
+        'The list of facts the AI can look up',
+        'The step-by-step path the AI should follow'
+      ],
+      correctIndex: 1,
+      explanation: 'A guardrail is the boundary. "Quote only published prices" keeps a fluent, confident answer from becoming a wrong one. The trigger is when to act; the guardrail is what never to do.'
+    }
+  ]}
+/>
+
+<LessonFooter to="/learn/builder/custom-tools" pathName="The builder track" step={2} totalSteps={8} />
+
+</InlineHighlighter>
+<MarkComplete courseId="capabilities-in-depth" site="vendasta_learn" />

--- a/docusaurus/training/builder/custom-tools.mdx
+++ b/docusaurus/training/builder/custom-tools.mdx
@@ -1,11 +1,152 @@
 ---
-title: "Custom tools"
+title: "Custom tools: connect any API"
 sidebar_position: 3
-description: "Build the doorways: methods, parameters, auth strategies, and MCP connections."
+description: "Turn a working API call into a tool an AI Employee can use: methods, parameters, authentication, and reading what it actually sent."
 ---
 
-:::info Content coming soon!
-This part of the learning path is being built. Check back shortly.
+import KnowledgeCheck from "@site/src/components/KnowledgeCheck";
+import CourseProgressBar from "@site/src/components/CourseProgressBar";
+import SectionFeedback from "@site/src/components/SectionFeedback";
+import InlineHighlighter from "@site/src/components/InlineHighlighter";
+import MarkComplete from "@site/src/components/MarkComplete";
+import LessonHeader from "@site/src/components/LessonHeader";
+import LessonFooter from "@site/src/components/LessonFooter";
+
+<InlineHighlighter courseId="custom-tools" site="vendasta_learn">
+
+<CourseProgressBar courseId="custom-tools" site="vendasta_learn" />
+
+<LessonHeader
+  difficulty="Advanced"
+  time="about 12 minutes"
+  lab
+  pathName="The builder track"
+  step={3}
+  totalSteps={8}
+  outcomes={[
+    "Turn a working API call into a custom tool",
+    "Choose the right authentication for the system you are calling",
+    "Recognize when a job needs a tool instead of more knowledge",
+    "Read what your tool actually sent, and fix it when it is wrong",
+  ]}
+/>
+
+## A tool is a doorway out
+
+Knowledge lets an AI Employee answer a question. A tool lets it do something in another system: check a calendar for open times, look up an order, read live inventory before it promises a product is in stock. Knowledge is what it knows; a tool is what it can reach.
+
+A tool and a capability are two halves of one thing. The tool is the how: the actual call to another system's API. The capability is the when and the why: the instruction that tells the AI to use it. You need both, and the last step covered the capability side. This one is the doorway itself.
+
+The AI decides when to walk through the doorway. The tool defines what is on the other side and what comes back. Build the doorway well and the AI uses it exactly when its capability says to.
+
+## Start from a working call
+
+The fastest reliable way to build a tool is to get the API call working on its own first, outside the platform, in a tool like Postman or from the command line. Once the call returns what you expect, you import it and the platform reads the shape of it for you.
+
+A URL is the address the tool calls, like the phone number the AI dials to reach the other system. The method is what it is asking for:
+
+| Method | What it means |
+|---|---|
+| **GET** | Give me some information |
+| **POST** | Create or send something new |
+| **PUT / PATCH** | Change something that exists |
+| **DELETE** | Remove something |
+
+The other system's API documentation tells you which method and URL to use. You are not guessing; you are copying what its docs already spell out. When a system gives you an example as a cURL command (a single line that makes the call), importing it fills in the method, URL, headers, and parameter names automatically.
+
+## The four parts of a tool
+
+Every custom tool is four things:
+
+- **Description**: what the tool does, in plain language. The AI reads this to decide whether this is the right doorway.
+- **Method and URL**: where it calls and what it is asking for, from the table above.
+- **Headers**: the metadata sent with every call, including how the tool proves it is allowed in (below).
+- **Parameters**: the values the call needs. Each parameter has a description (where the value comes from), a Required flag, and a "Set by AI" toggle. Turn Set by AI off when the value is always the same, and the tool uses a fixed value instead of letting the AI fill it.
+
+The parameter descriptions do the heavy lifting. "The order number from the customer's message, eight to ten digits" tells the AI exactly what to put there. When a tool sends the wrong thing, a vague parameter description is usually why.
+
+## Authentication: proving the tool is allowed in
+
+Most systems will not open the door without proof of who is knocking. That proof travels with the call, and the system's API docs tell you which kind it expects:
+
+| Strategy | How it travels | When you see it |
+|---|---|---|
+| **API key** | A key in a header or in the URL | The most common; simple systems |
+| **OAuth 2.0** | A token you obtain, then send on each call | Systems with user accounts and permissions |
+| **Basic auth** | A username and password, encoded | Older or internal systems |
+
+Whichever it uses, one rule holds: give the tool the narrowest access that does the job, and keep credentials out of anywhere they could be seen, including screenshots you share.
+
+There is also a newer option, an **MCP connection**, which links a whole set of tools at once instead of one call at a time. It is offered as a tool type when you add a tool; reach for it when a system publishes an MCP surface.
+
+## Read what it actually sent
+
+When a tool misbehaves, do not guess. After the AI uses it, open the **Explanation view** on the message to see the exact values the tool sent to the API. That tells you whether the tool sent the wrong thing (fix the parameter description) or the API rejected a correct call (fix the connection or the auth).
+
+Test on purpose, not just the happy path: the missing value, the wrong format, the request that names two things at once. If you cannot tell whether the tool or the API is the problem, run the call again on its own outside the platform to isolate it.
+
+:::tip Try it now
+Find any public API you can call without an account, like a weather service or a public directory, and get one request working from the command line or Postman. That single working call is exactly the raw material a custom tool imports. You will build one for real in the lab later in this path.
 :::
 
-**What you will learn here:** Configuring tools end to end: cURL import, parameters and headers, the four authentication strategies, and MCP connections, with a real integration as the worked example.
+<SectionFeedback courseId="custom-tools" site="vendasta_learn" section="content" />
+
+<KnowledgeCheck courseId="custom-tools" site="vendasta_learn"
+  sessionSize={3}
+  intro="Three quick questions on when a job needs a tool, choosing authentication, and reading what a tool sent."
+  questions={[
+    {
+      type: 'mcq',
+      question: 'A client\'s inventory changes through the day, and the AI keeps offering items that just sold out. What does that job need?',
+      options: [
+        'More detail added to the Knowledge Base entry',
+        'A tool that reads live inventory when asked',
+        'A stricter guardrail on the answer',
+        'A longer capability instruction'
+      ],
+      correctIndex: 1,
+      explanation: 'Live, changing data is a tool\'s job, not knowledge. If you find yourself updating a Knowledge Base entry constantly, that information wants to be a tool that fetches it fresh.'
+    },
+    {
+      type: 'mcq',
+      question: 'The Set by AI toggle on a parameter is turned off. What happens?',
+      options: [
+        'The AI decides the value from the conversation each time',
+        'The tool uses a fixed value you set, every call',
+        'The parameter becomes required for the AI to fill',
+        'The tool stops sending that parameter at all'
+      ],
+      correctIndex: 1,
+      explanation: 'Set by AI off means the value is fixed: the tool sends the same thing every time. Leave it on when the value comes from the conversation.'
+    },
+    {
+      type: 'mcq',
+      question: 'You are calling a simple external service that just needs a single secret string to prove access. Which authentication is that most likely to be?',
+      options: [
+        'OAuth 2.0 with a token exchange',
+        'An API key in a header or the URL',
+        'A full username-and-password login flow',
+        'No authentication of any kind'
+      ],
+      correctIndex: 1,
+      explanation: 'A single secret string is an API key, the most common strategy for simple systems. OAuth is for systems with user accounts and permissions.'
+    },
+    {
+      type: 'mcq',
+      question: 'Your tool runs but the API rejects it. What is the fastest way to tell whether the tool or the API is at fault?',
+      options: [
+        'Rewrite the capability instruction and try again',
+        'Add more parameters to the tool',
+        'Open Explanation to see what was sent, then test the call on its own',
+        'Switch the method from POST to GET'
+      ],
+      correctIndex: 2,
+      explanation: 'Explanation shows the exact values the tool sent. Pair that with running the call on its own outside the platform, and you can tell a bad parameter from a bad connection.'
+    }
+  ]}
+/>
+
+<LessonFooter to="/learn/builder/authenticate-and-first-api-call" pathName="The builder track" step={3} totalSteps={8} />
+
+</InlineHighlighter>
+<MarkComplete courseId="custom-tools" site="vendasta_learn" />

--- a/docusaurus/training/builder/index.mdx
+++ b/docusaurus/training/builder/index.mdx
@@ -1,15 +1,58 @@
 ---
 title: The builder track
 sidebar_position: 0
-sidebar_label: The builder track
-description: APIs, webhooks, custom tools, and deeper connections - for the partner who builds.
+sidebar_label: Overview
+description: "Wiring an AI Employee into the systems your clients already run: custom tools, the API, webhooks, automations, and where the platform hands off to a developer."
 hide_table_of_contents: true
 ---
 
-:::info Content coming soon!
-This path is in development.
-:::
+import PathRoadmap from "@site/src/components/PathRoadmap";
 
-This learning path is for the technical partner and citizen developer: the integration landscape, custom capabilities in depth, connecting any API with custom tools, webhooks and event-driven workflows, advanced automations, a full build lab, and the handoff to the developer platform.
+Connecting an AI Employee to the systems your clients already run: what can be connected, how to build the doorways with custom tools and the API, how data moves in and out, and where the platform hands off to a developer. This one assumes you are comfortable reading API documentation.
 
-**Where to go today:** [Automations in Documentation](/automations), [building custom tools](/ai/ai-capabilities/tools-overview/building-custom-tools), and [developers.vendasta.com](https://developers.vendasta.com) for the API reference.
+<PathRoadmap
+  steps={[
+    {
+      title: "The integration landscape",
+      description: "What decides whether a system can be connected, and the ladder from configure to build.",
+      to: "/learn/builder/the-integration-landscape",
+    },
+    {
+      title: "Capabilities in depth",
+      description: "Designing a capability from the outcome, and trimming it until it stays reliable.",
+      to: "/learn/builder/capabilities-in-depth",
+    },
+    {
+      title: "Custom tools: connect any API",
+      description: "Turn a working API call into a doorway an AI Employee can use.",
+      to: "/learn/builder/custom-tools",
+    },
+    {
+      title: "Authenticate and make your first API call",
+      description: "Service accounts, scopes, and your first contact upsert into the CRM.",
+      to: "/learn/builder/authenticate-and-first-api-call",
+    },
+    {
+      title: "Webhooks and platform events",
+      description: "Push instead of poll: sending data out, and receiving events as they happen.",
+      to: "/learn/builder/webhooks-and-platform-events",
+    },
+    {
+      title: "Advanced automations",
+      description: "Guarded triggers, activities over notes, custom objects, and data expressions.",
+      to: "/learn/builder/advanced-automations",
+    },
+    {
+      title: "The builder lab",
+      description: "Assemble it all into one AI Employee that books a meeting and updates the CRM.",
+      to: "/learn/builder/the-builder-lab",
+    },
+    {
+      title: "Beyond the platform",
+      description: "The build-tier line, the developer surface, and productizing what you built.",
+      to: "/learn/builder/beyond-the-platform",
+    },
+  ]}
+/>
+
+When you finish, [developers.vendasta.com](https://developers.vendasta.com) is the reference you will keep open as you build.

--- a/docusaurus/training/builder/the-builder-lab.mdx
+++ b/docusaurus/training/builder/the-builder-lab.mdx
@@ -1,11 +1,114 @@
 ---
 title: "The builder lab"
-sidebar_position: 6
-description: "Hands-on: a custom tool against two real APIs."
+sidebar_position: 7
+description: "Assemble the path into one working AI Employee: a custom tool that books a real meeting, a CRM upsert, and the modeling and data-contract decisions that keep it from breaking."
 ---
 
-:::info Content coming soon!
-This part of the learning path is being built. Check back shortly.
+import KnowledgeCheck from "@site/src/components/KnowledgeCheck";
+import CourseProgressBar from "@site/src/components/CourseProgressBar";
+import SectionFeedback from "@site/src/components/SectionFeedback";
+import InlineHighlighter from "@site/src/components/InlineHighlighter";
+import MarkComplete from "@site/src/components/MarkComplete";
+import LessonHeader from "@site/src/components/LessonHeader";
+import LessonFooter from "@site/src/components/LessonFooter";
+
+<InlineHighlighter courseId="the-builder-lab" site="vendasta_learn">
+
+<CourseProgressBar courseId="the-builder-lab" site="vendasta_learn" />
+
+<LessonHeader
+  difficulty="Advanced"
+  time="about 20 minutes"
+  lab
+  pathName="The builder track"
+  step={7}
+  totalSteps={8}
+  outcomes={[
+    "Build a custom tool that checks real availability and books a meeting",
+    "Wire it, plus a CRM upsert, into a working AI Employee",
+    "Model a multi-location structure before you build on it",
+    "Settle the data contract before you commit to a maintenance path",
+  ]}
+/>
+
+## What you will build
+
+This lab assembles everything the path has covered into one working AI Employee: a custom tool that checks real open times on a calendar and books one, a second call that adds the person to the CRM as a contact, and the capability that tells the AI when to reach for each. One employee, two real connections, doing work end to end.
+
+You will build it in a sandbox account, where nothing is at stake and you can break things on purpose.
+
+## Model before you build
+
+The build is the easy part. The modeling is where projects go sideways, so you do it first, on paper, before you connect anything.
+
+Start with the hardest version of the client, not the simplest: a business with several locations and several people who each work across more than one of them. Map who books into which calendar, and where each new contact belongs. Then check that structure against the simplest case, a single location with one person, to be sure it holds at both ends. Solve the hardest case first and the easy ones are already handled; do it the other way around and you rebuild when the hard case arrives.
+
+## Settle the data contract
+
+One decision shapes everything downstream: who keeps each record current. Is the calendar the source of truth for availability, or the CRM? Is a roster of people maintained by an API sync, or by hand? Name that contract out loud before you build, because changing it later means rebuilding on top of it. A data contract is not paperwork; it is the decision that keeps two systems from quietly disagreeing.
+
+## Build it in chunks
+
+Do not wire the whole thing and hope. Bring it up one piece at a time:
+
+1. Get the availability call working on its own, outside the platform, until it returns real open times.
+2. Get the booking call working on its own, so a test booking actually lands on the calendar.
+3. Get the contact upsert working, matching on email the way you practiced.
+4. Turn each working call into a custom tool, then attach them to a capability that says when to use each.
+5. Run the whole flow as the AI Employee, and spot-check the first few live bookings yourself.
+
+Confirm each piece alone before you chain them. Measure twice, cut once: on a build with this many moving parts, small steps are what keep the last one from collapsing the rest. When something misbehaves, the Explanation view shows you what the tool actually sent, so you fix the real cause instead of guessing.
+
+:::tip Try it now
+Work the five steps above in a sandbox account. When the AI Employee books a real meeting and the contact appears in the CRM without you touching either system, you have built an agent that acts in the real world, which is the whole point of this path.
 :::
 
-**What you will learn here:** A hands-on build: a custom tool that checks real meeting availability and books it, plus CRM contact creation, wired into an AI Employee.
+<SectionFeedback courseId="the-builder-lab" site="vendasta_learn" section="content" />
+
+<KnowledgeCheck courseId="the-builder-lab" site="vendasta_learn"
+  sessionSize={3}
+  intro="Three quick questions on the judgment behind the build: modeling, the data contract, and working in chunks."
+  questions={[
+    {
+      type: 'mcq',
+      question: 'Before connecting anything, which version of the client should you model first?',
+      options: [
+        'The simplest one, then add complexity later',
+        'The hardest one, then check it against the simplest',
+        'An average one, to cover the middle',
+        'Whichever the client asks for first'
+      ],
+      correctIndex: 1,
+      explanation: 'Solve the hardest case first, a multi-location, multi-person business, then confirm it holds for the simple case. Model the easy one first and you rebuild when the hard case arrives.'
+    },
+    {
+      type: 'mcq',
+      question: 'What does settling the data contract mean?',
+      options: [
+        'Signing a paperwork agreement with the client',
+        'Deciding who keeps each record current, and how',
+        'Choosing which subscription tier to buy',
+        'Writing the custom tool descriptions'
+      ],
+      correctIndex: 1,
+      explanation: 'The data contract is deciding the source of truth and how each record stays current, by API or by hand. Changing it later means rebuilding on top of it.'
+    },
+    {
+      type: 'mcq',
+      question: 'Why bring the build up one call at a time instead of wiring it all at once?',
+      options: [
+        'The platform blocks more than one call per automation',
+        'It is required to save the automation',
+        'You can confirm each piece works before chaining, so a failure is easy to locate',
+        'Each call needs its own service account'
+      ],
+      correctIndex: 2,
+      explanation: 'Measure twice, cut once. Confirming each call on its own means that when the chain misbehaves, you already know which piece is sound and which is not.'
+    }
+  ]}
+/>
+
+<LessonFooter to="/learn/builder/beyond-the-platform" pathName="The builder track" step={7} totalSteps={8} />
+
+</InlineHighlighter>
+<MarkComplete courseId="the-builder-lab" site="vendasta_learn" />

--- a/docusaurus/training/builder/the-integration-landscape.mdx
+++ b/docusaurus/training/builder/the-integration-landscape.mdx
@@ -1,11 +1,143 @@
 ---
 title: "The integration landscape"
 sidebar_position: 1
-description: "What is public, what is not, and where every kind of connection lives."
+description: "What makes a system connectable, how far you have to go to use its API, and when a job is really developer work."
 ---
 
-:::info Content coming soon!
-This part of the learning path is being built. Check back shortly.
+import KnowledgeCheck from "@site/src/components/KnowledgeCheck";
+import CourseProgressBar from "@site/src/components/CourseProgressBar";
+import SectionFeedback from "@site/src/components/SectionFeedback";
+import InlineHighlighter from "@site/src/components/InlineHighlighter";
+import MarkComplete from "@site/src/components/MarkComplete";
+import LessonHeader from "@site/src/components/LessonHeader";
+import LessonFooter from "@site/src/components/LessonFooter";
+
+<InlineHighlighter courseId="the-integration-landscape" site="vendasta_learn">
+
+<CourseProgressBar courseId="the-integration-landscape" site="vendasta_learn" />
+
+<LessonHeader
+  difficulty="Intermediate"
+  time="about 8 minutes"
+  pathName="The builder track"
+  step={1}
+  totalSteps={8}
+  outcomes={[
+    "Tell whether an outside system can be connected at all",
+    "Judge how far you have to go to use it, from a setting to custom code",
+    "Reach for the lightest approach that does the job",
+    "Recognize when a task is really developer work, and hand it off well",
+  ]}
+/>
+
+## What makes a system connectable
+
+Sooner or later a client asks you to make the platform work with something they already run: their booking system, their accounting software (or maybe it is your own tools you want to connect). Whether you can comes down to a doorway. Systems talk to each other through doorways, and the doorway the platform uses to reach other software is called an API.
+
+When a system has one, you can almost certainly connect it: read its data, send data to it, or both. When a system keeps everything locked behind its own walls, no integration can reach in, and that is a limit of that system.
+
+So the first move with any integration is to find out whether the system you want to connect to has an open API. Its own documentation will tell you, usually on a page called "API" or "Developers." If it does, you are most of the way there.
+
+## How far you have to go
+
+Knowing a system has an API does not mean you have to write code to use it. How far you go depends on the job, and the skill worth building is reaching for the lightest option that does it.
+
+Often you do not have to connect anything at all. What sounds like "we need an integration" is frequently already a setting, a custom field, or an automation inside the platform. Check there first.
+
+When you do need to reach another system, the options run from light to heavy:
+
+- A no-code glue tool like Zapier or Make passes data between two systems without writing anything. It is the right first reach for one or two connections.
+- A custom tool, or a direct call to the platform's own API, gives you more control, and earns its place when a glue tool would balloon at scale.
+- Custom code comes last, for when data has to be reshaped or reconciled before it fits. That is developer work.
+
+Most jobs sit lighter on that list than they first appear. Start light, and climb only when the job makes you.
+
+## What the platform opens up
+
+The platform is not only something you connect other tools to. It opens its own public APIs, so your code can work with its core records and actions directly, from the CRM to meetings and forms. When you are ready, [developers.vendasta.com](https://developers.vendasta.com) is the reference for all of it.
+
+One distinction saves confusion later: some things you drive by API, and some you build in the platform itself. You can start an automation from an API call or a webhook, but you do not author automations, AI Employees, or Vibe apps through an API. Those are built in the interface. Knowing which is which tells you where to go before you begin.
+
+## When it is developer work, and how to hand it off
+
+Most of this path is work you will do yourself. Custom code is the exception. When a task needs code to reshape data or reconcile records that do not match, that is real development work, and the solution architecture team exists for exactly that.
+
+Handing off well is its own skill. Bring a specific, reproducible example of what you need, confirm a support ticket exists so the request does not get lost, and keep your Customer Success contact in the loop. A clear ask that names the outcome and shows one concrete case moves faster than a general one.
+
+:::tip Try it now
+Pick one system a client uses every day: their booking tool, their point of sale, their accounting software. Take one minute to find out whether it has an open API (check its website for an "API" or "Developers" page). If it does, ask the lighter question next: could a setting or a no-code tool already do what you need, before you reach for anything heavier?
 :::
 
-**What you will learn here:** The real public API surface (CRM, meetings, forms, reputation), what has no public API, and the map of connection options from built-in integrations to custom tools.
+<SectionFeedback courseId="the-integration-landscape" site="vendasta_learn" section="content" />
+
+<KnowledgeCheck courseId="the-integration-landscape" site="vendasta_learn"
+  sessionSize={3}
+  intro="Three quick questions on what makes a system connectable, checking for the lightest option first, and when a job is developer work."
+  questions={[
+    {
+      type: 'mcq',
+      question: 'A client wants the platform to work with the accounting software they already use. What decides whether you can connect it?',
+      options: [
+        'Whether Vendasta has published a guide for that exact tool',
+        'Whether that software exposes an open API for other systems',
+        'Whether the software is popular enough to have a native integration',
+        'Whether the client is on a high enough subscription tier'
+      ],
+      correctIndex: 1,
+      explanation: 'Connectability comes down to the other system. If it exposes an open API, you can almost certainly connect it. If it locks its data down, no integration can reach in.'
+    },
+    {
+      type: 'mcq',
+      question: 'You want a follow-up task created every time a new lead arrives, and it can all happen inside the platform. What should you reach for first?',
+      options: [
+        'An automation inside the platform, with no outside connection',
+        'A custom tool that calls an external API',
+        'A glue tool like Zapier between two systems',
+        'Custom code written by a developer'
+      ],
+      correctIndex: 0,
+      explanation: 'Check the lightest option first. A trigger-and-action workflow with no outside system is just an automation inside the platform. No connection or code required.'
+    },
+    {
+      type: 'mcq',
+      question: 'You need to link one external form to the CRM for a single client. What is the sensible first reach?',
+      options: [
+        'Custom code that maps the two systems together',
+        'A request to the solution architecture team',
+        'A glue tool like Zapier or Make between them',
+        'A new product configured in Vendor Center'
+      ],
+      correctIndex: 2,
+      explanation: 'Start light. For one or two connections, a glue tool is fast and needs no code. Direct APIs and custom code earn their place at scale, not at the start.'
+    },
+    {
+      type: 'mcq',
+      question: 'Can you create a brand-new automation through the platform\'s API?',
+      options: [
+        'No: automations are built in the interface, but an API call can start one',
+        'Yes: the automation API creates and edits workflows directly',
+        'Yes, but only on Premium and Custom subscriptions',
+        'No: automations cannot be reached by an API at all'
+      ],
+      correctIndex: 0,
+      explanation: 'You drive some things by API and build others in the platform. You can trigger an existing automation programmatically, but authoring one happens in the interface.'
+    },
+    {
+      type: 'mcq',
+      question: 'A connection needs custom code to reconcile records from two systems that do not match. That work is...',
+      options: [
+        'A quick automation you can configure yourself',
+        'Something a glue tool handles in an afternoon',
+        'Not possible on the platform in any form',
+        'Developer work, best handed to the solution architecture team'
+      ],
+      correctIndex: 3,
+      explanation: 'Reshaping and reconciling mismatched data is real development work. Hand it off with a clear, reproducible example of what you need.'
+    }
+  ]}
+/>
+
+<LessonFooter to="/learn/builder/capabilities-in-depth" pathName="The builder track" step={1} totalSteps={8} />
+
+</InlineHighlighter>
+<MarkComplete courseId="the-integration-landscape" site="vendasta_learn" />

--- a/docusaurus/training/builder/webhooks-and-platform-events.mdx
+++ b/docusaurus/training/builder/webhooks-and-platform-events.mdx
@@ -1,11 +1,123 @@
 ---
 title: "Webhooks and platform events"
-sidebar_position: 4
-description: "Push instead of poll: outbound steps, inbound triggers, and vendor events."
+sidebar_position: 5
+description: "Push instead of poll: sending data out with an outbound webhook step, receiving events with inbound triggers, and the platform events a product receives."
 ---
 
-:::info Content coming soon!
-This part of the learning path is being built. Check back shortly.
+import KnowledgeCheck from "@site/src/components/KnowledgeCheck";
+import CourseProgressBar from "@site/src/components/CourseProgressBar";
+import SectionFeedback from "@site/src/components/SectionFeedback";
+import InlineHighlighter from "@site/src/components/InlineHighlighter";
+import MarkComplete from "@site/src/components/MarkComplete";
+import LessonHeader from "@site/src/components/LessonHeader";
+import LessonFooter from "@site/src/components/LessonFooter";
+
+<InlineHighlighter courseId="webhooks-and-platform-events" site="vendasta_learn">
+
+<CourseProgressBar courseId="webhooks-and-platform-events" site="vendasta_learn" />
+
+<LessonHeader
+  difficulty="Advanced"
+  time="about 10 minutes"
+  pathName="The builder track"
+  step={5}
+  totalSteps={8}
+  outcomes={[
+    "Explain the difference between polling and a webhook",
+    "Send data out of the platform with an outbound webhook step",
+    "Test-fire a webhook and read the payload before building on it",
+    "Start an automation from an inbound event",
+  ]}
+/>
+
+## Push, not poll
+
+There are two ways to find out when something happens in another system. You can ask on a timer, over and over, which is called polling. It is wasteful, and it is always a little behind. Or the other system can tell you the instant it happens. That message is a webhook.
+
+A webhook is a small message one system sends another the moment an event occurs. For anything time-sensitive, a lead arriving, an order changing, push beats poll every time.
+
+## Send data out: the outbound webhook step
+
+Inside an automation, a webhook step sends data out to any endpoint you name. It posts a small package of JSON, a plain and structured text format, to a URL you control. Three habits keep it working on the first try:
+
+- Put your data in the body of the request as JSON, not in the headers. Sending it as headers is the single most common mistake.
+- Send values as text. A number sent as a raw number can error; send it as a string.
+- It carries data, not files. There are no attachments.
+
+Before you wire anything downstream, test-fire the step and read exactly what arrives. That payload is the contract everything after it depends on, so you confirm its shape before you build on it, not after.
+
+## Receive events: inbound triggers
+
+The same idea runs in reverse. An automation can start from an inbound webhook: the platform gives the trigger its own unique URL, and a POST to that URL starts the workflow with whatever data you send. An automation can also be started by an API call, or by a glue tool like Zapier sitting in front of it. However it starts, the automation carries the work from there.
+
+## Platform events, when you productize
+
+When you build a product that others resell, the platform can notify you of events on it: a purchase, a new account, a change to a user or a customer. These are platform events, and they let your product react to what happens across every account that uses it. Use that name, platform events, which is the language the documentation uses too.
+
+You will build products like this in a later step. For now, the point is the shape: your code does not have to watch for these things, because the platform pushes them to you as they happen.
+
+:::tip Try it now
+Create an outbound webhook step in a test automation and point it at a free request-bin URL, like Webhook.site. Test-fire it and read the payload that lands. Seeing the exact shape of what the platform sends is the whole game; everything you build downstream is built to match it.
 :::
 
-**What you will learn here:** Outbound webhook steps with test-fire and verification, inbound webhook triggers, and the platform events vendors receive.
+<SectionFeedback courseId="webhooks-and-platform-events" site="vendasta_learn" section="content" />
+
+<KnowledgeCheck courseId="webhooks-and-platform-events" site="vendasta_learn"
+  sessionSize={3}
+  intro="Three quick questions on push versus poll, the outbound step, and starting an automation from outside."
+  questions={[
+    {
+      type: 'mcq',
+      question: 'What is the difference between polling and a webhook?',
+      options: [
+        'Polling is faster; a webhook is a slower backup',
+        'Polling asks on a timer; a webhook tells you the instant it happens',
+        'Polling sends data out; a webhook only receives',
+        'They are two names for the same thing'
+      ],
+      correctIndex: 1,
+      explanation: 'Polling asks "anything new?" on a timer and is always a little behind. A webhook is the other system telling you the moment an event occurs. For time-sensitive work, push beats poll.'
+    },
+    {
+      type: 'mcq',
+      question: 'Your outbound webhook step fires, but the receiving system gets nothing usable. What is the most common cause?',
+      options: [
+        'The data was put in the headers instead of the JSON body',
+        'The automation trigger never ran',
+        'The endpoint URL was too long',
+        'The webhook sent a file attachment'
+      ],
+      correctIndex: 0,
+      explanation: 'Data belongs in the body as JSON. Putting it in the headers is the most common misconfiguration, and the payload arrives empty or unusable.'
+    },
+    {
+      type: 'mcq',
+      question: 'Why test-fire an outbound webhook before building the rest of the workflow?',
+      options: [
+        'To confirm the automation is switched on',
+        'To generate billing for the API call',
+        'To see the exact payload shape everything downstream depends on',
+        'To register the endpoint with the platform'
+      ],
+      correctIndex: 2,
+      explanation: 'The payload is the contract. Test-firing shows you its exact shape so you build downstream steps to match it, instead of guessing and debugging later.'
+    },
+    {
+      type: 'mcq',
+      question: 'How can an automation be started from outside the platform?',
+      options: [
+        'It cannot; automations only start from a schedule',
+        'Only an administrator can start one manually',
+        'By a POST to the trigger\'s unique inbound webhook URL',
+        'By rebuilding it each time you need it'
+      ],
+      correctIndex: 2,
+      explanation: 'An inbound webhook gives the trigger its own URL; a POST to it starts the workflow. An API call or a glue tool can start one too.'
+    }
+  ]}
+/>
+
+<LessonFooter to="/learn/builder/advanced-automations" pathName="The builder track" step={5} totalSteps={8} />
+
+</InlineHighlighter>
+<MarkComplete courseId="webhooks-and-platform-events" site="vendasta_learn" />


### PR DESCRIPTION
Writes the full **Builder learning path** over the scaffolded stubs, live and rendering on the local preview. Eight steps plus the path overview.

## What's here
1. **The integration landscape** — what makes a system connectable (the API doorway), how far you have to go to use it (setting → glue tool → custom tool/API → custom code), and when it is developer work.
2. **Capabilities in depth** — outcome-first design, the Instruction/Guardrail/Trigger flip cards, trimming for reliability.
3. **Custom tools: connect any API** (Lab) — the doorway out, cURL import, the auth strategies, MCP, and the Explanation view as debugger.
4. **Authenticate and make your first API call** (Lab, new step) — service accounts, scopes at token generation, and the contact upsert (match key, fill-if-empty vs overwrite).
5. **Webhooks and platform events** — push vs poll, the outbound step and its real gotchas, inbound triggers, platform events.
6. **Advanced automations** — trigger scope, guarded triggers, activities over notes, custom objects, data expressions.
7. **The builder lab** (Lab) — assemble a custom tool that books a meeting + a CRM upsert into one AI Employee.
8. **Beyond the platform** — where it becomes developer work, keeping logic in the platform, the developer surface, and productizing.

Grounded in the existing partner API docs and 11 CSM/sales-engineer call transcripts (real-partner examples anonymized).

## Open items for review
- A few API specifics still need verification against developers.vendasta.com: exact scope names and the token-generation flow (step 4), the auth-strategy list and current MCP support (step 3). Nothing stated contradicts current docs; these are the spots to confirm.
- Two claims were deliberately left out pending verification: a webhook verifier token and an "orders exportable, invoices not" distinction (step 5).
- **Step 7 (the builder lab)** conceptual frame is solid, but its hands-on treatment (screenshots, lab callouts) should adopt the lab-pattern definition once that lands.
- Step 8's footer routes to Product courses as a placeholder terminus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)