### PR TITLE
Align the grey-labeled docs button with the page title

### DIFF
--- a/docusaurus/docs/vendasta-services/index.mdx
+++ b/docusaurus/docs/vendasta-services/index.mdx
@@ -6,16 +6,19 @@ tags: [vendasta-services, fulfillment, services, onboarding]
 keywords: [Vendasta Services, fulfillment services, website services, social media, digital advertising, review management]
 ---
 
+<div className="vs-overview-header">
+
+# Vendasta Services overview
+
 <a
   className="greylabel-docs-button"
   href="https://servicesdocs.io/"
   target="_blank"
-  rel="noopener noreferrer"
-  style={{float: 'right', marginTop: '0.5rem', marginLeft: '1rem'}}>
+  rel="noopener noreferrer">
   Open the grey-labeled docs
 </a>
 
-# Vendasta Services overview
+</div>
 
 Vendasta Services provides access to a team of experts who handle fulfillment for websites, social media management, digital advertising, review management, and other professional services. By leveraging our team and proven processes, you can deliver high-quality results with industry-leading turnaround times without expanding your internal team.
 

--- a/docusaurus/src/css/custom.css
+++ b/docusaurus/src/css/custom.css
@@ -2221,7 +2221,7 @@ div[class*="language-"] pre {
   align-items: center;
   justify-content: center;
   text-align: center;
-  padding: 0.5rem 1.5rem;
+  padding: 0.55rem 1.5rem;
   font-size: 0.9rem;
   font-weight: 600;
   line-height: 1.2;
@@ -2230,6 +2230,27 @@ div[class*="language-"] pre {
   border-radius: 4px;
   text-decoration: none;
   transition: background 0.2s ease, box-shadow 0.15s ease, transform 0.15s ease;
+}
+/* MDX wraps the label in a <p>; strip its default margin so the text centers. */
+.greylabel-docs-button p {
+  margin: 0;
+}
+
+/* Header row on the Vendasta Services overview: title left, button vertically
+   centered on the right; button drops below the title on narrow screens. */
+.vs-overview-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+.vs-overview-header h1 {
+  margin: 0 !important;
+}
+.vs-overview-header .greylabel-docs-button {
+  flex-shrink: 0;
 }
 .greylabel-docs-button:hover {
   color: #fff !important;


### PR DESCRIPTION
Follow-up to the merged [grey-labeled docs links PR]. The "Open the grey-labeled docs" button on the Vendasta Services overview was top-aligned and sat too high next to the large page title.

### Changes
- Wrap the title and button in a flex header row (`align-items: center`, `justify-content: space-between`, `flex-wrap: wrap`), replacing the previous `float: right` + fixed margin. The button now stays vertically centered in line with the title at any width and drops below it on narrow screens.
- Zero the MDX-injected `<p>` margin inside the button (`.greylabel-docs-button p`) so the label is properly centered — that stray margin was inflating the button and pushing content up.

