### PR TITLE
docs: rename Social Marketing to Social AI across cross-references

### DIFF
--- a/docusaurus/docs/accounts/accounts-lists/list-actions.mdx
+++ b/docusaurus/docs/accounts/accounts-lists/list-actions.mdx
@@ -61,7 +61,7 @@ Creates a downloadable CSV with the current data of all accounts in the List. Th
 - Website
 - Salesperson Email
 - Customer Identifier
-- Active Products (Listing Builder, Social Marketing, Reputation AI)
+- Active Products (Listing Builder, Social AI, Reputation AI)
 - Account Identifier
 - Tags
 - Toll-free Number

--- a/docusaurus/docs/administration/advanced/developer-apis/apis-and-environment.mdx
+++ b/docusaurus/docs/administration/advanced/developer-apis/apis-and-environment.mdx
@@ -57,8 +57,8 @@ We have APIs for the following products:
 - **Partner Center** - Manage accounts, users, and platform settings
 - **Local SEO** - Control local search optimization features
 - **Reputation AI** - Manage reviews and reputation data
-- **Social Marketing** - Automate social media posting and management
-  - *Note: the API does not support all features available in-product for Social Marketing*
+- **Social AI** - Automate social media posting and management
+  - *Note: the API does not support all features available in-product for Social AI*
 
 ### Products without current API access
 
@@ -164,7 +164,7 @@ Yes, for Partners on certain paid subscription levels, we offer APIs that enable
 <details>
 <summary>Which products have API access available?</summary>
 
-APIs are available for Brand Analytics, Business App, Partner Center, Local SEO, Reputation AI, and Social Marketing. APIs are not currently available for Snapshot Report, Task Manager, and Billing reports.
+APIs are available for Brand Analytics, Business App, Partner Center, Local SEO, Reputation AI, and Social AI. APIs are not currently available for Snapshot Report, Task Manager, and Billing reports.
 
 </details>
 

--- a/docusaurus/docs/administration/platform-settings/client-notifications/index.mdx
+++ b/docusaurus/docs/administration/platform-settings/client-notifications/index.mdx
@@ -58,7 +58,7 @@ After enabling the master toggle, expand each product section to configure its n
 
 - **Business App** — activity within your clients' Business App
 - **Review Management** — new reviews and responses
-- **Social Marketing** — post publishing and campaign activity
+- **Social AI** — post publishing and campaign activity
 - **WordPress Hosting** — website changes and alerts
 - **Orders and Commerce** — order placements, fulfillments, and billing events
 - **Task Manager** — task assignments, updates, and completions

--- a/docusaurus/docs/administration/platform-settings/customize-business-app/setup-guide.mdx
+++ b/docusaurus/docs/administration/platform-settings/customize-business-app/setup-guide.mdx
@@ -78,7 +78,7 @@ Test the complete client experience:
 The Get Started experience in Business App walks clients through key stages of the customer journey.
 
 ### Awareness
-Help clients expand their reach via social media. Prompt them to publish a post with Social Marketing.
+Help clients expand their reach via social media. Prompt them to publish a post with Social AI.
 
 ### Findability
 Ensure business listings stay accurate. Encourage the **Verify listings** or **Update business info** calls-to-action.
@@ -153,7 +153,7 @@ Disable the walkthrough video by navigating to **Partner Center** → **Administ
 <details>
 <summary>Should I connect my social accounts in Business App first?</summary>
 
-Yes. Connecting Facebook, Google Business Profile, or other social accounts inside Business App automatically shares those connections with products such as Social Marketing, Reputation AI, and Local SEO. Even if no products are active, the Marketing Funnel still displays insights sourced from connected accounts.
+Yes. Connecting Facebook, Google Business Profile, or other social accounts inside Business App automatically shares those connections with products such as Social AI, Reputation AI, and Local SEO. Even if no products are active, the Marketing Funnel still displays insights sourced from connected accounts.
 </details>
 
 <details>

--- a/docusaurus/docs/business-app/demoing-business-app-to-clients.mdx
+++ b/docusaurus/docs/business-app/demoing-business-app-to-clients.mdx
@@ -36,7 +36,7 @@ Each client account you create in Partner Center automatically gets a Business A
 
 ### What clients see
 
-When clients log in, they see only the products and services you've activated for them. If you activate Local SEO, they see the Local SEO dashboard. If you activate Social Marketing, they see Social Marketing. The interface adapts based on what they've purchased.
+When clients log in, they see only the products and services you've activated for them. If you activate Local SEO, they see the Local SEO dashboard. If you activate Social AI, they see Social AI. The interface adapts based on what they've purchased.
 
 ### Your role as a partner
 
@@ -95,15 +95,15 @@ Local SEO syncs your client's business information across online directories and
 - Client knows which directories are connected
 - Client can see keyword rankings (if applicable)
 
-### Step 3: Walk through Social Marketing
+### Step 3: Walk through Social AI
 
 **What to show them:**
 
-Social Marketing lets clients create, schedule, and publish posts across multiple social platforms from one place.
+Social AI lets clients create, schedule, and publish posts across multiple social platforms from one place.
 
 **How to demo it:**
 
-1. Open `Social Marketing`
+1. Open `Social AI`
 2. Show connected accounts under `Connect Accounts`
 3. Open `Posts` and click `Create` (blue button)
 4. Walk through creating a post:
@@ -229,15 +229,15 @@ The Executive Report pulls proof-of-performance data from all connected products
 </details>
 
 <details>
-<summary>Which platforms can be connected in Social Marketing?</summary>
+<summary>Which platforms can be connected in Social AI?</summary>
 
 Connected platforms vary by plan. Common platforms include Facebook, Google Business Profile, Instagram, X, LinkedIn, TikTok, and WordPress blogs.
 </details>
 
 <details>
-<summary>Can I post on my client's behalf in Social Marketing?</summary>
+<summary>Can I post on my client's behalf in Social AI?</summary>
 
-Yes, social posts can be created by a user who is directly logged in or an admin Social Marketing with the appropriate permissions. You cannot impersonate a user to make a social post.
+Yes, social posts can be created by a user who is directly logged in or an admin in Social AI with the appropriate permissions. You cannot impersonate a user to make a social post.
 </details>
 
 <details>

--- a/docusaurus/docs/business-app/executive-report/index.mdx
+++ b/docusaurus/docs/business-app/executive-report/index.mdx
@@ -55,7 +55,7 @@ The following products push information to the Executive Report:
 - Advertising Intelligence
   - Google Ads (via Advertising Intelligence)
   - Facebook Ads (via Advertising Intelligence)
-- Social Marketing
+- Social AI
 - Google Ads Robot
 - Marketgoo
 - Metricool
@@ -189,7 +189,7 @@ If there are no changes from the previous month for any specific section of the 
 
 Yes, you can choose weekly or monthly reports as defaults, or select a completely custom date range using the date selector in the top-right of the report.
 
-Note that **Listings** and **Social Marketing** cards are not available when a custom date range is selected. Those data sources are delivered in fixed monthly rollups and cannot be broken into arbitrary date ranges. An in-app banner appears to notify you when these cards are hidden. To see them again, switch back to the standard weekly or monthly view.
+Note that **Listings** and **Social AI** cards are not available when a custom date range is selected. Those data sources are delivered in fixed monthly rollups and cannot be broken into arbitrary date ranges. An in-app banner appears to notify you when these cards are hidden. To see them again, switch back to the standard weekly or monthly view.
 </details>
 
 <details>
@@ -225,7 +225,7 @@ Yes, the Executive Report is mobile-responsive and can be viewed from any device
 <details>
 <summary>What products need to be active to receive an Executive Report?</summary>
 
-You need active products that push data to the report, such as Reputation AI, Local SEO, WordPress Hosting, Advertising Intelligence, Social Marketing, and others listed in the supported products section.
+You need active products that push data to the report, such as Reputation AI, Local SEO, WordPress Hosting, Advertising Intelligence, Social AI, and others listed in the supported products section.
 </details>
 
 <details>

--- a/docusaurus/docs/business-app/index.mdx
+++ b/docusaurus/docs/business-app/index.mdx
@@ -367,7 +367,7 @@ For clients with multiple locations:
 
 Yes, connecting social accounts (Facebook, Google Business Profile) in Business App first provides several benefits:
 
-- Automatically connects accounts to other platform areas like Social Marketing, Reputation AI, and Local SEO
+- Automatically connects accounts to other platform areas like Social AI, Reputation AI, and Local SEO
 - Enables valuable stats throughout Executive Report product sections
 - Powers Marketing Funnel data even without active products
 - Streamlines the overall setup process across multiple products

--- a/docusaurus/docs/crm/activity-feed/index.mdx
+++ b/docusaurus/docs/crm/activity-feed/index.mdx
@@ -148,7 +148,7 @@ Yes! You can combine multiple filters such as date range + team member + activit
 <summary>What types of keywords can I search for?</summary>
 
 You can search for any text that appears in activity descriptions, including:
-- Product names (e.g., "Social Marketing", "Reputation AI")  
+- Product names (e.g., "Social AI", "Reputation AI")  
 - Competitor names
 - Deal stages or terms (e.g., "proposal", "contract", "decision maker")
 - Specific challenges or objections

--- a/docusaurus/docs/fulfillment/task-manager/tasks/creating-managing-tasks.mdx
+++ b/docusaurus/docs/fulfillment/task-manager/tasks/creating-managing-tasks.mdx
@@ -59,7 +59,7 @@ This guide covers default task types. You can auto-generate custom tasks using p
 Set default task generation for new accounts:
 
 1. Go to `Task Manager` > `Settings`
-2. Click `Reputation AI` or `Social Marketing`
+2. Click `Reputation AI` or `Social AI`
 3. Move the toggle to the on or off state to control automatic task generation
 
 ### Auto-Generate Tasks per Account
@@ -96,7 +96,7 @@ Certain products may need to be active before you can auto-generate tasks on the
 
 ### Social Posts Tasks
 - **Purpose**: Tasks prompting social media posting
-- **Requirements**: Social Marketing must be active
+- **Requirements**: Social AI must be active
 - **Setup**: Configure content type and posting commitments on individual accounts
 - **When Generated**: Based on posting schedule and commitments
 
@@ -125,7 +125,7 @@ Each account can have unique task generation settings:
 Some task types require specific products to be active:
 
 - **Mentions and Reviews**: Require Reputation AI
-- **Social Posts and Socialize**: Require Social Marketing
+- **Social Posts and Socialize**: Require Social AI
 
 ## Best Practices for Task Creation
 
@@ -174,7 +174,7 @@ While the system doesn't detail custom task creation templates, you can create r
 <details>
 <summary>What products need to be active for auto-generated tasks?</summary>
 
-Mentions and Reviews tasks require Reputation AI to be active. Social Posts and Socialize tasks require Social Marketing to be active. Google Q&A tasks require the Google account to be connected in Reputation AI.
+Mentions and Reviews tasks require Reputation AI to be active. Social Posts and Socialize tasks require Social AI to be active. Google Q&A tasks require the Google account to be connected in Reputation AI.
 
 </details>
 

--- a/docusaurus/docs/fulfillment/task-manager/tasks/specialized-task-types.mdx
+++ b/docusaurus/docs/fulfillment/task-manager/tasks/specialized-task-types.mdx
@@ -213,6 +213,6 @@ AI suggested responses are generated automatically based on the review content, 
 <details>
 <summary>Can I disable specific types of auto-generated tasks?</summary>
 
-Yes, you can control task generation at both the global level (Settings > Reputation AI or Social Marketing) and per account (Account Settings > Task generation). Each task type can be toggled independently.
+Yes, you can control task generation at both the global level (Settings > Reputation AI or Social AI) and per account (Account Settings > Task generation). Each task type can be toggled independently.
 
 </details>

--- a/docusaurus/docs/getting-started/getting-started-guides/getting-started-with-vendasta-services.mdx
+++ b/docusaurus/docs/getting-started/getting-started-guides/getting-started-with-vendasta-services.mdx
@@ -83,7 +83,7 @@ Ordering Vendasta Services products is the same as [ordering any product](/comme
 1. Go to **Partner Center** → **Businesses** → **Accounts** → Click on the account for which you want to place an order
 2. Click **Order Products**
 3. Select the package(s) or product(s) you wish to order
-   - You may be prompted to activate additional products that are needed to fulfill services (eg. Social Marketing is needed for our team to post as part of our social posting services)
+   - You may be prompted to activate additional products that are needed to fulfill services (eg. Social AI is needed for our team to post as part of our social posting services)
 4. Click **Proceed to Next Step**
 5. Review and fill in any contact information
 6. Click **Next**

--- a/docusaurus/docs/getting-started/index.mdx
+++ b/docusaurus/docs/getting-started/index.mdx
@@ -121,7 +121,7 @@ Business App serves two important purposes:
 #### For Your Local Business Clients
 Business App is where your clients access their purchased products and services:
 - View their business metrics and reports
-- Access purchased products (LocalSEO, Reputation AI, Social Marketing, etc.)
+- Access purchased products (LocalSEO, Reputation AI, Social AI, etc.)
 - Browse and purchase additional services from your Store
 - Receive updates and proof-of-performance reports
 
@@ -129,7 +129,7 @@ Business App is where your clients access their purchased products and services:
 You can also use Business App when you want to utilize Marketplace Products and Services for your own agency:
 - Access LocalSEO tools for your own business listings
 - Use Reputation AI for your agency's online presence
-- Leverage Social Marketing tools for your own social media
+- Leverage Social AI tools for your own social media
 - Utilize any other marketplace products you've purchased for self-use
 
 ### Key distinction

--- a/docusaurus/docs/index.mdx
+++ b/docusaurus/docs/index.mdx
@@ -64,7 +64,7 @@ Your comprehensive resource for all Vendasta platform tools and features. Explor
     Partner with AI to monitor your listings, reviews, mentions, and social media presence.
   </Card>
 
-  <Card href="https://docs.businessapp.io/social-marketing/" icon={useBaseUrl('/img/Social-Marketing.svg')} title="Social Marketing">
+  <Card href="https://docs.businessapp.io/social-marketing/" icon={useBaseUrl('/img/Social-Marketing.svg')} title="Social AI">
     Respond to customer posts, uncover potential prospects, and discover relevant content.
   </Card>
 

--- a/docusaurus/docs/marketing/acquisition-widgets/index.mdx
+++ b/docusaurus/docs/marketing/acquisition-widgets/index.mdx
@@ -21,7 +21,7 @@ Once a visitor provides their details, you can configure the widget to perform t
 - Activate products, including:
   - Reputation AI | Standard
   - Local SEO
-  - Social Marketing | Standard
+  - Social AI | Standard
   - Customer Voice | Standard
   - Advertising Intelligence
   - Website | Standard

--- a/docusaurus/docs/marketplace/products/edition-changes.mdx
+++ b/docusaurus/docs/marketplace/products/edition-changes.mdx
@@ -13,7 +13,7 @@ keywords: [edition change, upgrade, downgrade, proration, standard, pro, billing
 Edition changes and proration apply to Vendasta's own-and-operated (O&O) products:
 
 - Reputation AI
-- Social Marketing
+- Social AI
 - Customer Voice
 
 These products offer Standard and Pro editions. When you change editions, the charge is prorated based on how many days the current edition has been active in the billing cycle.
@@ -24,7 +24,7 @@ When you upgrade from Standard to Pro mid-cycle, you are charged immediately for
 
 **Worked example:**
 
-- Social Marketing renews on December 25
+- Social AI renews on December 25
 - You upgrade from Standard to Pro on December 15
 - Standard was active for 10 days of the 30-day cycle before the upgrade
 - The Pro charge is reduced by the prorated Standard cost for those 10 days (approximately $9.49 in this example)
@@ -44,7 +44,7 @@ Downgrade timing may vary. Check the product's current subscription details to c
 <details>
 <summary>Why was I charged immediately when I upgraded?</summary>
 
-Edition upgrades on O&O products (Reputation AI, Social Marketing, Customer Voice) are charged immediately when the upgrade is applied, prorated from the upgrade date through the next renewal date. This is different from most subscription changes, which take effect at renewal.
+Edition upgrades on O&O products (Reputation AI, Social AI, Customer Voice) are charged immediately when the upgrade is applied, prorated from the upgrade date through the next renewal date. This is different from most subscription changes, which take effect at renewal.
 </details>
 
 <details>

--- a/docusaurus/docs/marketplace/products/set-retail-prices.mdx
+++ b/docusaurus/docs/marketplace/products/set-retail-prices.mdx
@@ -16,7 +16,7 @@ The steps are the same for all products. The only difference is which product to
 
 1. Go to **Marketplace** > [**Products**](https://partners.vendasta.com/marketplace/manage-products).
 2. Search for and click the product you want to price:
-   - **Reputation AI, Customer Voice, Website, Social Marketing** — search by product name
+   - **Reputation AI, Customer Voice, Website, Social AI** — search by product name
    - **Advertising Intelligence** — search for *Advanced Reporting*
    - **Local SEO (Citation Builder)** — search for *Citation Builder*
    - **Local SEO (Listing Sync)** — search for *Listing Sync*

--- a/docusaurus/docs/multi-location-business-app/executive-report/executive-report.mdx
+++ b/docusaurus/docs/multi-location-business-app/executive-report/executive-report.mdx
@@ -33,7 +33,7 @@ The report can include:
 - Google Analytics
 - Reputation (Top Review Sources, Recent Reviews, Review Rating, Review Volume, Average Time to Response)
 - Listings data
-- Social media (powered by Social Marketing)
+- Social media (powered by Social AI)
 
 Additional Marketplace products and third-party metric sources will be added over time.
 

--- a/docusaurus/docs/multi-location-business-app/social/multi-location-social-posting.mdx
+++ b/docusaurus/docs/multi-location-business-app/social/multi-location-social-posting.mdx
@@ -8,15 +8,15 @@ description: Learn how to post to multiple social media accounts across differen
 With Multi-location Business App's social posting, you can:
 
 - Post to multiple Facebook, Instagram or Google Business Profile pages in one go
-- Customize posts for each individual location through dynamic content and allow the individual locations to customize multi-location posts in their own Social Marketing app.
+- Customize posts for each individual location through dynamic content and allow the individual locations to customize multi-location posts in their own Social AI app.
 - Review and monitor brand performance and drill down on individual locations in one view
 
 ## How it works
 
-You create and schedule posts from the Multi-location Business App; those posts are published to each location’s connected social accounts. You can target all locations or refine by group, geography, or individual location. Locations can also customize or edit scheduled posts in their own Social Marketing app.
+You create and schedule posts from the Multi-location Business App; those posts are published to each location’s connected social accounts. You can target all locations or refine by group, geography, or individual location. Locations can also customize or edit scheduled posts in their own Social AI app.
 
 :::info
-**Requirements:** Multi-location Business App must be set up for your group, and each location must have Social Marketing Standard or Pro. For best results, use one account per location with Facebook, Instagram, and Google Business Profile connected to that account’s Social Marketing app.
+**Requirements:** Multi-location Business App must be set up for your group, and each location must have Social AI Standard or Pro. For best results, use one account per location with Facebook, Instagram, and Google Business Profile connected to that account’s Social AI app.
 :::
 
 ## Creating a post
@@ -69,9 +69,9 @@ Once you're done with your post, you can choose to either publish it immediately
 
 ## Easy customization
 
-Each location can customize a scheduled multi-location post through Social Marketing in its own Business App. They can edit the post as they would with any regular post: change the date and time of posting, edit copy, change images, add hashtags, etc.
+Each location can customize a scheduled multi-location post through Social AI in its own Business App. They can edit the post as they would with any regular post: change the date and time of posting, edit copy, change images, add hashtags, etc.
 
-Simply go to Business App → Social Marketing → **My Posts** → **Scheduled Posts** or click **View More** on the Scheduled Posts section on the Overview page. You will see the scheduled multi-location post and will be able to edit it.
+Simply go to Business App → Social AI → **My Posts** → **Scheduled Posts** or click **View More** on the Scheduled Posts section on the Overview page. You will see the scheduled multi-location post and will be able to edit it.
 
 :::note
 **NOTE:** Editing a multi-location post for a single location will prevent you from making bulk edits to this location's post through the Multi-location Business App.
@@ -93,14 +93,14 @@ Finally, through the Overview page, you can see how your overall brand is doing 
 
 The "new posts" and "engagement" stats at the top of the page include data from posts published through the platform and directly on the connected social media sites.
 
-Clicking a location will open a side panel with more details specific to the location. Through this panel, you can launch this location's Business App, Social Marketing app, or Executive Report in a separate tab.
+Clicking a location will open a side panel with more details specific to the location. Through this panel, you can launch this location's Business App, Social AI app, or Executive Report in a separate tab.
 
 ## Frequently asked questions
 
 <details>
 <summary>What social networks are supported with multi-location social posting?</summary>
 
-Multi-location posting supports **Facebook**, **Instagram**, and **Google Business Profile** only. Other platforms your locations may have connected — such as LinkedIn or X — are not available for multi-location posts and must be posted to individually from each location's own Social Marketing app.
+Multi-location posting supports **Facebook**, **Instagram**, and **Google Business Profile** only. Other platforms your locations may have connected — such as LinkedIn or X — are not available for multi-location posts and must be posted to individually from each location's own Social AI app.
 
-**Instagram requirements:** Instagram posting requires Social Marketing **Pro**. Locations on Social Marketing Standard will not receive Instagram posts from a multi-location campaign, even if Instagram is connected to their account. The post will still publish to their Facebook and Google Business Profile pages.
+**Instagram requirements:** Instagram posting requires Social AI **Pro**. Locations on Social AI Standard will not receive Instagram posts from a multi-location campaign, even if Instagram is connected to their account. The post will still publish to their Facebook and Google Business Profile pages.
 </details>

--- a/docusaurus/docs/reports/premium-reports/index.mdx
+++ b/docusaurus/docs/reports/premium-reports/index.mdx
@@ -22,7 +22,7 @@ Stay on top of billing, invoicing, and payments with comprehensive financial ana
 Gain deeper insights into sales team activities and pipeline performance. Track sales activities, deal progression, win rates, average deal sizes, and opportunity management across salespersons and time periods.
 
 ### Operations reports
-Monitor account health and automation performance. View connection status for social marketing services, track automation execution rates, and identify broken connections or automation errors requiring attention.
+Monitor account health and automation performance. View connection status for Social AI services, track automation execution rates, and identify broken connections or automation errors requiring attention.
 
 ## How to access Premium Reports
 

--- a/docusaurus/docs/reports/premium-reports/operations-reports.mdx
+++ b/docusaurus/docs/reports/premium-reports/operations-reports.mdx
@@ -1,20 +1,20 @@
 ---
 title: Operations reports
-description: Operational insights covering account connection status, social marketing usage, and automation execution monitoring with error tracking capabilities
+description: Operational insights covering account connection status, Social AI usage, and automation execution monitoring with error tracking capabilities
 sidebar_position: 4
 ---
 
 # Operations reports
 
-Monitor your operational systems and account health with detailed insights into social marketing connections, automation performance, and system status. These reports help maintain service quality and identify issues before they impact performance.
+Monitor your operational systems and account health with detailed insights into Social AI connections, automation performance, and system status. These reports help maintain service quality and identify issues before they impact performance.
 
 ## Account connection reports
 
-### Social marketing usage
+### Social AI usage
 
 Monitor account connections across all product services, categorized by status and connection expiration dates.
 
-![Social Marketing Usage Report](./img/social-marketing-usage.jpg)
+![Social AI Usage Report](./img/social-marketing-usage.jpg)
 
 View connections categorized by:
 - **Connected**: Active, functioning connections

--- a/docusaurus/docs/vendasta-services/ai-workforce/ai-data-analyst.md
+++ b/docusaurus/docs/vendasta-services/ai-workforce/ai-data-analyst.md
@@ -9,7 +9,7 @@ import OptimizationPlanFaq from './_optimization-plan-faq.mdx';
 
 
 :::info Requirements
-**Conversations AI** (any edition) must be active, plus at least one of **CRM AI**, **Reputation AI**, **Social Marketing**, or **Local SEO** as a data source. See the full [requirements](#requirements) below.
+**Conversations AI** (any edition) must be active, plus at least one of **CRM AI**, **Reputation AI**, **Social AI**, or **Local SEO** as a data source. See the full [requirements](#requirements) below.
 :::
 
 The AI Data Analyst Setup is a done-for-you service where our experts configure, train, and launch the AI Data Analyst for your business. Our team handles the technical setup, connects your active data sources (CRM, Reviews/NPS, Social), and configures the AIR Analysis Framework so every response delivers a clear finding, a plain-language interpretation, and a recommended next step.
@@ -45,7 +45,7 @@ The AI will never surface raw data dumps or vague summaries. If it cannot produc
 
 ### 3. Data source connections
 
-The AI Data Analyst requires Conversations AI (any edition) and at least one of the following data sources to be active: **CRM AI**, **Reputation AI**, **Social Marketing**, or **Local SEO**. The quality and depth of insights depend directly on how much data is available in each connected source. Once we determine what is active, we connect the data sources available in your account:
+The AI Data Analyst requires Conversations AI (any edition) and at least one of the following data sources to be active: **CRM AI**, **Reputation AI**, **Social AI**, or **Local SEO**. The quality and depth of insights depend directly on how much data is available in each connected source. Once we determine what is active, we connect the data sources available in your account:
 
 * **CRM data:** contacts, companies, activities, and pipeline information
 * **Reviews and NPS:** customer feedback from connected review platforms
@@ -112,9 +112,9 @@ To set your business up for success, the following requirements must be met to d
 
 Conversations AI must be active on your account. Any edition of Conversations AI is supported. This is the platform requirement for deploying the AI Data Analyst.
 
-### CRM AI, Reputation AI, Social Marketing, or Local SEO (at least one required)
+### CRM AI, Reputation AI, Social AI, or Local SEO (at least one required)
 
-At least one of the following must be active: **CRM AI**, **Reputation AI**, **Social Marketing**, or **Local SEO**. These are the data sources the AI uses to generate insights. Without at least one active data source, the AI cannot perform meaningful analysis.
+At least one of the following must be active: **CRM AI**, **Reputation AI**, **Social AI**, or **Local SEO**. These are the data sources the AI uses to generate insights. Without at least one active data source, the AI cannot perform meaningful analysis.
 
 :::tip
 The more data sources that are active and populated, the richer and more actionable the AI's insights will be. We recommend having CRM data, connected review sources (Google, Facebook), and social accounts active before the onboarding call.
@@ -154,7 +154,7 @@ AIR stands for Analyze, Interpret, Recommend. Every response from the AI Data An
 
 <summary>What editions are required?</summary>
 
-**Conversations AI** must be active (any edition is supported). In addition, at least one of the following data-source editions must be active: **CRM AI**, **Reputation AI**, **Social Marketing**, or **Local SEO**. These editions unlock the data access and platform capabilities the AI Data Analyst relies on to generate insights. If you are unsure which editions are currently active on your account, please check with your account manager before the onboarding call.
+**Conversations AI** must be active (any edition is supported). In addition, at least one of the following data-source editions must be active: **CRM AI**, **Reputation AI**, **Social AI**, or **Local SEO**. These editions unlock the data access and platform capabilities the AI Data Analyst relies on to generate insights. If you are unsure which editions are currently active on your account, please check with your account manager before the onboarding call.
 
 </details>
 

--- a/docusaurus/docs/vendasta-services/ai-workforce/index.mdx
+++ b/docusaurus/docs/vendasta-services/ai-workforce/index.mdx
@@ -66,5 +66,5 @@ One. Each Setup and each Optimization Plan covers a single AI employee. To add a
 <details>
 <summary>What is required to set up an AI employee?</summary>
 
-All AI employees require Conversations AI to be active. The AI Reputation Specialist additionally requires Reputation AI Premium, and the AI Data Analyst requires at least one data source (CRM AI, Reputation AI, Social Marketing, or Local SEO). See each guide for details.
+All AI employees require Conversations AI to be active. The AI Reputation Specialist additionally requires Reputation AI Premium, and the AI Data Analyst requires at least one data source (CRM AI, Reputation AI, Social AI, or Local SEO). See each guide for details.
 </details>

--- a/docusaurus/docs/vendasta-services/using-the-platform/ordering-vendasta-services-products-best-practices.md
+++ b/docusaurus/docs/vendasta-services/using-the-platform/ordering-vendasta-services-products-best-practices.md
@@ -11,7 +11,7 @@ Ordering Vendasta Services products is the same as [ordering any product](../../
 1.  Go to `Partner Center` → `Businesses` → `Accounts` and click on the account for which you want to place an order
 2.  Click `Order Products`
 3.  Select the package(s) or product(s) you wish to order
-    *   You may be prompted to activate additional products that are needed to fulfill services (eg. Social Marketing is needed for our team to post as part of our social posting services)
+    *   You may be prompted to activate additional products that are needed to fulfill services (eg. Social AI is needed for our team to post as part of our social posting services)
 4.  Click `Proceed to Next Step`
 5.  Review and fill in any contact information
 6.  Click `Next`

--- a/docusaurus/docs/vendasta-services/working-with-our-team/index.mdx
+++ b/docusaurus/docs/vendasta-services/working-with-our-team/index.mdx
@@ -15,7 +15,7 @@ Vendasta Services is Vendasta’s in-house fulfillment vendor. This section cove
 
 Working with the team means knowing who to reach, where to find resources, and how to align on process and branding:
 
-- **Contacts** – **Vendasta Services** (marketingservices@yourdigitalagents.com, 1-866-378-8031) for products, fulfillment, and active projects. **Vendasta Sales** and **Onboarding** for sales and onboarding. **Support on Demand** (support@vendasta.com) for the Vendasta platform (Partner Center, Business App, Social Marketing).
+- **Contacts** – **Vendasta Services** (marketingservices@yourdigitalagents.com, 1-866-378-8031) for products, fulfillment, and active projects. **Vendasta Sales** and **Onboarding** for sales and onboarding. **Support on Demand** (support@vendasta.com) for the Vendasta platform (Partner Center, Business App, Social AI).
 - **Resources by product** – Website frameworks and forms, digital ads proposal requests, and social content questionnaires are linked from the resource overview. Presale questions can go to Vendasta Services with your sales rep CC’d.
 - **Training webinars** – Vendasta Services hosts partner-only webinars (Getting Started, Websites, Digital Ads, Social & Long-form Content, Listings & Reputation AI). Session links are on the [Webinar calendar](http://www.vendasta.com/webinar).
 - **White-label communications** – Default contact is unbranded (marketingservices@yourdigitalagents.com, 1-866-378-8031). If you prefer non-client-facing communication, provide your own contact information on the order and fulfillment forms.

--- a/docusaurus/docs/vendasta-services/working-with-our-team/vendasta-services-resource-overview.md
+++ b/docusaurus/docs/vendasta-services/working-with-our-team/vendasta-services-resource-overview.md
@@ -23,7 +23,7 @@ This article provides an overview of Vendasta's teams and resources, which are h
 * **Onboarding Specialist:** To get in touch with your assigned specialist.
     * **Email:** onboarding@vendasta.com
 
-* **Support on Demand (for partners only):** For questions about the Vendasta platform, including Partner Center, Business App, and Social Marketing.
+* **Support on Demand (for partners only):** For questions about the Vendasta platform, including Partner Center, Business App, and Social AI.
     * **Email:** support@vendasta.com
     * **Submit a ticket:** Contact support through Partner Center or via email
 


### PR DESCRIPTION
Business App's Social Marketing product is now Social AI. Updates 25 incidental mentions scattered across Accounts, Administration, Business App, CRM, Fulfillment, Marketplace, Multi-location Business App, Reports, and Vendasta Services docs to match. Edition names (Pro/Standard/Express) and existing URLs/asset paths are left unchanged.