### PR TITLE
docs(ai-workforce): AI Employee Setup rename + links, consolidated Setup structure, Reputation Specialist updates

### DIFF
--- a/docusaurus/docs/vendasta-services/ai-workforce/_optimization-plan-faq.mdx
+++ b/docusaurus/docs/vendasta-services/ai-workforce/_optimization-plan-faq.mdx
@@ -32,7 +32,7 @@ Optimization coverage applies to AI employees set up by our team within the stan
 
 <details>
 
-<summary>How do I submit an optimization plan request?</summary>
+<summary>How do I submit an optimization request?</summary>
 
 Email marketingservices@yourdigitalagents.com with the AI employee in question, the change you'd like made, and the desired outcome. You'll receive a same-day acknowledgment and an expected resolution timeline.
 

--- a/docusaurus/docs/vendasta-services/ai-workforce/ai-blogger.md
+++ b/docusaurus/docs/vendasta-services/ai-workforce/ai-blogger.md
@@ -23,8 +23,8 @@ The AI Blogger Setup is a done-with-you service where our experts configure, tra
 
 Choose one or the other:
 
-- **Setup**: a **one-time fee**. Our experts configure, train, and launch your AI Blogger.
-- **AI Workforce Optimization Plan**: an **ongoing monthly fee** that **includes the same setup** plus continued optimization (monthly check-ins, unlimited change requests, and a live training session).
+- **[AI Employee Setup](https://partners.vendasta.com/marketplace/products/MP-K48XKQV7DXLGQZ67ZH4MNZDM2FQCK8LM)**: a **one-time fee**. Our experts configure, train, and launch your AI Blogger.
+- **[AI Workforce Optimization Plan](https://partners.vendasta.com/marketplace/products/MP-JHLVQX6W4MJFZ8V3V68CWMQ43X6N46TW)**: an **ongoing monthly fee** that **includes the same setup** plus continued optimization (monthly check-ins, unlimited change requests, and a live training session).
 
 :::
 

--- a/docusaurus/docs/vendasta-services/ai-workforce/ai-data-analyst.md
+++ b/docusaurus/docs/vendasta-services/ai-workforce/ai-data-analyst.md
@@ -24,18 +24,20 @@ The AI Data Analyst Setup is a done-for-you service where our experts configure,
 
 Choose one or the other:
 
-- **[AI Employee Setup](https://partners.vendasta.com/marketplace/products/MP-K48XKQV7DXLGQZ67ZH4MNZDM2FQCK8LM)**: a **one-time fee**. Our experts configure, train, and launch your AI Data Analyst (everything in "What's included with setup" below).
+- **[AI Employee Setup](https://partners.vendasta.com/marketplace/products/MP-K48XKQV7DXLGQZ67ZH4MNZDM2FQCK8LM)**: a **one-time fee**. Our experts configure, train, and launch your AI Data Analyst (everything in "What's included" below).
 - **[AI Workforce Optimization Plan](https://partners.vendasta.com/marketplace/products/MP-JHLVQX6W4MJFZ8V3V68CWMQ43X6N46TW)**: an **ongoing monthly fee** that **includes the same setup** plus continued optimization (monthly check-ins, unlimited change requests, and a live training session).
 
 :::
 
-## What's included with setup
+## Setup
 
-### 1. AI Employee profile
+### What's included
+
+#### 1. AI Employee profile
 
 We create a custom AI Employee with a name and avatar that represents your analytical team. Business owners and managers interact directly with the Data Analyst through Business App to ask questions and receive structured insights. The profile is configured within the **AI Workforce** section of Business App.
 
-### 2. AIR Analysis Framework
+#### 2. AIR Analysis Framework
 
 We configure the AIR framework, the structured methodology that guides every AI response:
 
@@ -49,7 +51,7 @@ Every response follows this structure automatically, so you receive a clear find
 The AI will never surface raw data dumps or vague summaries. If it cannot produce a structured AIR response, it will say so clearly rather than generating an unhelpful answer.
 :::
 
-### 3. Data source connections
+#### 3. Data source connections
 
 The AI Data Analyst requires Conversations AI (any edition) and at least one of the following data sources to be active: **CRM AI**, **Reputation AI**, **Social AI**, or **Local SEO**. The quality and depth of insights depend directly on how much data is available in each connected source. Once we determine what is active, we connect the data sources available in your account:
 
@@ -58,7 +60,7 @@ The AI Data Analyst requires Conversations AI (any edition) and at least one of 
 * **Social engagement:** post performance and engagement metrics from connected social accounts
 
 
-### 4. Knowledge base setup
+#### 4. Knowledge base setup
 
 We connect your business profile and website, and upload any supplementary documents (price lists, service catalogs, or team structure information) that provide context the AI can use when interpreting your data.
 
@@ -66,19 +68,17 @@ We connect your business profile and website, and upload any supplementary docum
 The AI Data Analyst is an internal tool. No chat widget or website installation is required, and there are no customer-facing components in this setup.
 :::
 
-<OptimizationPlanSection />
-
-## The setup process
+### The setup process
 
 The process involves a fulfillment form, a series of calls, and configuration steps to get your AI Data Analyst running effectively.
 
-### 1. Fulfillment form
+#### 1. Fulfillment form
 
 To ensure a smooth and efficient setup, please fill out the fulfillment form with as much detail as possible. Let us know which data sources are active (CRM, Reviews/NPS, and Social) so we can configure the right capabilities from the start.
 
 * **Timeline:** We'll review the order and start the process within 2 business days.
 
-### 2. Onboarding call
+#### 2. Onboarding call
 
 Our team will lead a structured onboarding call to confirm your active data sources, understand the types of business questions you want the AI to answer, and configure the response framework. The response framework is a structured approach that guides the AI to analyze your data, interpret what it means, and recommend a clear next step in every response. We will come to the call with an initial setup ready to demo and refine together.
 
@@ -88,19 +88,19 @@ Our team will lead a structured onboarding call to confirm your active data sour
 If you are unable to attend the onboarding call, our team will proceed with setup using the information provided in your fulfillment form and will follow up via email and phone to review and refine. If we are unable to reach you after our follow-up process, the project will be closed, but can be reopened at any time by reaching back out to us.
 :::
 
-### 3. Data Analyst setup
+#### 3. Data Analyst setup
 
 Using the information gathered during the onboarding call, we will configure your AI Data Analyst with the AIR Analysis Framework, connect all active data sources (CRM, Reviews/NPS, Social), and upload any supplementary business context documents to the knowledge base.
 
 * **Timeline:** Your AI Data Analyst will be complete in 1 business day, or 3 business days for setups with multiple connected data sources.
 
-### 4. Training call
+#### 4. Training call
 
 This call will walk you through your new AI Data Analyst: how to ask questions, how to interpret the structured AIR responses, and how to act on the recommendations provided. We'll run live examples together using your actual data.
 
 * **Timeline:** This call can be booked in as little as 1 business day after Data Analyst setup completion, depending on availability.
 
-### 5. 30-day check-in
+#### 5. 30-day check-in
 
 This call will be used to review how you've been using the AI Data Analyst, assess whether the AIR framework is delivering useful insights, and refine the data source connections or knowledge base based on real usage.
 
@@ -109,6 +109,8 @@ Prior to this call, our team will run a set of sample queries to validate that t
 :::
 
 * **Timeline:** This call will be booked 3-4 weeks after the completion of your AI Data Analyst setup.
+
+<OptimizationPlanSection />
 
 ## Requirements
 

--- a/docusaurus/docs/vendasta-services/ai-workforce/ai-data-analyst.md
+++ b/docusaurus/docs/vendasta-services/ai-workforce/ai-data-analyst.md
@@ -24,8 +24,8 @@ The AI Data Analyst Setup is a done-for-you service where our experts configure,
 
 Choose one or the other:
 
-- **Setup**: a **one-time fee**. Our experts configure, train, and launch your AI Data Analyst (everything in "What's included with setup" below).
-- **AI Workforce Optimization Plan**: an **ongoing monthly fee** that **includes the same setup** plus continued optimization (monthly check-ins, unlimited change requests, and a live training session).
+- **[AI Employee Setup](https://partners.vendasta.com/marketplace/products/MP-K48XKQV7DXLGQZ67ZH4MNZDM2FQCK8LM)**: a **one-time fee**. Our experts configure, train, and launch your AI Data Analyst (everything in "What's included with setup" below).
+- **[AI Workforce Optimization Plan](https://partners.vendasta.com/marketplace/products/MP-JHLVQX6W4MJFZ8V3V68CWMQ43X6N46TW)**: an **ongoing monthly fee** that **includes the same setup** plus continued optimization (monthly check-ins, unlimited change requests, and a live training session).
 
 :::
 

--- a/docusaurus/docs/vendasta-services/ai-workforce/ai-human-resources-coordinator.md
+++ b/docusaurus/docs/vendasta-services/ai-workforce/ai-human-resources-coordinator.md
@@ -24,8 +24,8 @@ The AI Human Resources Coordinator Setup is a do-it-with-me service where our ex
 
 Choose one or the other:
 
-- **Setup**: a **one-time fee**. Our experts configure, train, and launch your AI Human Resources Coordinator (everything in "What's included with setup" below).
-- **AI Workforce Optimization Plan**: an **ongoing monthly fee** that **includes the same setup** plus continued optimization (monthly check-ins, unlimited change requests, and a live training session).
+- **[AI Employee Setup](https://partners.vendasta.com/marketplace/products/MP-K48XKQV7DXLGQZ67ZH4MNZDM2FQCK8LM)**: a **one-time fee**. Our experts configure, train, and launch your AI Human Resources Coordinator (everything in "What's included with setup" below).
+- **[AI Workforce Optimization Plan](https://partners.vendasta.com/marketplace/products/MP-JHLVQX6W4MJFZ8V3V68CWMQ43X6N46TW)**: an **ongoing monthly fee** that **includes the same setup** plus continued optimization (monthly check-ins, unlimited change requests, and a live training session).
 
 :::
 

--- a/docusaurus/docs/vendasta-services/ai-workforce/ai-human-resources-coordinator.md
+++ b/docusaurus/docs/vendasta-services/ai-workforce/ai-human-resources-coordinator.md
@@ -24,18 +24,20 @@ The AI Human Resources Coordinator Setup is a do-it-with-me service where our ex
 
 Choose one or the other:
 
-- **[AI Employee Setup](https://partners.vendasta.com/marketplace/products/MP-K48XKQV7DXLGQZ67ZH4MNZDM2FQCK8LM)**: a **one-time fee**. Our experts configure, train, and launch your AI Human Resources Coordinator (everything in "What's included with setup" below).
+- **[AI Employee Setup](https://partners.vendasta.com/marketplace/products/MP-K48XKQV7DXLGQZ67ZH4MNZDM2FQCK8LM)**: a **one-time fee**. Our experts configure, train, and launch your AI Human Resources Coordinator (everything in "What's included" below).
 - **[AI Workforce Optimization Plan](https://partners.vendasta.com/marketplace/products/MP-JHLVQX6W4MJFZ8V3V68CWMQ43X6N46TW)**: an **ongoing monthly fee** that **includes the same setup** plus continued optimization (monthly check-ins, unlimited change requests, and a live training session).
 
 :::
 
-## What's included with setup
+## Setup
 
-### 1. AI Employee profile
+### What's included
+
+#### 1. AI Employee profile
 
 We create a custom AI Employee with a name and avatar that represents your HR team. Employees interact with a professional HR persona that is warm, accurate, and appropriately cautious with sensitive topics. The profile is configured within the **AI Workforce** section of Business App.
 
-### 2. PolicyScope framework
+#### 2. PolicyScope framework
 
 We configure the PolicyScope framework — a three-level routing system that governs how the AI handles every HR inquiry:
 
@@ -47,11 +49,11 @@ We configure the PolicyScope framework — a three-level routing system that gov
 The AI will never guess or fabricate answers to personal questions — it is designed to redirect before it over-reaches.
 :::
 
-### 3. Escalation contact configuration
+#### 3. Escalation contact configuration
 
 We populate the Level 2 redirect language with your actual HR contact's name, role, phone, and email — so employees receive a clear, specific direction rather than a generic "speak to HR" message. Additional escalation contacts for Level 3 (IT, Finance, Legal) can be added at any time.
 
-### 4. Knowledge base setup
+#### 4. Knowledge base setup
 
 We upload every policy document, employee handbook, benefit guide, onboarding checklist, and FAQ provided during setup. This is the most critical step — the AI can only answer questions it has been given the information to answer.
 
@@ -59,27 +61,25 @@ We upload every policy document, employee handbook, benefit guide, onboarding ch
 The AI HR Coordinator is an internal tool and does not require a chat widget or website installation. No code will be added to your public website.
 :::
 
-### 5. Optional: Appointment booking
+#### 5. Optional: Appointment booking
 
 If your HR team uses a connected Google, Outlook, or Microsoft calendar in Business App, we can enable the AI to schedule meetings with HR team members directly in the conversation.
 
-### 6. Optional: Google Drive sync
+#### 6. Optional: Google Drive sync
 
 If your HR policies are stored and maintained in Google Drive, we can configure an automated sync so that policy updates in your Drive folder are automatically reflected in the AI's knowledge base. This requires brief access to your Google Drive folder structure.
 
-<OptimizationPlanSection />
-
-## The setup process
+### The setup process
 
 The process involves a fulfillment form, a series of calls, and configuration steps to get your AI Human Resources Coordinator running effectively.
 
-### 1. Fulfillment form
+#### 1. Fulfillment form
 
 To ensure a smooth and efficient setup, please fill out the fulfillment form with as much detail as possible. Include your escalation contact's full name, role, and contact information — this is required to configure the AI's handoff logic.
 
 * **Timeline:** We'll review the order and start the process within 2 business days.
 
-### 2. Onboarding call
+#### 2. Onboarding call
 
 Our team will lead a structured onboarding call to understand your HR workflows, the types of questions employees most commonly ask, and how you'd like sensitive or personal inquiries handled. We'll configure the PolicyScope framework — a three-level routing system that answers general questions directly, redirects personal inquiries to your HR contact, and declines out-of-scope questions gracefully. We will come to the call with an initial setup ready to demo and refine together.
 
@@ -89,19 +89,19 @@ Our team will lead a structured onboarding call to understand your HR workflows,
 If you are unable to attend the onboarding call, our team will proceed with setup using the information provided in your fulfillment form and will follow up via email and phone to review and refine. If we are unable to reach you after our follow-up process, the project will be closed — but can be reopened at any time by reaching back out to us.
 :::
 
-### 3. HR Coordinator setup
+#### 3. HR Coordinator setup
 
 Using the information gathered during the onboarding call, we will configure your AI HR Coordinator with the PolicyScope framework, set up your escalation contacts, upload all HR policy documents and handbooks to the knowledge base, and connect optional capabilities such as appointment booking if required.
 
 * **Timeline:** Your AI Human Resources Coordinator will be complete in 1 business day, or 3 business days for setups with large or complex policy libraries.
 
-### 4. Training call
+#### 4. Training call
 
 This call will walk you through your AI HR Coordinator — how it handles general policy questions, how it redirects personal or sensitive inquiries, and where it declines out-of-scope requests. We'll test it live together and answer any questions your team has before go-live.
 
 * **Timeline:** This call can be booked in as little as 1 business day after HR Coordinator Setup completion, depending on availability.
 
-### 5. 30-day check-in
+#### 5. 30-day check-in
 
 This call will be used to review real employee interactions, assess whether the AI is routing questions correctly across all three PolicyScope levels, and refine the knowledge base or escalation contacts based on actual usage.
 
@@ -110,6 +110,8 @@ Prior to this call, our team will review 5–10 conversations to identify gaps i
 :::
 
 * **Timeline:** This call will be booked 3–4 weeks after the completion of your HR Coordinator Setup.
+
+<OptimizationPlanSection />
 
 ## Requirements
 

--- a/docusaurus/docs/vendasta-services/ai-workforce/ai-inside-sales-representative.md
+++ b/docusaurus/docs/vendasta-services/ai-workforce/ai-inside-sales-representative.md
@@ -24,8 +24,8 @@ The AI Inside Sales Representative (ISR) Setup is a do-it-with-me service where 
 
 Choose one or the other:
 
-- **Setup**: a **one-time fee**. Our experts configure, train, and launch your AI Inside Sales Representative (everything in "What's included with setup" below).
-- **AI Workforce Optimization Plan**: an **ongoing monthly fee** that **includes the same setup** plus continued optimization (monthly check-ins, unlimited change requests, and a live training session).
+- **[AI Employee Setup](https://partners.vendasta.com/marketplace/products/MP-K48XKQV7DXLGQZ67ZH4MNZDM2FQCK8LM)**: a **one-time fee**. Our experts configure, train, and launch your AI Inside Sales Representative (everything in "What's included with setup" below).
+- **[AI Workforce Optimization Plan](https://partners.vendasta.com/marketplace/products/MP-JHLVQX6W4MJFZ8V3V68CWMQ43X6N46TW)**: an **ongoing monthly fee** that **includes the same setup** plus continued optimization (monthly check-ins, unlimited change requests, and a live training session).
 
 :::
 

--- a/docusaurus/docs/vendasta-services/ai-workforce/ai-inside-sales-representative.md
+++ b/docusaurus/docs/vendasta-services/ai-workforce/ai-inside-sales-representative.md
@@ -24,22 +24,24 @@ The AI Inside Sales Representative (ISR) Setup is a do-it-with-me service where 
 
 Choose one or the other:
 
-- **[AI Employee Setup](https://partners.vendasta.com/marketplace/products/MP-K48XKQV7DXLGQZ67ZH4MNZDM2FQCK8LM)**: a **one-time fee**. Our experts configure, train, and launch your AI Inside Sales Representative (everything in "What's included with setup" below).
+- **[AI Employee Setup](https://partners.vendasta.com/marketplace/products/MP-K48XKQV7DXLGQZ67ZH4MNZDM2FQCK8LM)**: a **one-time fee**. Our experts configure, train, and launch your AI Inside Sales Representative (everything in "What's included" below).
 - **[AI Workforce Optimization Plan](https://partners.vendasta.com/marketplace/products/MP-JHLVQX6W4MJFZ8V3V68CWMQ43X6N46TW)**: an **ongoing monthly fee** that **includes the same setup** plus continued optimization (monthly check-ins, unlimited change requests, and a live training session).
 
 :::
 
-## What's included with setup
+## Setup
 
-### 1. AI Employee profile
+### What's included
+
+#### 1. AI Employee profile
 
 We create a custom AI Employee with a name and avatar that represents your business. Customers interact with a professional sales persona rather than a generic bot. The profile is configured within the **AI Workforce** section of Business App.
 
-### 2. Sales role prompt
+#### 2. Sales role prompt
 
 We configure a confident, empathetic inbound sales consultant persona for your ISR. The prompt is designed to guide customers toward a solution — an appointment or consultation — rather than simply collecting a message. Every conversation is kept moving forward with qualifying questions and clear next steps.
 
-### 3. Lead discovery and qualification
+#### 3. Lead discovery and qualification
 
 We set up a custom capability that defines the qualification logic: the ISR confirms your business can actually serve the customer's need before capturing their contact information. If a customer asks about a service you do not offer, the ISR politely informs them and stops the lead capture process — no wasted time for your sales team.
 
@@ -47,7 +49,7 @@ We set up a custom capability that defines the qualification logic: the ISR conf
 The quality of your services list directly affects qualification accuracy. A specific services list — for example, 'furnace repair, AC installation, duct cleaning' rather than 'HVAC services' — allows the ISR to make faster, more accurate qualification decisions.
 :::
 
-### 4. Lead capture and appointment booking
+#### 4. Lead capture and appointment booking
 
 Built-in capabilities manage the full lead capture sequence: Name → Phone → Email. Phone number validation and objection handling are included — if a customer says 'just email me,' the ISR acknowledges their preference, explains the value of a quick call, and pivots. If they object a second time, the ISR accepts email as a fallback.
 
@@ -57,23 +59,21 @@ When a calendar is connected, the ISR checks availability and books appointments
 Appointment booking requires a connected Google, Outlook, or Microsoft calendar in Business App. Without it, the ISR qualifies and captures leads but cannot schedule meetings.
 :::
 
-### 5. Knowledge base setup
+#### 5. Knowledge base setup
 
 We connect your business profile, website, services list, and any FAQs to the ISR's knowledge base. This allows the ISR to answer questions about your services, pricing, hours, and location accurately — without fabricating information.
 
-<OptimizationPlanSection />
-
-## The setup process
+### The setup process
 
 The process involves a fulfillment form, a series of calls, and configuration steps to get your AI Inside Sales Representative running effectively.
 
-### 1. Fulfillment form
+#### 1. Fulfillment form
 
 To ensure a smooth and efficient setup, please fill out the fulfillment form with as much detail as possible. This will help streamline the entire experience.
 
 * **Timeline:** We'll review the order and start the process within 2 business days.
 
-### 2. Onboarding call
+#### 2. Onboarding call
 
 Our team of experts will lead an onboarding call to understand your business needs and configure your AI Inside Sales Representative to reflect your brand, tone, and qualification criteria. We will come to the call with an initial setup ready to demo and refine together.
 
@@ -84,19 +84,19 @@ Our team of experts will lead an onboarding call to understand your business nee
 If you are unable to attend the onboarding call, our team will proceed with setup using the information provided in your fulfillment form and will follow up via email and phone to review and refine. If we are unable to reach you after our follow-up process, the project will be closed — but can be reopened at any time by reaching back out to us.
 :::
 
-### 3. ISR setup
+#### 3. ISR setup
 
 Using the information gathered during the onboarding call, we will configure your AI Employee with a sales-qualified persona, set up lead discovery and qualification logic, enable lead capture and appointment booking capabilities, and connect your knowledge sources — including your services list, website, and FAQs.
 
 * **Timeline:** Your AI Inside Sales Representative will be complete in 1 business day, or 3 business days for setups with custom integrations or complex knowledge bases.
 
-### 4. Training call
+#### 4. Training call
 
 This call will walk you through your new AI Inside Sales Representative: where to find your captured leads, how the qualification logic works, how to manage conversations in Business App, and how appointment notifications are handled.
 
 * **Timeline:** This call can be booked in as little as 1 business day after ISR Setup completion, depending on availability.
 
-### 5. 30-day check-in
+#### 5. 30-day check-in
 
 This call will be used to review your conversations, determine whether the qualification logic or knowledge base needs to be updated, and ensure your ISR is converting inquiries effectively.
 
@@ -105,6 +105,8 @@ Prior to this call, our team will review 5–10 conversations to provide recomme
 :::
 
 * **Timeline:** This call will be booked 3–4 weeks after the completion of your ISR Setup.
+
+<OptimizationPlanSection />
 
 ## Requirements
 

--- a/docusaurus/docs/vendasta-services/ai-workforce/ai-receptionist.md
+++ b/docusaurus/docs/vendasta-services/ai-workforce/ai-receptionist.md
@@ -23,8 +23,8 @@ The AI Receptionist Setup is a done-for-you service where our experts configure,
 
 Choose one or the other:
 
-- **Setup**: a **one-time fee**. Our experts configure, train, and launch your AI Receptionist (everything in "What's included with setup" below).
-- **AI Workforce Optimization Plan**: an **ongoing monthly fee** that **includes the same setup** plus continued optimization (monthly check-ins, unlimited change requests, and a live training session).
+- **[AI Employee Setup](https://partners.vendasta.com/marketplace/products/MP-K48XKQV7DXLGQZ67ZH4MNZDM2FQCK8LM)**: a **one-time fee**. Our experts configure, train, and launch your AI Receptionist (everything in "What's included with setup" below).
+- **[AI Workforce Optimization Plan](https://partners.vendasta.com/marketplace/products/MP-JHLVQX6W4MJFZ8V3V68CWMQ43X6N46TW)**: an **ongoing monthly fee** that **includes the same setup** plus continued optimization (monthly check-ins, unlimited change requests, and a live training session).
 
 :::
 

--- a/docusaurus/docs/vendasta-services/ai-workforce/ai-receptionist.md
+++ b/docusaurus/docs/vendasta-services/ai-workforce/ai-receptionist.md
@@ -23,58 +23,60 @@ The AI Receptionist Setup is a done-for-you service where our experts configure,
 
 Choose one or the other:
 
-- **[AI Employee Setup](https://partners.vendasta.com/marketplace/products/MP-K48XKQV7DXLGQZ67ZH4MNZDM2FQCK8LM)**: a **one-time fee**. Our experts configure, train, and launch your AI Receptionist (everything in "What's included with setup" below).
+- **[AI Employee Setup](https://partners.vendasta.com/marketplace/products/MP-K48XKQV7DXLGQZ67ZH4MNZDM2FQCK8LM)**: a **one-time fee**. Our experts configure, train, and launch your AI Receptionist (everything in "What's included" below).
 - **[AI Workforce Optimization Plan](https://partners.vendasta.com/marketplace/products/MP-JHLVQX6W4MJFZ8V3V68CWMQ43X6N46TW)**: an **ongoing monthly fee** that **includes the same setup** plus continued optimization (monthly check-ins, unlimited change requests, and a live training session).
 
 :::
 
-## What's included with setup
+## Setup
 
-### 1. CRM pipeline and lead management
+### What's included
+
+#### 1. CRM pipeline and lead management
 
 To properly manage your leads, we will create a smart list and a sales pipeline for you in the CRM. The smart list automatically pulls all web chat and form leads into a single contact list, while the pipeline tracks new opportunities and can show the dollar value of each lead. You will also receive tasks and notifications for new leads.
 
-### 2. Booking, inventory, and service area connections
+#### 2. Booking, inventory, and service area connections
 
 * **Appointment Booking:** We can connect your calendar to the AI Receptionist to book appointments on your behalf. If a direct connection via API is not possible, the receptionist will provide a booking link to your customers instead.
 * **Service Area Lookup:** For service-based businesses, we can configure a custom capability that handles zip code lookups to ensure leads are within your service area.
 * **Inventory Connection:** For retail stores with an e-commerce website, we can set up a custom capability (through an open API) to look up inventory information and provide real-time updates.
 
-### 3. Automation creation
+#### 3. Automation creation
 
 Our team will set up 3-5 automations depending on your business needs. These automations will send you notifications for new leads and also send follow-ups to your leads to ensure they have a way to reach you.
 
-<OptimizationPlanSection />
-
-## The setup process
+### The setup process
 
 The process involves a series of calls and configuration steps to get your AI Receptionist running effectively.
 
-### 1. Initial training call
+#### 1. Initial training call
 
 Our experts will lead an onboarding call to understand your business needs and adjust pre-built lead capture workflows to suit you. We will come to the call with your chat receptionist already set up with your branding and a customized communication style to demonstrate. During this call, we will refine any additional knowledge sources and communication instructions together.
 
 * **Timeline:** An onboarding call can be booked in as little as one business day, depending on availability.
 * **For U.S. Businesses:** A2P registration is required to validate the use of SMS. Please be ready with your legal business information for this process, which can take up to two weeks to complete.
 
-### 2. AI Receptionist configuration
+#### 2. AI Receptionist configuration
 
 Using the refinements from the onboarding call, we will finish setting up your AI Receptionist and enable its voice settings. We will also create a lead capture form for your website, set up SMS registration, configure missed-call-text-back or SMS follow-up messaging, and enable AI Voice capabilities to ensure you never miss a lead.
 
 * **Timeline:** Your AI Receptionist will be complete in 1 business day, or 3 business days for workflows with custom integrations.
 * **Requirement:** We require access to the backend of your website to install the chatbot and lead form.
 
-### 3. Onboarding and walkthrough call
+#### 3. Onboarding and walkthrough call
 
 This call will be used to walk you through the newly configured lead capture process. Our experts will show you where to find your leads, how to engage in conversations, and how to create additional tasks for your sales team.
 
 * **Timeline:** This call can be booked in as little as one business day after the AI Receptionist setup is complete.
 
-### 4. 30-day check-in call
+#### 4. 30-day check-in call
 
 This call is scheduled to review your conversations, determine what knowledge or custom instructions need to be updated or refined, and ensure your AI Receptionist is communicating effectively. Before this call, our team will review 5-10 conversations to provide recommendations for improvement.
 
 * **Timeline:** This call will be booked 3-4 weeks after the completion of your AI Receptionist setup.
+
+<OptimizationPlanSection />
 
 ## Frequently asked questions (FAQs)
 

--- a/docusaurus/docs/vendasta-services/ai-workforce/ai-reputation-specialist.md
+++ b/docusaurus/docs/vendasta-services/ai-workforce/ai-reputation-specialist.md
@@ -13,7 +13,6 @@ Want to hand this to a client? The **grey-labeled guide** has the same informati
 <a className="button button--primary" href="https://servicesdocs.io/ai-workforce/ai-reputation-specialist" target="_blank" rel="noopener noreferrer">Open the client-facing AI Reputation Specialist guide →</a>
 :::
 
-
 :::info Requirements
 **Reputation AI Premium** must be active on your account to receive this service.
 :::
@@ -24,14 +23,14 @@ The AI Reputation Specialist Setup is a done-for-you service where our experts c
 
 Choose one or the other:
 
-- **[AI Employee Setup](https://partners.vendasta.com/marketplace/products/MP-K48XKQV7DXLGQZ67ZH4MNZDM2FQCK8LM)**: a **one-time fee**. Our experts configure, train, and launch your AI Reputation Specialist (everything in "What's included with setup" below).
+- **[AI Employee Setup](https://partners.vendasta.com/marketplace/products/MP-K48XKQV7DXLGQZ67ZH4MNZDM2FQCK8LM)**: a **one-time fee**. Our experts configure, train, and launch your AI Reputation Specialist (everything in "What's included" below).
 - **[AI Workforce Optimization Plan](https://partners.vendasta.com/marketplace/products/MP-JHLVQX6W4MJFZ8V3V68CWMQ43X6N46TW)**: an **ongoing monthly fee** that **includes the same setup** plus continued optimization (monthly check-ins, unlimited change requests, and a live training session).
 
 :::
 
-## What's included with setup
+## Setup
 
-### 1. One-time setup
+### What's included
 
 * Onboarding and training call
 * Configure & train the AI Reputation Specialist
@@ -40,27 +39,17 @@ Choose one or the other:
 * Install review display widgets
 * Align brand voice, templates, and messaging
 
-### 2. Monthly service
-
-* Adjustments to prompts, automations, and any AI employee feature updates
-* Responding to platforms outside of Google & Facebook*
-* Negative review approval workflow
-
-**Please note:** For reviews outside of Google and Facebook, you may select up to five external platforms for us to support on your behalf, such as Yelp, YellowPages, Better Business Bureau, TripAdvisor, OpenTable, CarGuru, DealerRater, Expedia, CarFax, Zillow, and more. At this time, we're unable to respond to reviews on Indeed or Glassdoor.
-
-<OptimizationPlanSection />
-
-## The setup process
+### The setup process
 
 The process involves a series of calls and configuration steps to get your AI Reputation Specialist running effectively.
 
-### 1. Fulfillment form
+#### 1. Fulfillment form
 
 To ensure a smooth and efficient process, please fill out the fulfillment form with as much detail as possible. This will help streamline the entire experience.
 
 * **Timeline:** We'll review the order and start the process within 2 business days.
 
-### 2. Onboarding & training call
+#### 2. Onboarding & training call
 
 Our team of experts will lead an onboarding call to understand your business needs and how to adjust our reputation workflows to suit you. We will come to the call with your initial Reputation Specialist setup with your branding and customized review response style to adjust during the call. We will refine any additional knowledge sources and/or review response instructions together.
 
@@ -69,14 +58,14 @@ We will also train and walk you through the new workflow. Our team of experts wi
 * **Timeline:** An onboarding call can be booked in as little as 1 business day, depending on availability.
 * **For U.S. Businesses:** A2P registration is required to validate the business' use of SMS. Please be ready with your business legal information if you'd like to use SMS. Registration for A2P can take up to two weeks to complete.
 
-### 3. AI Reputation Specialist setup
+#### 3. AI Reputation Specialist setup
 
 Using the refinements during the onboarding call, we will finish setting up your AI Reputation Specialist and automations for requesting reviews. We will create a Net Promoter Score (NPS) workflow if desired and we can install a review display widget on your website.
 
 * **Timeline:** Your AI Reputation Specialist will be complete in 1 business day after the call.
 * **Requirement:** We require access to the backend of your website in order to install the review widget if desired.
 
-### 4. 30-day check-in call
+#### 4. 30-day check-in call
 
 This call will be used to look at the review responses generated, determine what knowledge or custom instructions need to be updated or refined, and ensure that your AI Reputation Specialist is responding effectively.
 
@@ -84,25 +73,7 @@ This call will be used to look at the review responses generated, determine what
 
 * **Timeline:** This call is optional and can be booked 3-4 weeks after the completion of your AI Reputation Specialist Setup.
 
-### 5. Monthly support
-
-With monthly support, we make ongoing refinements to your AI Reputation Specialist as your business evolves. This includes updates to prompts, branding, automations, templates, integrations, and review management beyond Google and Facebook, with an optional approval workflow for negative reviews.
-
-For reviews outside of Google and Facebook, you may select up to five external platforms below for us to support on your behalf. 
-
-* Yelp
-* YellowPages
-* Better Business Bureau
-* TripAdvisor
-* OpenTable
-* CarGuru
-* DealerRater
-* Expedia
-* CarFax
-* Zillow
-* and more. 
-
-**Please note:** At this time, we're unable to respond to reviews on Indeed or Glassdoor.
+<OptimizationPlanSection />
 
 ## Frequently asked questions (FAQs)
 
@@ -126,7 +97,7 @@ This service is ideal for local businesses (and agencies serving local businesse
 
 <summary> What languages does the AI Reputation Specialist respond in?</summary>
 
-Any language that the review is left in, the AI employee will respond in the proper corresponding language. For all reviews outside of Google & Facebook, our team can only respond in English.
+Any language that the review is left in, the AI employee will respond in the proper corresponding language.
 
 </details>
 
@@ -182,7 +153,7 @@ After ordering, you'll complete a fulfillment form and then book an onboarding c
 
 <summary> Which review platforms does the AI employee respond to automatically?</summary>
 
-The AI Reputation Specialist can automatically respond to Google and Facebook reviews using your branded tone and custom instructions. Outside of these platforms, you may choose up to five external sources and our team will respond on your behalf.
+The AI Reputation Specialist can automatically respond to Google and Facebook reviews using your branded tone and custom instructions.
 
 </details>
 
@@ -206,7 +177,7 @@ Yes. The service includes automated review request workflows via email and SMS, 
 
 <summary> Can I change how the AI responds to reviews later?</summary>
 
-Yes. You or our team can update instructions, tone, and templates at any time. Our support also includes prompt refinements and ongoing adjustments as needed.
+Yes. You can update instructions, tone, and templates at any time. If you have the AI Workforce Optimization Plan active, our team can make these changes on your behalf.
 
 </details>
 
@@ -228,9 +199,9 @@ Yes. Email is available for all businesses, and SMS is available for Canadian an
 
 <details>
 
-<summary> What kind of support is included after setup?</summary>
+<summary> What kind of optimization is included after setup?</summary>
 
-Monthly support includes adjustments to prompts, workflow refinements and new feature additions, as well as ongoing management of reviews outside Google and Facebook. These updates are intended to refine and improve what's already been set up, focusing on adjustments and enhancements to existing prompts, automations, and templates rather than the creation of entirely new systems.
+If you have the AI Workforce Optimization Plan active, it includes adjustments to prompts, workflow refinements, and configuring new feature additions. These updates are intended to refine and improve what has already been set up, focusing on adjustments and enhancements to existing prompts, automations, and templates.
 
 </details>
 

--- a/docusaurus/docs/vendasta-services/ai-workforce/ai-reputation-specialist.md
+++ b/docusaurus/docs/vendasta-services/ai-workforce/ai-reputation-specialist.md
@@ -24,8 +24,8 @@ The AI Reputation Specialist Setup is a done-for-you service where our experts c
 
 Choose one or the other:
 
-- **Setup**: a **one-time fee**. Our experts configure, train, and launch your AI Reputation Specialist (everything in "What's included with setup" below).
-- **AI Workforce Optimization Plan**: an **ongoing monthly fee** that **includes the same setup** plus continued optimization (monthly check-ins, unlimited change requests, and a live training session).
+- **[AI Employee Setup](https://partners.vendasta.com/marketplace/products/MP-K48XKQV7DXLGQZ67ZH4MNZDM2FQCK8LM)**: a **one-time fee**. Our experts configure, train, and launch your AI Reputation Specialist (everything in "What's included with setup" below).
+- **[AI Workforce Optimization Plan](https://partners.vendasta.com/marketplace/products/MP-JHLVQX6W4MJFZ8V3V68CWMQ43X6N46TW)**: an **ongoing monthly fee** that **includes the same setup** plus continued optimization (monthly check-ins, unlimited change requests, and a live training session).
 
 :::
 

--- a/docusaurus/docs/vendasta-services/ai-workforce/ai-social-media-manager.md
+++ b/docusaurus/docs/vendasta-services/ai-workforce/ai-social-media-manager.md
@@ -23,8 +23,8 @@ The AI Social Media Manager Setup is a done-with-you service where our experts c
 
 Choose one or the other:
 
-- **Setup**: a **one-time fee**. Our experts configure, train, and launch your AI Social Media Manager.
-- **AI Workforce Optimization Plan**: an **ongoing monthly fee** that **includes the same setup** plus continued optimization (monthly check-ins, unlimited change requests, and a live training session).
+- **[AI Employee Setup](https://partners.vendasta.com/marketplace/products/MP-K48XKQV7DXLGQZ67ZH4MNZDM2FQCK8LM)**: a **one-time fee**. Our experts configure, train, and launch your AI Social Media Manager.
+- **[AI Workforce Optimization Plan](https://partners.vendasta.com/marketplace/products/MP-JHLVQX6W4MJFZ8V3V68CWMQ43X6N46TW)**: an **ongoing monthly fee** that **includes the same setup** plus continued optimization (monthly check-ins, unlimited change requests, and a live training session).
 
 :::
 

--- a/docusaurus/docs/vendasta-services/ai-workforce/ai-support-agent.md
+++ b/docusaurus/docs/vendasta-services/ai-workforce/ai-support-agent.md
@@ -24,8 +24,8 @@ The AI Support Agent Setup is a done-for-you service where our experts configure
 
 Choose one or the other:
 
-- **Setup**: a **one-time fee**. Our experts configure, train, and launch your AI Support Agent (everything in "What's included with setup" below).
-- **AI Workforce Optimization Plan**: an **ongoing monthly fee** that **includes the same setup** plus continued optimization (monthly check-ins, unlimited change requests, and a live training session).
+- **[AI Employee Setup](https://partners.vendasta.com/marketplace/products/MP-K48XKQV7DXLGQZ67ZH4MNZDM2FQCK8LM)**: a **one-time fee**. Our experts configure, train, and launch your AI Support Agent (everything in "What's included with setup" below).
+- **[AI Workforce Optimization Plan](https://partners.vendasta.com/marketplace/products/MP-JHLVQX6W4MJFZ8V3V68CWMQ43X6N46TW)**: an **ongoing monthly fee** that **includes the same setup** plus continued optimization (monthly check-ins, unlimited change requests, and a live training session).
 
 :::
 

--- a/docusaurus/docs/vendasta-services/ai-workforce/ai-support-agent.md
+++ b/docusaurus/docs/vendasta-services/ai-workforce/ai-support-agent.md
@@ -24,18 +24,20 @@ The AI Support Agent Setup is a done-for-you service where our experts configure
 
 Choose one or the other:
 
-- **[AI Employee Setup](https://partners.vendasta.com/marketplace/products/MP-K48XKQV7DXLGQZ67ZH4MNZDM2FQCK8LM)**: a **one-time fee**. Our experts configure, train, and launch your AI Support Agent (everything in "What's included with setup" below).
+- **[AI Employee Setup](https://partners.vendasta.com/marketplace/products/MP-K48XKQV7DXLGQZ67ZH4MNZDM2FQCK8LM)**: a **one-time fee**. Our experts configure, train, and launch your AI Support Agent (everything in "What's included" below).
 - **[AI Workforce Optimization Plan](https://partners.vendasta.com/marketplace/products/MP-JHLVQX6W4MJFZ8V3V68CWMQ43X6N46TW)**: an **ongoing monthly fee** that **includes the same setup** plus continued optimization (monthly check-ins, unlimited change requests, and a live training session).
 
 :::
 
-## What's included with setup
+## Setup
 
-### 1. AI Employee profile
+### What's included
+
+#### 1. AI Employee profile
 
 We configure the AI Employee with a name and avatar that represents your business. Customers interact with a professional support persona rather than a generic bot. The profile is configured within the **AI Workforce** section of Business App.
 
-### 2. HEARD Support Framework
+#### 2. HEARD Support Framework
 
 We configure the HEARD framework, a structured support methodology that guides every conversation through five stages:
 
@@ -47,7 +49,7 @@ We configure the HEARD framework, a structured support methodology that guides e
 
 For simple questions, the AI answers immediately. For complaints or unresolved issues, it follows the full sequence.
 
-### 3. Escalation logic
+#### 3. Escalation logic
 
 We configure your escalation rules so the AI hands off to your team only when it genuinely can't help, not for every inquiry it receives. Escalation is triggered when the AI cannot find an answer in the knowledge base, or when the issue requires human judgment. At that point, the AI smoothly transitions the conversation and captures the customer's contact information.
 
@@ -55,7 +57,7 @@ We configure your escalation rules so the AI hands off to your team only when it
 The quality and completeness of your knowledge base directly affects how often escalations are triggered. A well-documented FAQ reduces unnecessary handoffs to your team.
 :::
 
-### 4. Channel setup
+#### 4. Channel setup
 
 We connect all channels requested during the onboarding call. Supported channels include:
 
@@ -72,7 +74,7 @@ Each channel routes conversations to your AI Support Agent automatically, so cus
 SMS for U.S. businesses requires A2P registration before it can be activated. See the [requirements](#requirements) below for details.
 :::
 
-### 5. Chat widget installation
+#### 5. Chat widget installation
 
 For web chat, we will install the chat widget directly on your website, typically in the global footer or homepage, so it is visible to customers across all pages. We will need login access to the place where you edit your website (for example, WordPress, Wix, Squarespace, or whichever platform you use to manage your site).
 
@@ -80,23 +82,21 @@ For web chat, we will install the chat widget directly on your website, typicall
 If you are unable to provide website access, we will provide the embed code and installation instructions for your team or web developer to install independently.
 :::
 
-### 6. Knowledge base setup
+#### 6. Knowledge base setup
 
 We connect your business profile, website, and any FAQs, policies, or help documentation to the AI's knowledge base. This allows the Support Agent to answer questions about your services, hours, policies, and more without fabricating information.
 
-<OptimizationPlanSection />
-
-## The setup process
+### The setup process
 
 The process involves a fulfillment form, a series of calls, and configuration steps to get your AI Support Agent running effectively.
 
-### 1. Fulfillment form
+#### 1. Fulfillment form
 
 To ensure a smooth and efficient setup, please fill out the fulfillment form with as much detail as possible, including your common customer inquiries, escalation preferences, and the channels you'd like to activate.
 
 * **Timeline:** We'll review the order and start the process within 2 business days.
 
-### 2. Onboarding call
+#### 2. Onboarding call
 
 Our team will lead a structured onboarding call to understand your support needs, common customer inquiries, and escalation preferences. We'll configure the HEARD Support Framework, a structured approach that guides your AI through direct answers for simple questions, empathetic resolution for complaints, and a smooth handoff to your team when human support is needed. We'll come to the call with an initial setup ready to demo and refine together.
 
@@ -107,19 +107,19 @@ Our team will lead a structured onboarding call to understand your support needs
 If you are unable to attend the onboarding call, our team will proceed with setup using the information provided in your fulfillment form and will follow up via email and phone to review and refine. If we are unable to reach you after our follow-up process, the project will be closed, but can be reopened at any time by reaching back out to us.
 :::
 
-### 3. Agent setup
+#### 3. Agent setup
 
 Using the information gathered during the onboarding call, we will configure your AI Support Agent with the HEARD support framework, set up escalation logic to smoothly transition complex or unresolved issues to your team, connect all requested channels (web chat, SMS, Facebook, Instagram, and more), and install the chat widget on your website.
 
 * **Timeline:** Your AI Support Agent will be complete in 1 business day, or 3 business days for setups with multiple channels or complex knowledge bases.
 
-### 4. Training call
+#### 4. Training call
 
 This call will walk you through your new AI Support Agent: how it handles simple questions, complaints, and escalations, where to find captured leads and conversation summaries, and how to manage and respond to conversations in Business App.
 
 * **Timeline:** This call can be booked in as little as 1 business day after Agent setup completion, depending on availability.
 
-### 5. 30-day check-in
+#### 5. 30-day check-in
 
 This call will be used to review real conversations, assess how the AI is handling inquiries, and refine the knowledge base, escalation triggers, and support prompts based on actual interactions.
 
@@ -128,6 +128,8 @@ Prior to this call, our team will review 5-10 conversations to identify improvem
 :::
 
 * **Timeline:** This call will be booked 3-4 weeks after the completion of your AI Support Agent setup.
+
+<OptimizationPlanSection />
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
Follow-up updates to the AI Workforce (AI employee) articles.

### SKU clarity
- Renamed "Setup" to **AI Employee Setup** in the "Two ways" callout on all 8 articles, and linked both SKUs (AI Employee Setup, AI Workforce Optimization Plan) to their Partner Center marketplace product pages.

### Setup structure
- Consolidated setup content so it is no longer split above and below the plan. Each article now has a single **`## Setup`** with **`### What's included`** at the top and **`### The setup process`** beneath it, followed by the AI Workforce Optimization Plan section.

### AI Reputation Specialist (per stakeholder doc)
- Removed the Monthly support section.
- Removed all "reviews outside Google & Facebook" content (What's included item, Monthly support list, and the related FAQ sentences).
- Reframed ongoing support around the AI Workforce Optimization Plan; trimmed/updated the affected FAQs.
- Renamed a FAQ to "What kind of optimization is included after setup?"

### Shared FAQ
- Dropped "plan" from the shared optimization FAQ: "How do I submit an optimization request?"

## Notes
- Verified locally: Docusaurus builds and all pages render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
