### PR TITLE
docs(ai-workforce): AI Social Media Manager & AI Blogger, client-facing callouts, GBP rewrite

### DIFF
--- a/docusaurus/docs/vendasta-services/ai-workforce/ai-blogger.md
+++ b/docusaurus/docs/vendasta-services/ai-workforce/ai-blogger.md
@@ -7,6 +7,12 @@ description: "An overview of the AI Blogger service: how setup works, how your a
 import OptimizationPlanSection from './_optimization-plan-section.mdx';
 import OptimizationPlanFaq from './_optimization-plan-faq.mdx';
 
+:::tip Share a client-facing version
+Want to hand this to a client? The **grey-labeled guide** has the same information with no brand or platform names, so it is safe to send directly.
+
+<a className="button button--primary" href="https://servicesdocs.io/ai-workforce/ai-blogger" target="_blank" rel="noopener noreferrer">Open the client-facing AI Blogger guide →</a>
+:::
+
 :::info Requirements
 **Social AI Premium** must be active on the account. A **WordPress** site is required: WordPress is the only supported blogging platform at this time.
 :::

--- a/docusaurus/docs/vendasta-services/ai-workforce/ai-blogger.md
+++ b/docusaurus/docs/vendasta-services/ai-workforce/ai-blogger.md
@@ -1,0 +1,167 @@
+---
+title: "AI Blogger: Setup & Optimization Workforce Plan"
+sidebar_label: "AI Blogger"
+description: "An overview of the AI Blogger service: how setup works, how your autonomous blog calendar is built, and ongoing optimization."
+---
+
+import OptimizationPlanSection from './_optimization-plan-section.mdx';
+import OptimizationPlanFaq from './_optimization-plan-faq.mdx';
+
+:::info Requirements
+**Social AI Premium** must be active on the account. A **WordPress** site is required: WordPress is the only supported blogging platform at this time.
+:::
+
+The AI Blogger Setup is a done-with-you service where our experts configure, train, and launch the AI Blogger for your business. Our team handles the branding, trains the AI on your voice and target keywords, connects your WordPress site, and sets up an autonomous blog calendar that drafts or schedules SEO-focused posts.
+
+:::info Two ways to get the AI Blogger
+
+Choose one or the other:
+
+- **Setup**: a **one-time fee**. Our experts configure, train, and launch your AI Blogger.
+- **AI Workforce Optimization Plan**: an **ongoing monthly fee** that **includes the same setup** plus continued optimization (monthly check-ins, unlimited change requests, and a live training session).
+
+:::
+
+## Setup
+
+Setup runs through a short series of calls where our experts configure, train, and launch your AI Blogger. Here is how it works and what we set up along the way.
+
+### 1. Onboarding call
+
+Our experts lead an onboarding call to understand your blogging goals and content strategy. We discuss your WordPress site, publishing cadence, blog length, image preferences, and your preferred approval workflow, along with your brand voice, target keywords, and any banned topics or words.
+
+* **Timeline:** An onboarding call can be booked in as little as 1 business day, depending on availability.
+
+### 2. Configuration and launch
+
+Using the refinements from the onboarding call, we configure and launch your AI Blogger. This is where everything gets set up:
+
+* **Branding:** we set the AI's name and profile photo to match your brand, and select the generative AI model used to draft your content.
+* **Brand training:** we train the AI so your posts sound authentic, on-brand, and relevant to your business, using:
+    * Your website content and business profile, so posts reflect your services, messaging, and voice
+    * Any additional documentation about your products, services, service areas, or FAQs
+    * Your brand voice, tone, and preferred writing style, including any wording or phrases to include or avoid
+    * Target keywords and topic clusters identified during your onboarding call
+    * A list of banned topics, words, claims, or compliance language the AI must avoid
+* **Connecting your WordPress site:** we connect your site using our Blog Post Connector plugin. This involves installing and activating the plugin on your WordPress site, generating a connection key from Settings → Blog Post Connector, and entering your site URL and key into your AI Blogger setup. We can walk you through each step during the onboarding call, or complete them for you if we are provided access to your WordPress dashboard.
+* **Your blog calendar:** we set up the autonomous calendar that generates and drafts or schedules your posts (see [Your blog content calendar](#your-blog-content-calendar) below).
+
+* **Timeline:** Your AI Blogger will be complete 1 business day after the onboarding call.
+
+:::note
+
+Only one WordPress blog is used per post. If you have multiple WordPress sites, we will confirm with you which one should receive content.
+
+:::
+
+### 3. Walkthrough and training call
+
+We walk you through the new workflow: where to find your generated blog calendar and individual posts, how drafts, scheduled posts, and published posts are managed in Business App and on WordPress, how to edit or regenerate a blog before it publishes, and how to chat with your AI Blogger directly to generate posts, refine drafts, or adjust content conversationally.
+
+### 4. 30-day review
+
+At your 30-day check-in, we audit your generated posts for brand voice consistency, SEO optimization, image quality, and content accuracy (flagging any unverified claims before they compound) and refresh your website knowledge source so the AI stays current. We also confirm whether your publishing cadence, blog length, and approval setting still make sense as your business evolves.
+
+## Your blog content calendar
+
+Your AI Blogger runs on a recurring trigger (daily, weekly, or monthly) that generates a fresh blog calendar. Each time it runs, we configure:
+
+* **Goal:** what each post should achieve (by default, ranking well in search while reading like a deeply researched, human-written article).
+* **Total blog posts:** how many unique posts are generated per run, matched to your publishing cadence.
+* **Blog length:** Short (1000-1100 words), Medium (1500-1600 words), or Long (2000-2100 words).
+* **Images:** AI-generated or stock (royalty-free from Pexels and Pixabay).
+* **Networks:** the WordPress site posts should publish to.
+
+### Choosing your approval workflow
+
+You choose how much oversight you want before content goes live:
+
+* **Draft (recommended for new setups):** the AI generates the calendar and writes each blog, but nothing goes live until you review and approve it in Business App or WordPress.
+* **Schedule:** the AI writes each blog and schedules it to publish automatically on the calendar date.
+
+Your approval preference is confirmed during the onboarding call and can be changed at any time as you become more comfortable with the AI's output. Drafts can always be found in Business App and under Posts → Drafts in WordPress.
+
+### How we handle edits and refinements
+
+If you would like something changed (tone, structure, topic focus, keyword targeting, or anything else), let our team know. Rather than editing a single post after the fact, we update the underlying prompts so all future posts reflect the change going forward, keeping your blog consistent and on-brand over time.
+
+<OptimizationPlanSection />
+
+:::info What optimization covers for the AI Blogger
+
+Within the optimization plan, our team can:
+
+* Make small adjustments to the posts or images by chatting with your AI Blogger.
+* Update the prompts that guide how content is written.
+* Change your setup, such as publishing frequency, blog length, or connected platform.
+
+Not included: publishing blogs to your website for you. We install and connect the WordPress plugin so posts can be published, but ongoing publishing runs through your selected approval workflow (Draft or Schedule).
+
+:::
+
+## What we'll need from you
+
+To set your business up for success, we will need the following:
+
+**Website access**
+
+* Ability to install and activate a plugin on your WordPress dashboard (or admin access so our team can do this on your behalf), plus the connection key generated from Settings → Blog Post Connector.
+
+**Content strategy**
+
+* Your blogging goal and overall content strategy.
+* How many posts you would like per run, and your desired publishing cadence.
+* Your preferred blog length (Short, Medium, or Long).
+* Whether you would like to review everything before it is posted (Draft) or have it scheduled automatically.
+
+**Brand guidelines**
+
+* Brand voice samples and target keywords.
+* Any banned topics, words, or phrases, and compliance language that must be avoided.
+* Relevant holidays or current events specific to your business or industry.
+
+## Frequently asked questions (FAQs)
+
+<details>
+<summary>What is the AI Blogger Setup service?</summary>
+
+It is a done-with-you service where our experts configure, train, and launch your AI Blogger, including connecting your WordPress site and building your autonomous blog calendar.
+</details>
+
+<details>
+<summary>Which blogging platforms are supported?</summary>
+
+WordPress is the only supported platform at this time. Additional platforms may be added in the future.
+</details>
+
+<details>
+<summary>Can I review blog posts before they go live?</summary>
+
+Yes. Choosing the Draft approval setting means every post is generated and held for your review, in Business App or directly in WordPress, before it is scheduled or published.
+</details>
+
+<details>
+<summary>Can I change my blogging strategy later?</summary>
+
+Yes. Publishing cadence, blog length, and your approval setting can all be updated at any time. Many clients revisit these during their 30-day review.
+</details>
+
+<details>
+<summary>What kind of images does the AI use?</summary>
+
+By default, the AI generates original featured images for each post, falling back to royalty-free stock photography from Pexels and Pixabay if needed. Visual brand and WordPress-theme guidelines can be applied to either option.
+</details>
+
+<details>
+<summary>How does the AI learn my brand voice?</summary>
+
+We train it using your website, business profile, target keywords, and any brand documents you provide, along with the tone and topic preferences you share during onboarding.
+</details>
+
+<details>
+<summary>What happens after the first 30 days?</summary>
+
+We complete a 30-day review and audit, checking brand voice consistency, SEO performance, and content accuracy, and confirm whether your cadence, blog length, or approval setting should be adjusted.
+</details>
+
+<OptimizationPlanFaq />

--- a/docusaurus/docs/vendasta-services/ai-workforce/ai-data-analyst.md
+++ b/docusaurus/docs/vendasta-services/ai-workforce/ai-data-analyst.md
@@ -7,6 +7,12 @@ description: "An overview of the AI Data Analyst service, detailing the process 
 import OptimizationPlanSection from './_optimization-plan-section.mdx';
 import OptimizationPlanFaq from './_optimization-plan-faq.mdx';
 
+:::tip Share a client-facing version
+Want to hand this to a client? The **grey-labeled guide** has the same information with no brand or platform names, so it is safe to send directly.
+
+<a className="button button--primary" href="https://servicesdocs.io/ai-workforce/ai-data-analyst" target="_blank" rel="noopener noreferrer">Open the client-facing AI Data Analyst guide →</a>
+:::
+
 
 :::info Requirements
 **Conversations AI** (any edition) must be active, plus at least one of **CRM AI**, **Reputation AI**, **Social Marketing**, or **Local SEO** as a data source. See the full [requirements](#requirements) below.

--- a/docusaurus/docs/vendasta-services/ai-workforce/ai-human-resources-coordinator.md
+++ b/docusaurus/docs/vendasta-services/ai-workforce/ai-human-resources-coordinator.md
@@ -7,6 +7,12 @@ description: "An overview of the AI Human Resources Coordinator service, detaili
 import OptimizationPlanSection from './_optimization-plan-section.mdx';
 import OptimizationPlanFaq from './_optimization-plan-faq.mdx';
 
+:::tip Share a client-facing version
+Want to hand this to a client? The **grey-labeled guide** has the same information with no brand or platform names, so it is safe to send directly.
+
+<a className="button button--primary" href="https://servicesdocs.io/ai-workforce/ai-human-resources-coordinator" target="_blank" rel="noopener noreferrer">Open the client-facing AI Human Resources Coordinator guide →</a>
+:::
+
 
 :::info Requirements
 **Conversations AI** must be active on your account. See the full [requirements](#requirements) below.

--- a/docusaurus/docs/vendasta-services/ai-workforce/ai-inside-sales-representative.md
+++ b/docusaurus/docs/vendasta-services/ai-workforce/ai-inside-sales-representative.md
@@ -7,6 +7,12 @@ description: "An overview of the AI Inside Sales Representative service, detaili
 import OptimizationPlanSection from './_optimization-plan-section.mdx';
 import OptimizationPlanFaq from './_optimization-plan-faq.mdx';
 
+:::tip Share a client-facing version
+Want to hand this to a client? The **grey-labeled guide** has the same information with no brand or platform names, so it is safe to send directly.
+
+<a className="button button--primary" href="https://servicesdocs.io/ai-workforce/ai-inside-sales-representative" target="_blank" rel="noopener noreferrer">Open the client-facing AI Inside Sales Representative guide →</a>
+:::
+
 
 :::info Requirements
 **Conversations AI** must be active on your account. See the full [requirements](#requirements) below.

--- a/docusaurus/docs/vendasta-services/ai-workforce/ai-receptionist.md
+++ b/docusaurus/docs/vendasta-services/ai-workforce/ai-receptionist.md
@@ -7,6 +7,11 @@ description: "An overview of the AI Receptionist service, detailing the process 
 import OptimizationPlanSection from './_optimization-plan-section.mdx';
 import OptimizationPlanFaq from './_optimization-plan-faq.mdx';
 
+:::tip Share a client-facing version
+Want to hand this to a client? The **grey-labeled guide** has the same information with no brand or platform names, so it is safe to send directly.
+
+<a className="button button--primary" href="https://servicesdocs.io/ai-workforce/ai-receptionist" target="_blank" rel="noopener noreferrer">Open the client-facing AI Receptionist guide →</a>
+:::
 
 :::info Requirements
 **Conversations AI** must be active on your account (any edition — Standard, Pro, or Premium).

--- a/docusaurus/docs/vendasta-services/ai-workforce/ai-reputation-specialist.md
+++ b/docusaurus/docs/vendasta-services/ai-workforce/ai-reputation-specialist.md
@@ -7,6 +7,12 @@ description: "An overview of the AI Reputation Specialist service, detailing the
 import OptimizationPlanSection from './_optimization-plan-section.mdx';
 import OptimizationPlanFaq from './_optimization-plan-faq.mdx';
 
+:::tip Share a client-facing version
+Want to hand this to a client? The **grey-labeled guide** has the same information with no brand or platform names, so it is safe to send directly.
+
+<a className="button button--primary" href="https://servicesdocs.io/ai-workforce/ai-reputation-specialist" target="_blank" rel="noopener noreferrer">Open the client-facing AI Reputation Specialist guide →</a>
+:::
+
 
 :::info Requirements
 **Reputation AI Premium** must be active on your account to receive this service.

--- a/docusaurus/docs/vendasta-services/ai-workforce/ai-social-media-manager.md
+++ b/docusaurus/docs/vendasta-services/ai-workforce/ai-social-media-manager.md
@@ -7,6 +7,12 @@ description: "An overview of the AI Social Media Manager service: how setup work
 import OptimizationPlanSection from './_optimization-plan-section.mdx';
 import OptimizationPlanFaq from './_optimization-plan-faq.mdx';
 
+:::tip Share a client-facing version
+Want to hand this to a client? The **grey-labeled guide** has the same information with no brand or platform names, so it is safe to send directly.
+
+<a className="button button--primary" href="https://servicesdocs.io/ai-workforce/ai-social-media-manager" target="_blank" rel="noopener noreferrer">Open the client-facing AI Social Media Manager guide →</a>
+:::
+
 :::info Requirements
 **Social AI Premium** must be active on the account.
 :::

--- a/docusaurus/docs/vendasta-services/ai-workforce/ai-social-media-manager.md
+++ b/docusaurus/docs/vendasta-services/ai-workforce/ai-social-media-manager.md
@@ -1,0 +1,167 @@
+---
+title: "AI Social Media Manager: Setup & Optimization Workforce Plan"
+sidebar_label: "AI Social Media Manager"
+description: "An overview of the AI Social Media Manager service: how setup works, how your autonomous content calendar is built, and ongoing optimization."
+---
+
+import OptimizationPlanSection from './_optimization-plan-section.mdx';
+import OptimizationPlanFaq from './_optimization-plan-faq.mdx';
+
+:::info Requirements
+**Social AI Premium** must be active on the account.
+:::
+
+The AI Social Media Manager Setup is a done-with-you service where our experts configure, train, and launch the AI Social Media Manager for your business. Our team handles the branding, trains the AI on your voice and content, connects your social accounts, and sets up an autonomous content calendar that drafts, schedules, or publishes posts across your networks.
+
+:::info Two ways to get the AI Social Media Manager
+
+Choose one or the other:
+
+- **Setup**: a **one-time fee**. Our experts configure, train, and launch your AI Social Media Manager.
+- **AI Workforce Optimization Plan**: an **ongoing monthly fee** that **includes the same setup** plus continued optimization (monthly check-ins, unlimited change requests, and a live training session).
+
+:::
+
+## Setup
+
+Setup runs through a short series of calls where our experts configure, train, and launch your AI Social Media Manager. Here is how it works and what we set up along the way.
+
+### 1. Onboarding call
+
+Our experts lead an onboarding call to understand your business's social media goals and content strategy. We come to the call with your AI Social Media Manager already pre-configured in your branding, so we can refine it together: posting cadence, content mix, target networks, and your preferred approval workflow.
+
+* **Timeline:** An onboarding call can be booked in as little as 1 business day, depending on availability.
+
+### 2. Configuration and launch
+
+Using the refinements from the onboarding call, we configure and launch your AI Social Media Manager. This is where everything gets set up:
+
+* **Branding:** we set the AI's name and profile photo to match your brand, and select the generative AI model used to draft your content.
+* **Brand training:** we train the AI so your posts sound authentic and on-brand, using:
+    * Your website content and business profile, so posts reflect your services, messaging, and voice
+    * Any additional documentation about your products, services, FAQs, or promotions
+    * Your brand voice, tone, and persona, including preferred hashtags, emoji use, and calls to action
+    * Wording, phrases, or topics that should be included or explicitly avoided
+* **Connecting your accounts:** we connect each platform you want the AI to publish to (Facebook, Instagram, LinkedIn, X (Twitter), YouTube, TikTok, and Google Business Profile) using your credentials, or we walk you through connecting them yourself.
+* **Your content calendar:** we set up the autonomous calendar that generates and drafts, schedules, or publishes your posts (see [Your social content calendar](#your-social-content-calendar) below).
+
+* **Timeline:** Your AI Social Media Manager will be complete 1 business day after the onboarding call.
+
+### 3. Walkthrough and training call
+
+We walk you through the new workflow: where to find your generated calendar and individual posts, how drafts, scheduled posts, and published posts are managed in Business App, and how to chat with your AI Social Media Manager directly to generate posts, pull performance insights, or adjust content conversationally.
+
+### 4. 30-day review
+
+At your 30-day check-in, we review how your calendar is performing, highlighting top-performing posts surfaced by the AI, and confirm whether your posting cadence, content split, and approval setting still make sense as your business evolves.
+
+## Your social content calendar
+
+Your AI Social Media Manager runs on a recurring trigger (daily, weekly, or monthly) that generates a fresh content calendar. Each time it runs, we configure:
+
+* **Goal:** what the posts should achieve (for example, boosting brand awareness or driving leads).
+* **Total posts:** how many unique post topics are generated per run (each topic becomes one post per connected network).
+* **Content split:** the mix of Business, Engagement, and Industry content (default 40% / 30% / 30%).
+* **Post length and structure:** by default, a short hook, value, and call-to-action format, adapted per network.
+* **Images:** AI-generated or stock (royalty-free from Pexels and Pixabay).
+* **Networks:** which connected platforms receive posts.
+
+### Choosing your approval workflow
+
+You choose how much oversight you want before content goes live:
+
+* **Draft (recommended for new setups):** the AI writes each post, but nothing goes live until you review and approve it in Business App.
+* **Schedule:** the AI writes and queues each post to publish at the optimal time per network, without requiring manual approval.
+* **Publish:** the AI writes and publishes each post immediately; best for businesses that want fully hands-off execution.
+
+Your approval preference is confirmed during the onboarding call and can be changed at any time as you become more comfortable with the AI's output.
+
+### How we handle edits and refinements
+
+If you would like something changed (tone, structure, topic focus, hashtag use, or anything else), let our team know. Rather than editing a single post after the fact, we update the underlying prompts so all future posts reflect the change going forward, keeping your calendar consistent and on-brand over time.
+
+### Performance insights
+
+Once your calendar is live, the AI Social Media Manager pulls engagement metrics (likes, comments, shares, and link clicks) from your connected networks and feeds those insights back into future calendar generation, so performance improves over time.
+
+<OptimizationPlanSection />
+
+:::info What optimization covers for the AI Social Media Manager
+
+Within the optimization plan, our team can:
+
+* Make small adjustments to the posts or images by chatting with your AI Social Media Manager.
+* Update the prompts that guide how content is written.
+* Change your setup, such as posting frequency, content split, or connected platforms.
+
+Not included: manually reviewing and editing every social post and image the AI generates. We tune the prompts and settings so future content improves, rather than hand-editing each post.
+
+:::
+
+## What we'll need from you
+
+To set your business up for success, we will need the following:
+
+**Account access**
+
+* Login credentials (or a walkthrough during onboarding) for each social account you want connected.
+
+**Content strategy**
+
+* Your posting goal and overall content strategy.
+* How often you would like the AI to generate content (weekly or monthly).
+* How many posts you would like per week or month.
+* Your desired content split across Business, Engagement, and Industry posts.
+* Whether you would like to review everything before it is posted (Draft) or have it scheduled automatically.
+
+**Brand guidelines**
+
+* Brand voice samples and tone preferences.
+* Any banned topics, words, or phrases, and compliance language that must be avoided.
+* Relevant holidays or current events specific to your business or industry.
+
+## Frequently asked questions (FAQs)
+
+<details>
+<summary>What is the AI Social Media Manager Setup service?</summary>
+
+It is a done-with-you service where our experts configure, train, and launch your AI Social Media Manager, including connecting your social accounts and building your autonomous content calendar.
+</details>
+
+<details>
+<summary>Which platforms are supported?</summary>
+
+Facebook, Instagram, LinkedIn, X, YouTube, TikTok, and Google Business Profile.
+</details>
+
+<details>
+<summary>Can I review posts before they go live?</summary>
+
+Yes. Choosing the Draft approval setting means every post is generated and held for your review before it is scheduled or published.
+</details>
+
+<details>
+<summary>Can I change my content strategy later?</summary>
+
+Yes. Posting cadence, content split, post length, networks, and your approval setting can all be updated at any time. Many clients revisit these during their 30-day review.
+</details>
+
+<details>
+<summary>What kind of images does the AI use?</summary>
+
+By default, the AI generates original images for each post, falling back to royalty-free stock photography from Pexels and Pixabay if needed. Visual brand guidelines can be applied to either option.
+</details>
+
+<details>
+<summary>How does the AI learn my brand voice?</summary>
+
+We train it using your website, business profile, and any brand documents you provide, along with the tone, wording, and topic preferences you share during onboarding.
+</details>
+
+<details>
+<summary>What happens after the first 30 days?</summary>
+
+We complete a 30-day review to walk through performance, including top-performing posts and engagement trends, and confirm whether your cadence, content split, or approval setting should be adjusted.
+</details>
+
+<OptimizationPlanFaq />

--- a/docusaurus/docs/vendasta-services/ai-workforce/ai-support-agent.md
+++ b/docusaurus/docs/vendasta-services/ai-workforce/ai-support-agent.md
@@ -7,6 +7,12 @@ description: "An overview of the AI Support Agent service, detailing the process
 import OptimizationPlanSection from './_optimization-plan-section.mdx';
 import OptimizationPlanFaq from './_optimization-plan-faq.mdx';
 
+:::tip Share a client-facing version
+Want to hand this to a client? The **grey-labeled guide** has the same information with no brand or platform names, so it is safe to send directly.
+
+<a className="button button--primary" href="https://servicesdocs.io/ai-workforce/ai-support-agent" target="_blank" rel="noopener noreferrer">Open the client-facing AI Support Agent guide →</a>
+:::
+
 
 :::info Requirements
 **Conversations AI** must be active on your account. The edition that is active will affect which channels our team is able to connect. See the full [requirements](#requirements) below.

--- a/docusaurus/docs/vendasta-services/ai-workforce/index.mdx
+++ b/docusaurus/docs/vendasta-services/ai-workforce/index.mdx
@@ -54,6 +54,8 @@ Choose the AI employee to set up or manage:
 - **[AI Support Agent](./ai-support-agent.md)** – Customer support across channels, escalations, and lead capture. Requires Conversations AI.
 - **[AI Data Analyst](./ai-data-analyst.md)** – Conversational insights from CRM, review, and social data. Requires Conversations AI plus at least one data source.
 - **[AI Human Resources Coordinator](./ai-human-resources-coordinator.md)** – Internal HR support and meeting scheduling. Requires Conversations AI.
+- **[AI Social Media Manager](./ai-social-media-manager.md)** – Autonomous social content calendar across your connected networks, brand training, and approval workflows. Requires Social AI Premium.
+- **[AI Blogger](./ai-blogger.md)** – Autonomous, SEO-focused blog calendar published to WordPress, with brand training and approval workflows. Requires Social AI Premium and a WordPress site.
 
 ## FAQ
 

--- a/docusaurus/docs/vendasta-services/listings-claims-optimization/google-business-profile-optimization.md
+++ b/docusaurus/docs/vendasta-services/listings-claims-optimization/google-business-profile-optimization.md
@@ -1,14 +1,18 @@
 ---
 title: "Google Business Profile Optimization"
 sidebar_label: "Google Business Profile Optimization"
-description: "An overview of the fully managed Google Business Profile Optimization service, including the setup process, monthly maintenance, and what to expect"
+description: "An overview of the fully managed Google Business Profile Optimization service, including the setup process, verification options, monthly maintenance, and what to expect."
+tags: [vendasta-services, listings, google-business-profile, optimization, gbp, verification]
+keywords: [Google Business Profile, GBP optimization, listing claim, verification, postcard, suspension, reinstatement, bulk verification, Social Marketing]
 ---
 
 # Google Business Profile Optimization
 
 ## Overview
 
-Google Business Profile (GBP) Optimization is a fully managed solution where a team of listing specialists claims, maintains, and optimizes your business listing on a monthly basis.
+Google Business Profile (GBP) Optimization is a fully managed solution where the Listing Fulfillment team claims, maintains, and optimizes the business listing on a monthly basis.
+
+**What to expect:** order confirmation → completed fulfillment form → claiming and verification → initial optimization → monthly updates and posting.
 
 ## What's Included
 
@@ -16,167 +20,285 @@ The service includes a one-time initial optimization once the listing is claimed
 
 ### Initial profile optimization
 
-Once the listing is successfully claimed, the team performs an initial optimization to ensure the profile is accurate and complete. This includes:
+Once the listing is successfully claimed, our team performs an initial optimization so the profile is accurate and complete. This includes:
 
-* Confirming the accuracy of the business name, address, phone number, website, hours, and category.
+* Confirming the business name, address, phone number, website, hours of operation, and category.
 * Adding a logo, cover photo, up to 5 videos, and up to 5 photos.
-* Adding attributes like Highlights, Amenities, and Service Options where applicable.
+* Adding Highlights, Amenities, Attributes, and Service Options where applicable.
 
-You will receive a confirmation email within 2 business days after this work is completed.
+A confirmation email is sent within 2 business days after this work is completed, letting the contact on the fulfillment form know the GBP is claimed and the monthly optimized service is beginning.
 
 ### Monthly profile updates
 
 Once per month, our team logs into the Google Business Profile to:
 
 * Ensure all information remains accurate.
-* Manage any edits you provide, including uploading new photos and videos.
-* Work to lift any listing suspensions that may occur to maintain your online presence.
+* Manage edits you provide, including uploading new photos and videos.
+* Work to lift listing suspensions so the business can maintain its online presence.
+
+Tell us as soon as possible about any changes to the business name, address, or phone number. If we are unable to recover a suspended listing, we may work with you to create a new listing. A new listing can still face suspension due to association with a previously suspended listing.
 
 ### Monthly content posting
 
-One service-based post is published to the listing each month. These posts provide general information about your business to potential customers.
+Once per month, a service-based post is published to the listing. The post appears on the knowledge panel in Google Search results. Posts are keyword-rich and focus on the high-value services the business offers.
 
-* Posts feature a call to action, such as `Book`, `Learn More`, or `Call Now`.
+* Posts include a call to action, such as Book, Order online, Buy, Learn more, Sign up, or Call now.
 * Content is based on relevant information and links from the business website.
-* Images are sourced from stock photo websites or the business website.
-* You can provide specific images or content you would like to see posted.
+* Images may come from a stock image site or the business website.
+* You can supply specific images or content you want posted.
 
-## Prerequisites
+**Timeline:** These monthly components are completed by the end of each month.
 
-* **Eligibility:** Businesses that conduct in-person business with customers, either from a storefront or in a service area, are eligible. Not eligible: rental or for-sale properties, lead generation companies, brands/organizations/artists, and online-only businesses (including eCommerce). See [Google's guidelines](https://support.google.com/business/answer/3038177) for representing your business online.
-* **Business details for the fulfillment form:** Business name, address, phone number, website, hours, and category, plus a logo, cover photo, and any photos/videos.
-* **A physical address:** P.O. boxes cannot be used when claiming GBP listings.
+#### Social Marketing and posting
 
-## Getting Started
+GBP Optimization monthly posting is fulfilled through **Social Marketing**. Social Marketing Standard is activated at no charge for the duration of an active GBP Optimization subscription if a paid edition is not already active on the account.
 
-The initial setup involves submitting your business information, claiming and verifying the listing, and performing an initial optimization.
+If GBP Optimization is cancelled, we notify you before ending the complimentary Social Marketing instance. If you want to keep Social Marketing, it can stay active and Social Marketing charges will begin in the next billing period.
 
-### 1. Submitting your information
+:::warning
 
-The process begins when you complete and submit a fulfillment form with your business details. To avoid delays, provide as much detail as possible. The team reviews the order and starts the process within 2 business days; initial fulfillment work is completed within two business days of receiving the completed form.
-
-### 2. Listing claim and verification
-
-Our team works to claim and verify the listing using the information you provided. This step can take two weeks or more to complete, depending on Google's requirements and how quickly requested information is provided.
-
-You may be required to comply with one of Google's allowed verification methods, which can include:
-
-* **Video Verification:** Providing a video of the physical location, equipment, or assets used by the business. In some cases, this may be a live video call.
-* **Phone Call/Text Message:** Google sends an automated call or text with a PIN to the business phone number.
-* **Postcard:** A physical postcard with a PIN is mailed to the business's physical address, which can take two weeks or more. P.O. boxes cannot be used.
-* **Email:** Google sends a PIN to an email address at the business’s domain.
-
-:::note Please note
-
-*   You may need to verify with more than one method.
-*   The available methods depend on a variety of factors (Google cites business category, public information, region, and more).
-*   We do not have visibility on the method that Google will select for any given business, nor can we control or change the methods available when claiming and verifying a business.
+If listings are found to be in violation of Google's guidelines, they may be removed without warning. If fulfillment work has not yet begun, a full refund may be issued. If fulfillment has already been completed, no refunds are issued. It is your responsibility to submit listings that comply with [Google's guidelines](https://support.google.com/business/answer/3038177) for account eligibility.
 
 :::
 
-### 3. Initial profile optimization
+## Prerequisites
 
-Once the listing is claimed, the team performs the initial optimization (see [What's Included](#whats-included)) and sends a confirmation email within 2 business days, after which the monthly optimized service begins.
+**Eligibility:** Businesses that serve customers in person, from a storefront or in a service area, are generally eligible, including businesses with existing listings that need re-verification or reinstatement. Not eligible: rental or for-sale properties, lead generation companies, brands, organizations, artists, and online-only businesses (including e-commerce). It is your responsibility to ensure businesses you ask us to claim meet [Google's guidelines for representing your business online](https://support.google.com/business/answer/3038177). **We reserve the right to refuse service** for businesses that are not eligible.
+
+**How to prepare before claiming starts:**
+
+* If you already have access to a listing, you can add [listings@yourdigitalagents.com](mailto:listings@yourdigitalagents.com) as an owner in advance (see [If you already have access](#if-you-already-have-access-to-the-listing)). If you are not sure how, ask us and we can walk you through it.
+* Prepare business documents Google may require (for example, a business license or utility bill) and provide them when asked.
+* For a new listing claim, complete the fulfillment form as soon as possible with at least: business name, address, phone number, logo, cover photo, business description, hours of operation, and an email to add as an owner of the listing.
+* **P.O. boxes cannot be used** when claiming GBP listings.
+
+## Getting Started
+
+### 1. Submitting your information
+
+When GBP Optimization is purchased, the Listing Fulfillment team receives the fulfillment form and works to verify the listing using the information provided.
+
+* **Timeline:** We review the order and start the process within 2 business days. Initial fulfillment work is completed within 2 business days of receiving a fully completed fulfillment form.
+* **Attempt to verify:** The team attempts verification with the information in the form within 48 hours of receiving it (where the process allows).
+
+If information is missing from the form, the overall process will be delayed. After the confirmation email is received, provide any missing information promptly so work can continue.
+
+### 2. Listing claim and verification
+
+Fulfillment can follow several paths depending on the situation. The most common are a brand new listing claim, gaining access to an existing listing (you have access, or you do not), and reinstating a suspended listing (when you have access).
+
+#### Brand new listing claim
+
+Our team works to create a new listing from the fulfillment form. As part of this we add the business name, address, and phone number, plus a logo, cover photo, up to 5 photos and 5 videos, and (where applicable) Highlights, Amenities, Attributes, and Service Options.
+
+You will be offered (and required to complete) one or more of Google's verification methods. To avoid delays, provide all requested information as soon as possible. Methods can include:
+
+* **Video verification:** You may need to provide a video of unlocking the physical location or cash register. For service area businesses, videos may need to show tools, equipment, and assets used to provide services. In some cases, Google may require a live video call.
+* **Phone call / text message:** Google sends an automated call or text with a PIN to the business phone number.
+* **Postcard:** A physical postcard with a PIN is mailed to the business's physical address. This can take two weeks or more and is a very common method.
+* **Email:** Google sends a PIN to an email address at the business domain (for example, `...@businesswebsite.com`).
+
+:::note Please note
+
+* You may need to verify with more than one method, and verification may be required more than once.
+* The available methods depend on many factors (Google cites business category, public information, region, and more).
+* We do not have visibility into which method Google will offer, and we cannot control or change the methods available. We must comply with whatever Google offers, including video verification when required.
+* If there is a suspension on the listing or additional verification is required, the timeline may be delayed.
+
+:::
+
+**Timeline:** This step often takes two weeks or more, depending on how quickly information is provided and on Google's processes. Most new claims take less than a week, but the process can take a month or longer if there is significant back-and-forth with Google.
+
+#### If you already have access to the listing
+
+Add our team so we can manage the profile:
+
+1. Open the business profile, then open the kebab menu (three dots) next to Profile strength.
+2. Go to Business Profile settings → People and access → Add.
+3. Add [listings@yourdigitalagents.com](mailto:listings@yourdigitalagents.com) as an Owner or Manager.
+
+:::note
+
+Without Owner access, we cannot add other users to the profile.
+
+:::
+
+#### If the listing is claimed and you do not have access
+
+If the GBP is already claimed and you are not the owner, we can work to have the listing unlocked so it can be claimed again. Typical steps:
+
+* The platform often has a Request ownership (or similar) flow that notifies the current owner.
+* If the current owner denies the request, we may need to work with Google Support; we cannot guarantee ownership.
+* If the current owner does not respond within 3 business days (where that rule applies), the listing may be claimed using the same verification methods as in a [brand new listing claim](#brand-new-listing-claim).
+
+This process often takes two weeks or more. Due to reliance on Google Support, we cannot guarantee the listing can be claimed this way.
+
+#### Reinstating a suspended listing
+
+To start reinstatement, follow the steps above to add [listings@yourdigitalagents.com](mailto:listings@yourdigitalagents.com) as an owner on the listing. Once we have ownership access, we work with Google Support.
+
+Helpful to prepare in advance (Google often asks for at least one of these, plus verification):
+
+* An official document with the business name and address (for example, a business license or utility bill).
+* Photos of the storefront, ideally with a street sign visible.
+* Photos inside the business that support ownership (for example, from behind the counter).
+* For service area businesses, a video of tools and equipment used for the services.
+
+This process can take two weeks or more. We cannot guarantee reinstatement. **If the listing is suspended and neither you nor the business have access, it may not be recoverable** through Google Support.
+
+### Multi-location and bulk verification (10+ locations)
+
+For 10 or more locations, we can pursue bulk verification with Google. Before requesting multi-location claiming, confirm that:
+
+* The spreadsheet includes 10 or more locations for the same business.
+* It includes all locations for that brand you want on this account.
+* The business is not in Google's restricted verticals.
+* The business is not a service area business (for this bulk flow).
+* A verified account does not already exist for this use case.
+
+Client expectations:
+
+* Provide a branded email and password under the brand's domain (for example, `locations@yourbrand.com`). **Do not** attach a recovery email or phone to that Gmail, or sign-in for our team can fail.
+* Complete the team's spreadsheet with each location: business name, address, zip, phone number, website, and category. If some rows are already claimed, only claimable listings will be processed after upload.
+
+**What our team does:** We sign in, create a Google Business Profile location group, import the spreadsheet (Add business → Import businesses → select the file), align primary categories across locations, and submit a [bulk listing verification](https://support.google.com/business/answer/4490296) request. Google reviews the request against its quality guidelines and may email with questions. Google may still require individual verification for some or all locations.
 
 ## FAQ
 
+### Eligibility and business type
+
 <details>
+<summary>What types of businesses are eligible for this service?</summary>
 
-<summary> What types of businesses are eligible for this service?</summary>
+Businesses that serve customers in person, from a storefront or in a service area, are generally eligible. This also includes businesses with existing listings that need re-verification or reinstatement, provided they follow [Google's guidelines](https://support.google.com/business/answer/3038177).
 
-Businesses that conduct in-person business with customers, either from a storefront or in a service area, are eligible. Businesses that are not eligible include rental properties, lead generation companies, and online-only businesses, including eCommerce.
+Businesses that are not eligible include rental properties, lead generation companies, and online-only businesses, including e-commerce. See also the FAQ on what type of business cannot be claimed with this service (below).
 </details>
 
 <details>
-
 <summary>What type of business cannot be claimed with this service?</summary>
 
-* Rental or for-sale properties such as vacation homes, model homes, or vacant apartments
-* An ongoing service, class, or meeting at a location that you don't own or have the authority to represent
+Examples of businesses that are not eligible for a Business Profile include:
+
+* Rental or for-sale properties (vacation homes, model homes, vacant apartments, etc.)
+* An ongoing service, class, or meeting at a location you don't own or aren't authorized to represent
 * Lead generation agents or companies
-* Brands
-* Organizations
-* Artists
+* Brands, organizations, or artists (as described in Google's rules)
+* Other online-only businesses, including e-commerce
 
-Other online-only businesses including ecommerce
-For a full list of eligibility criteria, please refer to [Google’s guidelines](https://support.google.com/business/answer/3038177) for representing your business online.
+For the full list, see [Google's guidelines for representing your business online](https://support.google.com/business/answer/3038177).
 </details>
 
 <details>
+<summary>Can you claim a listing for a business that is still under construction?</summary>
 
-<summary> What happens if someone else already owns the business listing?</summary>
-
-If the listing is already claimed by another owner, our team can request ownership and work with Google Support to gain access. If access cannot be gained, we will discuss the next steps with you.
+Usually, listings cannot be created until the business is open and ready to receive customers. Occasionally Google allows a listing within about three months of the opening date. Contact your services representative before ordering if this applies.
 </details>
 
 <details>
+<summary>The business runs two different companies with the same phone number and address. Can you claim both listings?</summary>
 
-<summary> How long does the claiming process take?</summary>
+An identical address and phone number can be treated as duplicates. If two separate business licenses can be provided, Google may allow two listings. This is not guaranteed.
+</details>
 
-While most new claims take less than a week, the process can take a month or longer if there is significant back-and-forth required with Google.
+### Claiming, ownership, and verification
+
+<details>
+<summary>What happens if someone else already owns the business listing?</summary>
+
+If the listing is already claimed by another owner, we can request ownership and work with Google Support to gain access. If access cannot be gained, we will discuss next steps with you. See also [If the listing is claimed and you do not have access](#if-the-listing-is-claimed-and-you-do-not-have-access) above.
 </details>
 
 <details>
+<summary>How long does the claiming process take?</summary>
 
-<summary> What happens if my business listing gets suspended?</summary>
-
-Making edits to a profile can sometimes trigger a re-verification requirement or a suspension. If a listing is suspended, our team will work with Google to have the suspension lifted. However, there is no guarantee that Google will agree to reinstate the listing.
+While most new claims take less than a week, the process can take a month or longer if there is significant back-and-forth with Google. Work may be discontinued after three months of attempts, or after repeated unsuccessful communication.
 </details>
 
 <details>
-
-<summary> How do you decide what to post on the business profile?</summary>
-
-Posts are created using relevant content from your business website. If you have specific content, promotions, or events you would like posted, you should provide that information to the team.
-</details>
-
-<details>
-
 <summary>What is the status of my Google Business Profile verification? Is my verification complete?</summary>
 
-You can view the current status of verification in the Projects tab of your dashboard. There you can find information about any in-progress or complete work that our team is fulfilling on your behalf. You will be able to see any notes left by our team about the status, including any issues that may require a different type of verification or may be waiting on resolution from a Google support ticket.
+You can view the current status of verification in the Projects tab of the dashboard. There you can find information about any in-progress or completed work our team is fulfilling on your behalf, plus notes from our team (including any issues that may require a different type of verification or that may be waiting on resolution from a Google support ticket).
 
-![Projects Tab.png](./img/18617870927639-802d00bc47.png)
+![Projects Tab](./img/18617870927639-802d00bc47.png)
 </details>
 
 <details>
+<summary>Will you create a profile image and cover image for the business?</summary>
 
+No. These images must be provided (for example, via the fulfillment form; see the FAQ on how to send images to the team, below).
+</details>
+
+<details>
+<summary>When will the listing be complete?</summary>
+
+Most new claims finish in under a week, but complex cases can take over a month. Work may stop after three months of attempts or after repeated unsuccessful communication.
+</details>
+
+<details>
+<summary>An edit was made on the listing but the changes are not showing. Why?</summary>
+
+Edits can go through manual review, which delays publication. Most edits appear within about 3 business days. **Warning:** Editing a profile can trigger re-verification or suspension. Reinstatement is not guaranteed.
+</details>
+
+### Suspensions and Google Support
+
+<details>
+<summary>What happens if my business listing gets suspended?</summary>
+
+Making edits to a profile can sometimes trigger a re-verification requirement or a suspension. If a listing is suspended, our team works with Google to have it lifted. There is no guarantee Google will reinstate the listing. Google does not always explain why profiles are suspended or how tickets are triaged; we share updates as we receive them.
+
+See [Reinstating a suspended listing](#reinstating-a-suspended-listing) above.
+</details>
+
+<details>
 <summary>Why was my Google Business Profile suspended?</summary>
 
-If your Google Business Profile becomes suspended, note that Google doesn't provide transparency on why businesses are unverified, why they become suspended, or how their support requests are triaged. We work with them as best as we can to pass information on when we are managing a support request, but we can only be as transparent as they are.
+Google often does not provide clear reasons for suspension or unverified status. We work with them on open requests and pass on what we learn, but we can only be as transparent as Google is.
 </details>
 
 <details>
-
-<summary>What's the status of my Google support ticket? When will it be resolved?</summary>
-
-Note that Google is not transparent about their service level expectations and we won't know precisely when to expect an answer from them on tickets. If it's a brand new support or reinstatement request, we typically hear from them within 3 to 7 business days. If no response is received after 7 business days, we submit a new ticket. For existing support tickets, if there is no response and the process becomes blocked, we may have no options but to submit a new support request.
-</details>
-
-<details>
-
-<summary>Can I be added to the Google Support ticket?</summary>
-
-Our team is trained to use best practices to resolve an issue with Google. In order to streamline the communications with Google's Support team and work toward the best resolution possible, we do not typically add other stakeholders to the ticket. We are able to do so upon request. Note that we do pass on all of the updates as we receive them.
-</details>
-
-<details>
-
-<summary>How does multi-location & bulk verification work?</summary>
-
-For businesses with 10 or more locations, we can request bulk verification from Google. This process requires a spreadsheet containing the information for all locations. Please note that Google may still require individual verification for some or all of the locations.
-</details>
-
-<details>
-
 <summary>What is the process for reinstating a suspended listing?</summary>
 
-Making edits to a profile can sometimes trigger a re-verification requirement or a suspension from Google. If a listing is suspended, our team will work diligently with Google to have the suspension lifted. However, there is no guarantee that Google will agree to reinstate the listing, as the final decision rests with them.
+Same as the suspension handling above: we work with Google, and reinstatement is not guaranteed. If you have access, add [listings@yourdigitalagents.com](mailto:listings@yourdigitalagents.com) as owner and gather the [documents and media](#reinstating-a-suspended-listing) that Google commonly requests.
 </details>
 
 <details>
+<summary>What's the status of my Google support ticket? When will it be resolved?</summary>
 
+Google does not publish reliable service level expectations, so we won't know precisely when to expect an answer on tickets. For new support or reinstatement requests, we often hear within 3 to 7 business days. If there is no response after 7 business days, we typically open a new ticket. For long-running tickets with no movement, we may need to submit a new request.
+</details>
+
+<details>
+<summary>Can I be added to the Google Support ticket?</summary>
+
+Our team is trained to work tickets efficiently with Google. To streamline communications and work toward the best resolution possible, we do not usually add other stakeholders to the ticket. We can do so on request. We forward all updates as we receive them.
+</details>
+
+<details>
+<summary>How does multi-location and bulk verification work?</summary>
+
+For 10 or more locations, we can request bulk verification per [Google's bulk verification process](https://support.google.com/business/answer/4490296). Requirements include a spreadsheet, a branded domain email, and rules such as not using a service area business model for this flow. Google may still require per-location verification. See [Multi-location and bulk verification](#multi-location-and-bulk-verification-10-locations) above.
+</details>
+
+### Posts, content, and attachments
+
+<details>
+<summary>How do you decide what to post on the business profile?</summary>
+
+Posts work well for services, promotions, or events. Tell our team if you have specific content; otherwise we use relevant content from the business website (see [Monthly content posting](#monthly-content-posting)).
+</details>
+
+<details>
+<summary>How do I send images to the team?</summary>
+
+Use the fulfillment form to send profile and cover images. For all other images, email [marketingservices@yourdigitalagents.com](mailto:marketingservices@yourdigitalagents.com).
+</details>
+
+<details>
 <summary>What business types or categories don't have access to Google Business Profile posts?</summary>
+
+Examples include:
 
 * Adult Entertainment
 * Camps
@@ -187,4 +309,11 @@ Making edits to a profile can sometimes trigger a re-verification requirement or
 * Hotel (all hotel categories)
 * Vacation Rental
 * Wine Store (and other alcohol-related categories)
+
+</details>
+
+<details>
+<summary>If needed, where should I upload attachments for my order?</summary>
+
+Upload attachments in the attachments section of the fulfillment form, or email them to [marketingservices@yourdigitalagents.com](mailto:marketingservices@yourdigitalagents.com) so our team can access everything needed.
 </details>


### PR DESCRIPTION
## Summary
Expands the AI Workforce section and adds a client-facing link on every AI employee setup article.

### New articles
- **AI Social Media Manager** and **AI Blogger** setup + AI Workforce Optimization Plan guides, following the existing AI-employee template (shared `<OptimizationPlanSection />` / `<OptimizationPlanFaq />` snippets).
- Structure: one **Setup** section (4-step process with deliverables folded in) plus a dedicated **Your … calendar** section; required product is **Social AI Premium** (AI Blogger also requires WordPress). Both linked from the AI Workforce index.

### Client-facing callouts (all 8 AI setup articles)
- Each partner AI employee setup page now shows a top-of-page callout with a button linking to its **corresponding grey-labeled guide** on servicesdocs.io, so partners can share the unbranded version with clients.
- Links are **one-directional** (partner → grey-label only) to preserve the grey label.

### Google Business Profile Optimization
- Rewritten to full parity with the grey-labeled version, in partner tone (branded, no em dashes, `→` for nav paths): expanded eligibility/prerequisites, the four fulfillment paths, multi-location bulk verification, and a categorized FAQ.

## Notes
- Verified locally: Docusaurus builds and all affected pages render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
