### PR TITLE
fix(executive-report): clarify Citation Builder is independent of Rep…

### DIFF
--- a/docusaurus/docs/multi-location-business-app/executive-report/executive-report.mdx
+++ b/docusaurus/docs/multi-location-business-app/executive-report/executive-report.mdx
@@ -105,7 +105,9 @@ This means the two tabs will often show different numbers, which is expected, no
 
 Citation tracking in the Executive Report provides proof of performance under the Listings category. Citations are mentions of a business found online—a business name plus another detail (phone number, website, or address). They help search engines understand a business and improve findability.
 
-Citation data is powered by **Reputation AI Pro**. The citations card appears for accounts that have Reputation AI Pro active. **Citation Builder** and **Listing Sync Pro** can also affect and help increase citations found. If Reputation AI Pro is not active for a client, the citations card does not appear in their Executive Report.
+The citation tracking card in the Executive Report is powered by **Reputation AI Pro** — it appears only for accounts that have Reputation AI Pro active. If Reputation AI Pro is not active for a client, the citations card does not appear in their Executive Report.
+
+**Citation Builder** and **Listing Sync Pro** are separate, independent Local SEO add-ons that can help build and increase citations found for a business. Neither requires Reputation AI Pro to be active — they're sold and used on their own. Citation Builder is currently available for businesses located in the **US only**.
 
 ![Citation tracking in executive report](../img/multi-location/citation-tracking.jpg)
 


### PR DESCRIPTION
…utation AI Pro

AI Assistant was citing this FAQ entry and telling users Citation Builder requires Reputation AI Pro, since the doc conflated the citation tracking card (which does require Reputation AI Pro) with Citation Builder (a separate Local SEO add-on). Also adds US-only availability, which the assistant was previously guessing at.