### PR TITLE
docs: document per-channel AI Employee behavior

### DIFF
--- a/docusaurus/docs/ai/ai-capabilities/configuring-capabilities.md
+++ b/docusaurus/docs/ai/ai-capabilities/configuring-capabilities.md
@@ -103,6 +103,17 @@ Get contact info when needed.
 - **Test and iterate** - Try different phrasings and see what produces better results
 :::
 
+### Tailor a capability to specific channels
+
+Your AI Employee knows which channel it's responding on, so a capability's instructions can reference the channel by name. This is useful when a task should behave differently depending on where the customer reaches out — for example, collecting fewer details for lead capture over SMS than by email:
+
+```
+When capturing a lead on SMS, ask for name and phone number only, one question at a time, and keep each message short.
+When capturing a lead by email, you can ask for name, email, phone, and preferred appointment time in a single reply.
+```
+
+For guidance on channel-specific behavior across the whole AI Employee, see [Adjust responses by channel](../ai-workforce/index.mdx#adjust-responses-by-channel).
+
 #### Why Examples Matter
 
 Including examples in your instructions helps your AI understand exactly what you want:

--- a/docusaurus/docs/ai/ai-workforce/ai-chat-receptionist/index.md
+++ b/docusaurus/docs/ai/ai-workforce/ai-chat-receptionist/index.md
@@ -75,6 +75,10 @@ Your AI Chat Receptionist is assigned to the **Web Chat** channel by default. Th
 The Web Chat widget isn't automatically added to your website! You'll need to install the widget code or enable it within your site builder before your AI can start engaging visitors. When you are ready to install the widget, refer to [How to install the Conversations Web Chat Widget](/business-app/conversations/web-chat/)
 :::
 
+:::tip Respond differently on each channel
+Your AI Chat Receptionist knows which channel it's replying on, so it can adapt its tone and reply length per channel. To set this up, add channel-specific instructions to the **Purpose** prompt or to a capability's instructions — for example, "When responding on SMS, keep replies to one or two sentences with no formatting; when responding on web chat, you can use short lists and links." Both places work. See [Adjust responses by channel](../index.mdx#adjust-responses-by-channel) for examples.
+:::
+
 ### Step 2: Configure Your AI Chat Receptionist Capabilities
 
 Capabilities are like instructions that guide how your AI Chat Receptionist behaves and what actions it can take. Review these and adjust as needed to make sure your AI performs the way you want.

--- a/docusaurus/docs/ai/ai-workforce/index.mdx
+++ b/docusaurus/docs/ai/ai-workforce/index.mdx
@@ -172,6 +172,39 @@ The more up-to-date and specific your knowledge sources, the more helpful and ac
 
 ---
 
+## Adjust responses by channel
+
+Your AI Employee knows which channel a conversation is happening on, so a single employee can respond differently depending on where a customer reaches out. A text message and an email often call for different lengths and tones, and your AI can adapt to each one automatically.
+
+**What this is:**  
+There's no separate menu for per-channel behavior. Instead, you write **channel-specific instructions** in the same places you write your other instructions, and the AI applies them only when it's responding on that channel.
+
+**What to do:**  
+Add channel-specific instructions in either (or both) of these places:
+
+- **The Purpose field** (labeled `Role` on the Chat and Voice Receptionists) — best for behavior that should apply across everything the employee does, such as tone, greeting style, or reply length per channel.
+- **A capability's instructions** — best for shaping a single task, such as how much information to collect for lead capture on SMS versus email.
+
+Reference the channel by name in your instructions and describe how you want the AI to behave there. For example, add lines like these to your Purpose field or a capability's instructions:
+
+```text wrap
+When responding on SMS, keep replies short and conversational. Use plain text only — no bullet points, headings, or markdown, since text messages display them as raw symbols. Aim for one or two sentences.
+
+When responding by email, you can write longer, more detailed replies. Open with a professional greeting and sign off with the business name.
+
+When responding on web chat, keep answers brief and friendly, and offer to continue the conversation or book an appointment.
+```
+
+:::tip
+Only add channel-specific instructions for the channels where the default behavior isn't quite right. For everything else, your AI Employee falls back to its general Purpose and capability instructions.
+:::
+
+:::info Instructions shape communication, not actions
+These instructions change *how* your AI Employee communicates on each channel. They don't change *which* actions it can take — those come from its capabilities and tools. See the [AI Capabilities Overview](../ai-capabilities/).
+:::
+
+---
+
 ## Testing and optimizing your AI Employees
 
 After initial setup, regularly test and optimize your AI Employees to ensure they're performing effectively.


### PR DESCRIPTION
## What this does

Adds docs for the feature where an AI Employee knows which channel it's replying on and can respond differently per channel (e.g. short texts on SMS, longer replies by email).

Mirrors the same change made in the Business App end-user docs, so partners and their SMB clients get the same guidance from either site.

## The key point

There's no separate menu for this. You add channel-specific instructions to the fields you already use, and the AI applies them only on that channel:

- **Purpose / Role field** — for how the AI behaves overall
- **A capability's instructions** (like Lead Capture) — for one specific task

Both work. That answers the common question: "Do I use the Role field or the lead capture capability?" — either.

## Files changed

- **AI Workforce Overview** — new "Adjust responses by channel" section with copy-paste examples.
- **AI Chat Receptionist** — a short callout under Communication Channels pointing to that section.
- **Configuring capabilities** — a per-channel lead capture example.

## Link to share (live after this merges)

- `/ai/ai-workforce#adjust-responses-by-channel` — the main one, covers all AI Employees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)