### PR TITLE
Docs: OctoTable connection UX improvements (PHNX-2007)

### DIFF
--- a/docusaurus/docs/business-app/administration/business-connections-integrations.mdx
+++ b/docusaurus/docs/business-app/administration/business-connections-integrations.mdx
@@ -217,6 +217,22 @@ You cannot remove a Facebook connection from within Integrations directly. To re
 
 If the connection fails, verify that the user holds Superadmin-level access on the LinkedIn Page in LinkedIn's settings.
 
+### How to Set Up OctoTable Integration
+
+**Requirements:**
+- An OctoTable account with RixAPI enabled.
+
+**Steps:**
+1. In OctoTable, search for **RixAPI** and enable it.
+2. Locate the **Property ID** in OctoTable — it's needed to complete the connection.
+3. In Business App, go to **Administration** → **Integrations** → **Browse** and find the **OctoTable** card.
+4. Click **Connect**, then enter the **Property ID** on the pre-connect form.
+5. Click **Add Connection** to complete setup.
+
+:::note
+OctoTable connections use a shared, pre-configured Client ID and Secret. Only a Property ID is required to connect — there are no separate Client ID or Secret fields to fill in.
+:::
+
 ### How to Set Up Google Analytics Connection
 
 <img src={require('./img/business-app/google-analytics/ga4-connection-1.jpg').default} alt="GA4 connection process" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
@@ -278,6 +294,7 @@ If the connection fails, verify that the user holds Superadmin-level access on t
 - **Social Media**: Facebook, Instagram, LinkedIn
 - **Analytics**: Google Analytics 4, Google Search Console
 - **Review Platforms**: Google Business Profile integration
+- **Restaurant Management**: OctoTable
 
 ## Frequently Asked Questions
 
@@ -376,5 +393,17 @@ First, check the connection status in the **Manage** tab. Try disconnecting and 
 <summary>Are there additional costs for integrations?</summary>
 
 Most integrations are included with Business App, but some may require specific subscriptions (like Reputation AI Premium for automated review requests). Check the integration marketing page for pricing details.
+</details>
+
+<details>
+<summary>Do I need a Client ID and Secret to connect OctoTable?</summary>
+
+No. Business App uses a shared, pre-configured connection for all OctoTable accounts. Only a Property ID is required to connect.
+</details>
+
+<details>
+<summary>What is RixAPI?</summary>
+
+RixAPI is the name OctoTable uses for the API that must be enabled in an OctoTable account before connecting to Business App.
 </details>
 


### PR DESCRIPTION
## JIRA

[PHNX-2007](https://vendasta.jira.com/browse/PHNX-2007) — Improve OctoTable integration UX to fix mistake and make clear how users connect

## Classification

- **Type:** UI/UX change (connection flow)
- **Repo targeted:** Partner Center (this PR)
- **Also affects:** Business App — see companion PR in `vendasta/businessapp-docs`

## Summary of documentation updates

Updated `docusaurus/docs/business-app/administration/business-connections-integrations.mdx`:

- Added a new **"How to Set Up OctoTable Integration"** subsection describing the current connection flow: enable **RixAPI** in OctoTable, locate the **Property ID**, then connect in Business App using only that Property ID (no Client ID/Secret fields).
- Added a `:::note` clarifying that OctoTable connections use a shared, pre-configured Client ID and Secret, so partners don't need to source or enter those credentials themselves.
- Added **OctoTable** to the "Supported Integration Examples" list under a new "Restaurant Management" category.
- Added two FAQ entries: whether a Client ID/Secret is needed, and what RixAPI is.

## Existing vs. new docs

**Updated existing documentation.** This repo documents all Business App integrations for partner-facing readers in a single comprehensive page rather than one file per vendor (confirmed — no per-vendor integration files exist here, unlike the Business App repo). The new OctoTable subsection follows the same pattern as the existing Facebook/WhatsApp/LinkedIn subsections (Requirements + numbered Steps, no image since none was available).

## Placement reasoning

Inserted the new "How to Set Up OctoTable Integration" subsection directly before the existing "How to Set Up Google Analytics Connection" subsection, alongside the other individual-integration subsections in the same file. No new page or category was created, consistent with this repo's existing structure for integration documentation.

## Acceptance criteria coverage

| AC | Covered |
|---|---|
| Store/use a shared Client ID & Secret for all connections; remove the UI fields asking customers to fill them in | ✅ Documented via the new subsection and note callout, plus a new FAQ entry |
| Add clear step-by-step instructions (find RixAPI in OctoTable, enable it, find account ID) at the top of the connection flow | ✅ Documented as steps 1–2 of the new subsection |

## Figma / images

None were provided on the ticket. No screenshot was added for this subsection (consistent with the existing Facebook/WhatsApp/LinkedIn subsections in this file, which also have no images).

## Skills used

- Manual review against existing file conventions (`business-connections-integrations.mdx`) — no dedicated pre-push validation skill exists in this repo; verified frontmatter, `<details>`/`<summary>` tag balance, and absence of the disallowed `>` character manually.

## Assumptions / limitations

- The ticket's acceptance criteria refer to an "account ID," while implementation comments on the ticket use the term **Property ID** for the same field. This doc uses **Property ID**, matching the field name confirmed in the linked implementation PR discussion.
- Exact OctoTable-side navigation labels were not specified in the ticket and could not be verified against a live screenshot, so instructions are written at the level of detail confirmed in the ticket only.
- Could not confirm the GitHub username of the developer who implemented this change (Kaarthika Subramaniam) — the linked PR lives in `vendasta/platform-integrations`, which is outside this session's repo access, so no reviewer was auto-assigned. Please assign the appropriate reviewer manually.

cc @ahnikakuse @haleyserrano @maryam6samadi


---
_Generated by [Claude Code](https://claude.ai/code/session_01HdYjp6i7s64wfpy3Uxz6X8)_

[PHNX-2007]: https://vendasta.jira.com/browse/PHNX-2007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ