### PR TITLE
docs: article verification fixes for 5 flagged articles

### DIFF
--- a/docusaurus/docs/accounts/reports/executive-report-advertising.mdx
+++ b/docusaurus/docs/accounts/reports/executive-report-advertising.mdx
@@ -5,17 +5,15 @@ sidebar_label: Advertising
 description: View Google Ads and Facebook Ads performance summaries in the Executive Report via Advertising Intelligence.
 ---
 
-# Executive Report: Advertising (Advertising Intelligence)
+## What is the advertising performance summary?
 
-## What is the Advertising Performance Summary?
+You can view performance summaries for both your Facebook Ads and Google Ads accounts within the Executive Report in Business App. This consolidated view gives you and your clients a complete picture of advertising performance across multiple platforms.
 
-Users of Advertising Intelligence can view performance summaries for both their Facebook Ads and Google Ads accounts within the Executive Report in Business App. This consolidated view gives you and your clients a complete picture of advertising performance across multiple platforms.
-
-## Why is the Advertising Performance Summary important?
+## Why is the advertising performance summary important?
 
 You and your clients can see what's happening across all your digital marketing channels in one place. This allows you to quickly and easily get insights into which ads are performing well and cut down on overhead with automated reporting. By combining real-time performance reporting across ad channels with unique sales data, you can keep your clients updated with their true ROI.
 
-### Metrics You Can View
+### Metrics you can view
 
 - **ROI** - Return on investment across advertising channels
 - **Client spend** - Total advertising spend
@@ -24,27 +22,27 @@ You and your clients can see what's happening across all your digital marketing 
 - **Conversions** - Actions taken by users (purchases, sign-ups, etc.)
 - **Comparisons to previous time period** - Week-over-week or month-over-month performance
 
-## How to Set Up Advertising Performance Reporting
+## How to set up advertising performance reporting
 
 ### Prerequisites
 - Advertising Intelligence must be activated for the account
 - Ad accounts must be connected to Advertising Intelligence
 
-### Connecting Ad Accounts
+### Connecting ad accounts
 1. With Advertising Intelligence activated, connect your Facebook Ads and/or Google Ads accounts to the product
 2. Go to the Executive Report in Business App and select a time period
 3. Under the "Advertising" section, you'll see subsections for "Facebook Ads" and "Google Ads" (depending on which accounts are connected)
 
-### Viewing Performance Data
+### Viewing performance data
 In the Executive Report, you can view the summary of both your Facebook Ads and Google Ads campaigns in a unified advertising section. This provides a comprehensive view of your advertising performance across platforms.
 
 ![Facebook Ads Performance Summary in Executive Report](../../business-app/executive-report/img/facebook-ads-performance.jpg)
 
-## Data Updates
+## Data updates
 
 Updated advertising data in the Executive Report is populated every Sunday, starting the week when you connect an account. This ensures you have regular, consistent updates on your advertising performance to share with clients.
 
-## Supported Advertising Platforms
+## Supported advertising platforms
 
 The Executive Report currently supports advertising data from:
 - **Google Ads** (via Advertising Intelligence)

--- a/docusaurus/docs/business-app/executive-report/leads.mdx
+++ b/docusaurus/docs/business-app/executive-report/leads.mdx
@@ -8,23 +8,21 @@ tags: [leads, executive-report, lead-generation, conversions, ai-receptionist]
 keywords: [leads-tracking, lead-sources, phone-calls, web-chat, ai-receptionist, customer-interactions]
 ---
 
-# Executive Report: Leads
+The Leads section of the Executive Report provides a comprehensive view of how many new leads and customer interactions your clients are generating across all channels. This section helps partners demonstrate lead generation value and track the effectiveness of different lead capture methods.
 
-The Leads section of the Executive Report provides a comprehensive view of how many new leads and customer interactions your business is generating across all channels. This section helps partners demonstrate lead generation value and track the effectiveness of different lead capture methods.
+## What's included in leads reporting
 
-## What's Included in Leads Reporting
-
-### Lead Generation Summary
+### Lead generation summary
 - **Number of new leads captured in CRM, by source**: Overall count of organically captured leads with source breakdown
 - **Number of conversations happening in Conversations, by channel**: Communication activity across all channels
 - **Web chat effectiveness metrics**: Detailed web chat performance tracking
 
-### Web Chat Specific Metrics
+### Web Chat specific metrics
 - **Unique visitors that saw web chat**: Total website visitors who were shown the chat widget
 - **Unique conversations**: Number of visitors who actually engaged with the web chat
 - **Leads captured**: Web chat conversations that resulted in captured lead information
 
-### Lead Sources Tracked
+### Lead sources tracked
 The Leads section aggregates data from organically captured leads only. Sources include:
 
 - **Phone Calls** (Google Business Profile) - Direct calls from business listings
@@ -35,7 +33,7 @@ The Leads section aggregates data from organically captured leads only. Sources 
 - **SMS** - Text message conversations that generate leads
 - **Any other lead source** - Custom lead sources are automatically included
 
-:::important Lead Source Exclusions
+:::warning Lead Source Exclusions
 Leads are **not counted** in these analytics when they come from:
 - **Bulk Import** - Manually imported contact lists
 - **CRM UI** - Contacts manually created in the CRM interface
@@ -43,30 +41,30 @@ Leads are **not counted** in these analytics when they come from:
 These manual additions are excluded since they're not organically captured leads. To include manually created leads in analytics, change their lead source field to something other than "bulk import" or "crm ui".
 :::
 
-### Messages and Conversations
+### Messages and conversations
 - **Message Volume**: Total messages across all channels with timeline visualization
 - **Message Types**: Breakdown of received messages vs. sent by AI vs. sent by team
 - **Conversations by Source**: Charts showing conversation creation from SMS, WebChat, and Email
 - **Lead Conversion**: Tracking of conversations that convert into actionable leads
 
-## Understanding Your Lead Data
+## Understanding your lead data
 
-### Lead Summary Metrics
+### Lead summary metrics
 The top-level metrics show:
 ```
 Leads: 59 (-2)
 ```
 This indicates 59 total leads for the period, with a decrease of 2 from the previous period.
 
-### Lead Source Breakdown
-Individual source performance might look like:
+### Lead source breakdown
+Individual source performance looks like:
 - **Phone calls (Google Business Profile)**: 29 leads
 - **AI Voice Receptionist**: 20 leads  
 - **Web Chat**: 3 leads
 - **Zapier**: 2 leads
 - **Forms**: 2 leads
 
-### Message Activity
+### Message activity
 - **Total messages**: Shows volume across all communication channels
 - **Daily timeline**: Visual representation of message activity over time
 - **Message categories**: 
@@ -74,7 +72,7 @@ Individual source performance might look like:
   - Messages sent by AI receptionist
   - Messages sent by your team
 
-## Why This Data Matters
+## Why this data matters
 
 ### For Partners
 - **Demonstrate ROI**: Show clients exactly how many leads you're generating
@@ -82,33 +80,33 @@ Individual source performance might look like:
 - **Service Value**: Prove the impact of AI receptionist and web chat tools
 - **Growth Tracking**: Monitor lead generation trends over time
 
-### For Client Conversations
+### For client conversations
 - **Lead Quality**: Discuss which sources generate the highest-converting leads
 - **Channel Optimization**: Recommend focusing on best-performing lead sources
 - **Technology Impact**: Show value of AI tools in lead capture and response
 - **Competitive Advantage**: Demonstrate comprehensive lead tracking capabilities
 
-## Optimizing Lead Generation
+## Optimizing lead generation
 
-### Best Practices
+### Best practices
 - **Multi-channel approach**: Enable multiple lead capture methods for comprehensive coverage
 - **AI Integration**: Utilize AI Voice Receptionist and Web Chat for 24/7 lead capture
 - **Response Speed**: Monitor message activity to ensure fast response times
 - **Data Integration**: Connect Zapier integrations for complete lead tracking
 
-### Configuration Tips
+### Configuration tips
 - **Form Integration**: Ensure website forms are properly connected to CRM
 - **Phone Tracking**: Verify Google Business Profile phone number accuracy
 - **Chat Setup**: Configure web chat widget for optimal lead conversion
 - **AI Training**: Optimize AI receptionist for industry-specific lead qualification
 
-## Multi-Location Support
+## Multi-Location support
 
 Lead analytics are available in both Single-Location and Multi-Location Executive Reports:
 - **Single-Location**: Shows leads specific to that location
 - **Multi-Location**: Provides rolled-up analytics across all locations for comprehensive overview
 
-## Related Lead Capture Tools
+## Related lead capture tools
 
 The Leads section integrates with several Vendasta products:
 - **AI Voice Receptionist** - Automated phone answering and lead qualification
@@ -118,9 +116,9 @@ The Leads section integrates with several Vendasta products:
 - **Google Business Profile** - Business listing optimization for phone leads
 - **Conversations** - Unified inbox for all customer communications
 
-## Data Sources and Requirements
+## Data sources and requirements
 
-### What Data Feeds This Section
+### What data feeds this section
 - **Google Business Profile**: Phone call tracking and customer actions
 - **AI Voice Receptionist**: Call volume and lead qualification data
 - **Web Chat**: Chat interactions and lead conversion tracking
@@ -128,7 +126,7 @@ The Leads section integrates with several Vendasta products:
 - **Zapier**: Third-party integration data
 - **SMS Platform**: Text message conversations and lead data
 
-### Setup Requirements
+### Setup requirements
 For complete lead tracking, ensure:
 - Google Business Profile is connected and phone tracking is enabled
 - AI Voice Receptionist is configured for your business
@@ -137,7 +135,7 @@ For complete lead tracking, ensure:
 - Zapier connections are active (if used)
 - SMS services are set up for text-based lead capture
 
-## Frequently Asked Questions (FAQs)
+## Frequently asked questions (FAQs)
 
 <details>
 <summary>Why don't I see all lead sources in my report?</summary>
@@ -148,7 +146,7 @@ Lead sources only appear when there's data available. If you don't see a particu
 <details>
 <summary>How are leads counted vs. conversations?</summary>
 
-**Conversations** track all customer interactions, while **Leads** specifically count interactions that result in actionable contact information or qualified prospects. A single customer might generate multiple conversations but only count as one lead.
+**Conversations** track all customer interactions, while **Leads** specifically count interactions that result in actionable contact information or qualified prospects. A single customer can generate multiple conversations but only count as one lead.
 </details>
 
 <details>
@@ -160,7 +158,7 @@ The Executive Report shows lead volume by source. For conversion tracking and le
 <details>
 <summary>Why do message counts seem higher than lead counts?</summary>
 
-Messages include all communications (initial contact, follow-ups, customer service), while leads specifically count new prospects. A single lead might generate dozens of messages throughout the customer relationship.
+Messages include all communications (initial contact, follow-ups, customer service), while leads specifically count new prospects. A single lead can generate dozens of messages throughout the customer relationship.
 </details>
 
 <details>
@@ -187,7 +185,7 @@ Leads are counted when they come from any source **except** "bulk import" and "c
 Yes, you can hide the Leads section in **Partner Center > Accounts > Manage Business App > Customize Business App > Executive Report > Sections** if lead tracking isn't properly configured or you don't want to show incomplete data.
 </details>
 
-## Related Resources
+## Related resources
 
 - [Executive Report Overview](./index.mdx)
 - [Customize Executive Report](/accounts/reports/customize-executive-report)

--- a/docusaurus/docs/business-app/executive-report/seo.mdx
+++ b/docusaurus/docs/business-app/executive-report/seo.mdx
@@ -6,9 +6,7 @@ sidebar_position: 30
 description: Show SEO proof-of-performance using Google Search Console and MarketGoo data in the Executive Report.
 ---
 
-# Executive Report: SEO (Google Search Console & MarketGoo)
-
-Show SEO proof-of-performance in the Executive Report! Automatically prove that the work you're doing for your customers is helping their business show higher in Google search results.
+Show SEO proof-of-performance in the Executive Report. Automatically prove that the work you're doing for your clients is helping their business show higher in Google search results.
 
 ## Google Search Console
 
@@ -20,7 +18,7 @@ By connecting [Google Search Console](https://search.google.com/search-console/a
 - Which queries are getting the most clicks, and their average position in search results?
 - Which website pages are getting the most clicks and impressions?
 
-With this powerful no-cost feature, you can show how all the hard work you do on a business's marketing (website content, blog, listings, reviews, social media, etc) is resulting in real improvements in their SEO – to help you retain your clients for longer!
+With this no-cost feature, you can show how all the hard work you do on a business's marketing (website content, blog, listings, reviews, social media, etc) is resulting in real improvements in their SEO, helping you retain your clients for longer.
 
 ![Google Search Console report](./img/google-search-console-report.jpg)
 
@@ -80,13 +78,13 @@ MarketGoo data populates within the Executive Report under the SEO section. It's
 
 If Google Search Console data is not appearing in your Executive Report, follow these troubleshooting steps:
 
-### 1. When Was GSC Connected?
+### 1. When was GSC connected?
 Data collection begins after the GSC account is connected, but it can take a few days for the data to populate. Please verify when GSC was connected and check if data is visible within the GSC interface.
 
-### 2. Daily Data Collection Timing
+### 2. Daily data collection timing
 Note that data is collected once daily, typically around midnight CST. Any recent changes may take up to 24 hours to reflect in reports.
 
-### 3. When Did the Website Go Live?
+### 3. When did the website go live?
 If the website is newly launched, there may not be sufficient data yet to display in the reports. Check for activity or traffic within GSC to confirm.
 
 If you have completed these checks and the issue persists, additional investigation may be required.
@@ -106,15 +104,15 @@ If you have completed these checks and the issue persists, additional investigat
 
 **How are the 'Queries on 1st page of Google Search' cards calculated?**
 
-- We created a new custom metric that is a great way to show proof of improvement over time to a business owner. Each day, we count the number of queries where:
+- This custom metric is a great way to show proof of improvement over time to a business owner. Each day, we count the number of queries where:
   - They each have an average position of between 1.0 and 10.0 (the first page of Google).
   - The business's website received at least one click within the last 30 days for that keyword.
-- We created this definition to eliminate the noise that can come from the hundreds of keywords a business might appear for but never get a click, because of poor relevancy.
+- This definition eliminates the noise that can come from the hundreds of keywords a business appears for but never gets a click, because of poor relevancy.
 - This number is calculated once every 24 hours and then plotted on a trendline, to show a trend over time. As a website's SEO is improved, so will this number on this card.
 
 **Why aren't Average CTR or Average Position metrics in the reporting?**
 
-- Average CTR (click-through-rate) and Average Position are helpful metrics to look at on a per-keyword level, but when rolled up as an overall stat, they are not helpful in proving performance to an SMB client, because they are averages that will continually be dragged down by every new keyword that the website appears for. Essentially, these are two metrics a business will never be able to win at, and will never go "up and to the right". So we decided to not include them in our Executive Report of high-level performance metrics.
+- Average CTR (click-through-rate) and Average Position are helpful metrics to look at on a per-keyword level, but when rolled up as an overall stat, they are not helpful in proving performance to an SMB client, because they are averages that will continually be dragged down by every new keyword that the website appears for. Essentially, these are two metrics a business will never be able to win at, and will never go "up and to the right". So these metrics aren't included in our Executive Report of high-level performance metrics.
 
 **Do you support Domain Properties?**
 

--- a/docusaurus/docs/business-app/my-products/index.mdx
+++ b/docusaurus/docs/business-app/my-products/index.mdx
@@ -1,22 +1,21 @@
 ---
 title: My Products
 sidebar_position: 1
+description: Let your clients view, access, and organize their active products from the My Products page in Business App.
 ---
-
-# My Products
 
 Your clients can view and access their products right from their Business App. On the Products page in Business App, your clients will be able to see all of the products they have active. They can also select the ones that they use the most to appear in the side panel.
 
-![My Products page in Business App](./img/my-products-1.png)
+<img src={require('./img/my-products-1.png').default} alt="My Products page in Business App" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
 
-### **Configuring My Products in Business App**
+### Configuring my products in Business App
 
-You can remove access to the My Products page for all of your clients by going to **Partner Center > Administration > Customize Business App > My products** and unchecking the box that shows the page.
+You can remove access to the My Products page for all of your clients by going to `Partner Center` → `Administration` → `Customize Business App` → `My products` and unchecking the box that shows the page.
 
-You can hide this tab or remove access for individual products on a user-by-user basis by [configuring their permissions](/accounts/manage-users/configure-user-permissions.mdx).
+You can hide this tab or remove access for individual products on a user-by-user basis by [configuring their permissions](/accounts/manage-users#managing-user-permissions).
 
-### **How can I organize the products on the side panel of Business App?**
+### How can I organize the products on the side panel of Business App?
 
-By clicking on the Products page and clicking on the pin icon in the top right of each product, you can choose which products will appear on the Business App side panel, for yourself. Each user can set these independently.
+From the Products page, click the pin icon in the top right of each product to choose which products appear on the Business App side panel, for yourself. Each user can set these independently.
 
-![Pin icon to organize products](./img/my-products-2.png)
+<img src={require('./img/my-products-2.png').default} alt="Pin icon to organize products" style={{width: '60%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />

--- a/docusaurus/docs/vendasta-services/sales-marketing-assets/marketing-information-by-product.md
+++ b/docusaurus/docs/vendasta-services/sales-marketing-assets/marketing-information-by-product.md
@@ -1,10 +1,10 @@
 ---
 title: "Marketing Information By Product"
 sidebar_label: "Marketing Information By Product"
-description: "We have a host of information and marketing assets available in the Marketplace. For quick access and easy reference, we have provided a list of the main produ"
+description: "Find marketing information and assets for each product in the Marketplace, including quick links to the main product pages."
 ---
 
-We have a host of information and marketing assets available in the Marketplace. Go to *Screenshots and Files* at the top of each page to find valuable resources. For quick access and easy reference, here is a list of the main product pages here:
+We have a host of information and marketing assets available in the Marketplace. Go to `Screenshots and Files` at the top of each page to find valuable resources. For quick access and easy reference, here is a list of the main product pages:
 
 *   [Local Listings Management](https://partners.vendasta.com/marketplace/products/MP-5DVQX5R8JBTD2RHWZLZ5BD56RTHJPW84)
     
@@ -14,5 +14,3 @@ We have a host of information and marketing assets available in the Marketplace.
     
 *   [Templated Website](https://partners.vendasta.com/marketplace/products/MP-FG7W5FPWG4VWLRVPWM8GX2MJ4MTC7D8H)
     
-
-For insights and top tips on accessing and using these resources, check out this video:


### PR DESCRIPTION
## Summary
Daily article verification batch for 5 flagged articles: fixed duplicate H1 headings, title-case headings, audience-language issues, prohibited/promotional wording, evergreen tense violations, an invalid callout type, a broken internal link, and missing/truncated frontmatter.

- **Marketing Information By Product** — fixed truncated description, duplicate wording, removed a dangling video reference with no link
- **My Products** — fixed broken internal link, added missing description, converted images to standard require() markup, tightened phrasing
- **Executive Report: Leads** — fixed invalid \`:::important\` callout, removed prohibited \"might\" (x3), 20 headings to sentence case
- **Executive Report: SEO** — removed promotional tone (\"powerful\", exclamation), fixed 2 evergreen tense violations, removed \"might\", 3 headings to sentence case
- **Executive Report: Advertising** — removed duplicate H1, 8 headings to sentence case, audience-language fix

**Not included:** issue #723 (Executive Report: Advertising) is intentionally left open — it flags a genuine product-fact conflict between this article (Facebook Ads) and \`business-app/demoing-business-app-to-clients.mdx\` (Microsoft Ads) that needs SME confirmation before either is corrected. See the discussion on that issue for follow-up.

## Test plan
- [ ] Spot-check rendered pages for the 5 articles (headings, callout, images)
- [ ] Confirm internal link fix in My Products resolves correctly
- [ ] SME to resolve Advertising Intelligence platform discrepancy (issue #723) separately

Closes #726
Closes #727
Closes #724
Closes #725

🤖 Generated with [Claude Code](https://claude.com/claude-code)