### PR TITLE
Docs: direct product URLs in Marketplace Products (DENG-815)

### DIFF
--- a/docusaurus/docs/marketplace/products/index.mdx
+++ b/docusaurus/docs/marketplace/products/index.mdx
@@ -145,6 +145,12 @@ For the custom package option, you must first create and publish the package to 
 You can also fulfill an order by selecting the order notification from your notifications panel.
 </details>
 
+<details>
+<summary>Can I link directly to a specific product?</summary>
+
+Yes. Each product you open in **Marketplace** → **Products** has its own URL. Copy it from your browser's address bar to bookmark it or share a direct link to that product.
+</details>
+
 ## Advanced product management
 
 - **Markets**: With Markets, set pricing and availability by region, use market-specific branding, and monitor performance per market.


### PR DESCRIPTION
## JIRA
[DENG-815](https://vendasta.jira.com/browse/DENG-815) — "Add URL to all products to help find the product detail faster" (Done)

## Classification
UI/UX change — Marketplace product deep-linking

## Repo
Partner Center docs only. Not applicable to Business App: product management under **Marketplace → Products** is a partner-facing workflow, not something Business App end users see.

## Summary of updates
Added one FAQ entry to the existing **Products overview** page (`docusaurus/docs/marketplace/products/index.mdx`) noting that each product now has its own URL that can be copied/bookmarked/shared, per the ticket's stated goal of helping partners find a product's detail page faster.

## Existing vs. new docs
Updated existing docs — no new page created. The `marketplace/products/index.mdx` overview page already documents the Products list and per-product management, and already has a "Frequently asked questions" section with the same `<details>` pattern, so this fits there without disrupting structure.

## Placement reasoning
Added as the last FAQ entry before the "Advanced product management" section, alongside other product-discovery/navigation FAQs (e.g. renaming products, disabling auto-activation).

## Acceptance criteria coverage
None were listed on the ticket — the only source material was the summary and a single example URL (`.../marketplace/manage-products/{productId}`) in the description, confirming the per-product URL pattern exists. The doc update is scoped strictly to that one fact.

## Figma / images
None provided or used.

## Skills used
None of the repo's authoring skills matched this narrow a change; edited directly following the existing FAQ format and this repo's markdown conventions (`→` instead of `>`, `<details>` spacing).

## Assumptions / limitations
- No parent epic is linked to this ticket, so the Step 1.5 rollout-gating check found nothing to verify against.
- No linked GitHub PR/remote link was found on the ticket, and GitHub access for this task is scoped to `businessapp-docs`/`partnercenter-docs` only, so the implementing engineer could not be identified for review assignment. No reviewer has been requested; please assign manually.
- The ticket description is minimal (a summary line plus one example URL, no acceptance criteria). This PR documents only the literal, confirmed behavior (a per-product URL exists) and avoids inferring any additional UI (e.g. a visible "copy link" button) not evidenced in the source.

---
@ahnikakuse @haleyserrano @maryam6samadi


---
_Generated by [Claude Code](https://claude.ai/code/session_01XXxG7DwSGBtym5NYA4Qt8u)_

[DENG-815]: https://vendasta.jira.com/browse/DENG-815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ