### PR TITLE
Docs: A2P campaign rejection reason now shown in registration status (BREW-2746)

### DIFF
--- a/docusaurus/docs/business-app/conversations/sms/us-businesses-sms-registration.mdx
+++ b/docusaurus/docs/business-app/conversations/sms/us-businesses-sms-registration.mdx
@@ -142,7 +142,7 @@ If the brand registration was approved but the campaign was rejected, the most c
 - Sample messages don't include opt-out instructions (e.g., "Reply STOP to unsubscribe")
 - Sample messages include a public URL shortener like bit.ly or tinyurl.com. These are blocked by carriers.
 
-If the registration is rejected, the business should correct the issue and resubmit once the form shows a failed status.
+If the registration is rejected, the registration status shows the specific reason for the failure. The business should use it, together with the causes above, to correct the issue and resubmit once the form shows a failed status.
 </details>
 
 <details>


### PR DESCRIPTION
## Summary

- **JIRA:** [BREW-2746 — Display all the Campaign errors in the A2P Form, and Email](https://vendasta.jira.com/browse/BREW-2746)
- **Classification:** Feature behavior change / UI change (A2P campaign registration flow)
- **Repo targeted:** Partner Center

The story's user need explicitly covers "an SMB **or Partner supporting an SMB**", and this repo carries its own copy of the US SMS registration article (used when a partner is helping a client through A2P registration/rejection). Updated that copy so partners point clients to the specific rejection reason now shown in-app, instead of only the general rejection-cause list.

## Files changed

- `docusaurus/docs/business-app/conversations/sms/us-businesses-sms-registration.mdx` — "Why was the registration rejected?" FAQ, campaign-rejection subsection

## Existing docs updated vs. new docs created

Updated an existing page only — no new page created. The article already had a "Why was the registration rejected?" FAQ covering the same rejection categories as the Business App version. Added one sentence to the campaign-rejection subsection pointing to the in-app rejection message.

## Placement reasoning

This is the most directly relevant, already-sidebar-linked article covering A2P registration for the partner audience. No new section or page was warranted for a one-sentence clarification.

## Acceptance criteria coverage

| Acceptance criterion | Status |
|---|---|
| Fetch and store detailed A2P failure reasons if not already stored | Backend-only; not user-facing, not documented |
| Detailed campaign failure reasons displayed in the UI | ✅ Documented — FAQ now notes the registration status shows the specific rejection reason |
| Detailed campaign failure reasons displayed in the email notification | ⚠️ **Not documented.** The subtask for this criterion, [BREW-2787](https://vendasta.jira.com/browse/BREW-2787), is still **To Do**. Documenting the email behavior now would describe a feature that isn't live yet. |

## Rollout status note

The parent epic, [BREW-2733 "A2P Revisions"](https://vendasta.jira.com/browse/BREW-2733), is still in **Team Planning** status. Its other open children (BREW-2773, BREW-2749) are backend/reporting follow-ups with no feature-flag, eligibility, or region-gating language — so they don't block this doc update. Flagging the epic's incomplete status here as a transparency note.

## Figma/images

None provided on the ticket (no attachments). No new screenshots needed.

## Skills used

None of this repo's specialized skills applied directly (no learning-path or cross-repo sync content involved); edit was a direct, minimal FAQ update following repo formatting conventions in CLAUDE.md.

## Assumptions/limitations

- No access to the underlying product/code repo, so exact UI copy for the new rejection-reason display couldn't be verified — wording stays generic to match acceptance-criteria language without inventing UI labels.
- Email-notification behavior intentionally omitted per the acceptance-criteria table above.

---
@ahnikakuse @haleyserrano @maryam6samadi

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_0165SGk4sMjizxdQmrZGBJyi)_

[BREW-2787]: https://vendasta.jira.com/browse/BREW-2787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ