### PR TITLE
feat(vendasta-services): link to grey-labeled docs from overview and sidebar

### DIFF
--- a/docusaurus/docs/vendasta-services/index.mdx
+++ b/docusaurus/docs/vendasta-services/index.mdx
@@ -6,6 +6,15 @@ tags: [vendasta-services, fulfillment, services, onboarding]
 keywords: [Vendasta Services, fulfillment services, website services, social media, digital advertising, review management]
 ---
 
+<a
+  className="greylabel-docs-button"
+  href="https://servicesdocs.io/"
+  target="_blank"
+  rel="noopener noreferrer"
+  style={{float: 'right', marginTop: '0.5rem', marginLeft: '1rem'}}>
+  Open the grey-labeled docs
+</a>
+
 # Vendasta Services overview
 
 Vendasta Services provides access to a team of experts who handle fulfillment for websites, social media management, digital advertising, review management, and other professional services. By leveraging our team and proven processes, you can deliver high-quality results with industry-leading turnaround times without expanding your internal team.

--- a/docusaurus/src/css/custom.css
+++ b/docusaurus/src/css/custom.css
@@ -2191,3 +2191,50 @@ div[class*="language-"] pre {
 [data-theme='dark'] .comparison-card:hover {
   border-color: #3F9B63;
 }
+
+/* External-link icon injected next to the "Vendasta Services" sidebar category
+   (see swizzled src/theme/DocSidebarItem/Category). Points at the grey-labeled docs. */
+.sidebar-category-with-link {
+  position: relative;
+}
+.sidebar-external-link-icon {
+  position: absolute;
+  top: 0;
+  right: 2.75rem; /* sits to the left of the collapse caret */
+  display: flex;
+  align-items: center;
+  height: 37px; /* matches the category header row height */
+  padding: 0 4px;
+  color: white;
+  opacity: 0.6;
+  transition: opacity 0.15s ease;
+}
+.sidebar-external-link-icon:hover {
+  opacity: 1;
+  color: white;
+}
+
+/* Button on the Vendasta Services overview page linking to the grey-labeled docs.
+   Matches the blue "Switch to Business App Docs" sidebar button. */
+.greylabel-docs-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 0.5rem 1.5rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  line-height: 1.2;
+  color: #fff !important;
+  background: rgb(5, 93, 149);
+  border-radius: 4px;
+  text-decoration: none;
+  transition: background 0.2s ease, box-shadow 0.15s ease, transform 0.15s ease;
+}
+.greylabel-docs-button:hover {
+  color: #fff !important;
+  background: rgb(4, 75, 120);
+  text-decoration: none;
+  box-shadow: 0 4px 12px rgba(5, 93, 149, 0.25);
+  transform: translateY(-1px);
+}

--- a/docusaurus/src/theme/DocSidebarItem/Category/index.tsx
+++ b/docusaurus/src/theme/DocSidebarItem/Category/index.tsx
@@ -1,0 +1,44 @@
+import React, {type ReactElement} from 'react';
+import OriginalCategory from '@theme-original/DocSidebarItem/Category';
+import type {Props} from '@theme/DocSidebarItem/Category';
+
+// The grey-labeled, client-facing Vendasta Services documentation.
+const GREY_LABEL_DOCS_URL = 'https://servicesdocs.io/';
+
+export default function CategoryWrapper(props: Props): ReactElement {
+  const isVendastaServices = props.item?.label === 'Vendasta Services';
+
+  if (!isVendastaServices) {
+    return <OriginalCategory {...props} />;
+  }
+
+  return (
+    <div className="sidebar-category-with-link">
+      <OriginalCategory {...props} />
+      <a
+        href={GREY_LABEL_DOCS_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="sidebar-external-link-icon"
+        title="Open the grey-labeled Vendasta Services docs"
+        aria-label="Open the grey-labeled Vendasta Services docs (opens in a new tab)"
+        onClick={(e) => e.stopPropagation()}>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true">
+          <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+          <polyline points="15 3 21 3 21 9" />
+          <line x1="10" y1="14" x2="21" y2="3" />
+        </svg>
+      </a>
+    </div>
+  );
+}


### PR DESCRIPTION
## Link partners to the grey-labeled Vendasta Services docs

Adds two entry points from Partner Center docs to the client-facing (grey-labeled) docs at [servicesdocs.io](https://servicesdocs.io/):

- **Overview page** — a blue "Open the grey-labeled docs" button on the Vendasta Services overview, styled to match the "Switch to Business App Docs" button.
- **Sidebar** — an external-link icon next to the "Vendasta Services" category, via a swizzled `DocSidebarItem/Category` (injected only for that category) plus supporting CSS.

### Testing
- `npm run build` passes; `npm run typecheck` adds no new errors.
- Verified locally in the dev server — button and sidebar icon render and link correctly.


<img width="271" height="52" alt="image" src="https://github.com/user-attachments/assets/16e94dd2-c88a-4607-90cc-8c5652889cd0" />


<img width="1136" height="409" alt="image" src="https://github.com/user-attachments/assets/5f8af759-3095-4e98-8419-178da237f4ee" />

