### PR TITLE
docs(learn): fix unsupported or outdated marketing stats

### DIFF
--- a/docusaurus/training/products/attract/local-seo-listings/power-your-organic-search-visibility.mdx
+++ b/docusaurus/training/products/attract/local-seo-listings/power-your-organic-search-visibility.mdx
@@ -107,7 +107,7 @@ A slow-loading webpage is synonymous with a high bounce rate. The longer it take
 
 <div className="principle-area"><span className="principle-area__icon">⭐</span>Review Requests & Reputation Management</div>
 
-**74% of consumers** state that positive reviews build trust with local businesses. Positive online reviews show Google that your site is trustworthy.
+**85% of consumers**, according to [BrightLocal](https://www.brightlocal.com/research/local-consumer-review-survey/), say positive reviews make them more likely to use a business. Positive online reviews show Google that your site is trustworthy.
 
 ### 3 tactics to boost reviews
 

--- a/docusaurus/training/products/attract/local-seo-listings/search-engine-marketing.mdx
+++ b/docusaurus/training/products/attract/local-seo-listings/search-engine-marketing.mdx
@@ -46,7 +46,7 @@ SEM is the most effective way for an online business to be found by prospective 
 People often talk about SEO and PPC separately when truthfully the two go hand in hand. Both strategies target the same goal, and utilization of the two in an integrated way builds authority and drives quicker results simultaneously.
 
 :::tip Did you know?
-According to Backlinko, less than one percent of Google searchers click on the second page of search results.
+According to [Backlinko](https://backlinko.com/google-ctr-stats), less than one percent of Google searchers click on the second page of search results.
 :::
 
 ### The gap
@@ -66,10 +66,7 @@ There is a gap either at the beginning (waiting for SEO traction) or the end (lo
 
 <div className="principle-area"><span className="principle-area__icon">📍</span>Introduction to Local SEO</div>
 
-Local search engine optimization is a branch of SEO that focuses on optimizing a business and its website to be found in local search results. Local SEO aims to increase the search visibility of a brick-and-mortar storefront or services business within a local community. It is of particular importance to smaller businesses that look to do business with customers in specific geographic regions.
-
-- **46% of all Google searches** have local intent
-- Consumers want to find local businesses quickly and easily
+Local search engine optimization is a branch of SEO that focuses on optimizing a business and its website to be found in local search results. Local SEO aims to increase the search visibility of a brick-and-mortar storefront or services business within a local community. It is of particular importance to smaller businesses that look to do business with customers in specific geographic regions, where consumers want to find local businesses quickly and easily.
 
 ### Why Local SEO matters
 
@@ -117,7 +114,7 @@ Set up dashboards in Google Analytics to measure the impact of work from an SEO 
 
 <FlipCardGrid>
   <FlipCard front="SEM" back="SEO + PPC. Both under one umbrella." subtext="Strategy" />
-  <FlipCard front="Local SEO" back="46% local intent. GBP. 3-Pack." subtext="Focus" />
+  <FlipCard front="Local SEO" back="Local intent. GBP. 3-Pack." subtext="Focus" />
   <FlipCard front="SEO Culture" back="Collaboration. Ownership. All channels." subtext="Mindset" />
 </FlipCardGrid>
 

--- a/docusaurus/training/products/attract/local-seo-listings/why-local-businesses-need-seo.mdx
+++ b/docusaurus/training/products/attract/local-seo-listings/why-local-businesses-need-seo.mdx
@@ -81,9 +81,7 @@ Organic searches and local listings make up the majority of clicks on Google. SE
 
 ### Inbound vs outbound marketing & SEO
 
-- **59% of marketers** say inbound practices provided the highest quality leads (HubSpot State of Inbound)
-- **SEO leads convert at 14.6%** vs outbound at 1.7%
-- SEO targets traffic with intent to buy. We interpret "searcher intent" to identify people ready to make a purchase rather than those just looking for information
+SEO is inbound marketing: it targets traffic with intent to buy rather than interrupting people who aren't looking for you. We interpret "searcher intent" to identify people ready to make a purchase rather than those just looking for information.
 
 ---
 
@@ -160,7 +158,7 @@ OSRs ensure target keywords are prominently featured in key sections throughout 
     { type: "mcq", question: "What are the two major factors Google looks at when deciding the best answer?", options: ["Speed and Design", "Relevance and Trust", "Price and Reviews", "Social and Ads"], correctIndex: 1, explanation: "Relevance = Onsite. Trust = Offsite." },
     { type: "truefalse", statement: "Relevance has everything to do with your customer's website—code and content.", correct: true, explanation: "When Google crawls a website, they see both the code and the content." },
     { type: "mcq", question: "What is Trust measured by in SEO?", options: ["Website speed", "Number of other websites that link back to your customer's website", "Number of pages on the site", "Social media followers"], correctIndex: 1, explanation: "Trust is measured by the number of OTHER websites that talk about or link back to your customer's website." },
-    { type: "mcq", question: "How does this course compare SEO leads versus outbound leads on conversion?", options: ["Outbound leads typically convert faster than SEO leads", "SEO leads convert at a much higher rate than outbound leads in the cited comparison", "Conversion rates are identical for both sources", "SEO leads only convert for national brands, not SMBs"], correctIndex: 1, explanation: "The course cites SEO leads converting at 14.6% versus outbound at 1.7%—positioning SEO leads as stronger converters." },
+    { type: "mcq", question: "Why does the course describe SEO as inbound marketing?", options: ["It interrupts people with ads regardless of what they're searching for", "It targets traffic that already has intent to buy, rather than reaching people who aren't looking for you", "It only works for businesses with a national audience", "It replaces the need to understand searcher intent"], correctIndex: 1, explanation: "SEO targets traffic with intent to buy—searcher intent identifies people ready to purchase rather than just browsing." },
     { type: "mcq", question: "What are the two qualifications for a good SEO candidate?", options: ["They have a budget and want ads", "They have a website and they're not on the first page of Google", "They have social media and a blog", "They have 100+ reviews"], correctIndex: 1, explanation: "They have a website. They're not on the first page of Google. It's as simple as that." }
   ]}
 />

--- a/docusaurus/training/products/convert/snapshot-executive-reports/snapshot-section-breakdown.mdx
+++ b/docusaurus/training/products/convert/snapshot-executive-reports/snapshot-section-breakdown.mdx
@@ -90,7 +90,7 @@ Do your customers trust you? Review highlights include: number of reviews found,
 | Scenario | Solution |
 |----------|----------|
 | No reviews | Introduce **Customer Voice**—ask customers for positive reviews |
-| Negative score (&lt; 4/5) | **Reputation Management**—studies show 3.5 → 4 score can increase revenue 15% |
+| Negative score (&lt; 4/5) | **Reputation Management**—a [Harvard Business School study](https://www.hbs.edu/ris/Publication%20Files/12-016_a7e4a5a2-03f9-490d-b093-8f951238dba2.pdf) found a one-star rating increase can lift revenue 5-9% for independent restaurants |
 | High score across the board | **Reputation Management**—manage review sources, one dashboard, track sentiment |
 
 ---
@@ -101,7 +101,7 @@ Can your customers find you? If a consumer cannot find what they're looking for 
 
 ### Mobile-friendly website
 
-Over 70% of website traffic flows through mobile devices. Our software uses Google's algorithm: **RED** (fix immediately), **YELLOW** (consider fixing), **GREEN** (passed).
+Mobile devices account for just over half of website traffic worldwide, according to [Statcounter](https://gs.statcounter.com/platform-market-share/desktop-mobile-tablet). Our software uses Google's algorithm: **RED** (fix immediately), **YELLOW** (consider fixing), **GREEN** (passed).
 
 ### Desktop website
 
@@ -171,7 +171,7 @@ Anytime you can drive home the value of your FULL solution set, you should. A pa
     { type: "mcq", question: "How long can you make LIVE updates to a Snapshot Report without additional fees?", options: ["Up to 3 days from creation", "Up to 7 days while the report is LIVE", "Up to 14 days with a paid add-on", "Up to 30 days for enterprise tiers"], correctIndex: 1, explanation: "The **Listings** tip states you can make LIVE updates for up to 7 days without extra fees." },
     { type: "truefalse", statement: "The SEO section is based on organic search, not paid ads.", correct: true, explanation: "**SEO** contrasts with **Advertising**: SEO grades organic results (top 50), while Advertising pulls paid campaign data." },
     { type: "whicharea", principle: "Where would you learn about Listing Distribution and the four data aggregators?", correctArea: "📍 Listings", explanation: "**Introduce: Listing Distribution** in **Listings** explains submitting to four data aggregators and 300+ sources." },
-    { type: "fillblank", principle: "Studies show taking a business from 3.5 to 4 review score can increase revenue by ___.", before: "", answer: "15%", after: "", hint: "Percentage.", explanation: "**Reviews** cites that moving from 3.5 to 4 can lift revenue about 15% when paired with Reputation Management." },
+    { type: "fillblank", principle: "A Harvard Business School study found a one-star Yelp rating increase can lift revenue for independent restaurants by ___.", before: "", answer: "5-9%", after: "", hint: "A range in percent, e.g. 5-9%.", explanation: "**Reviews** cites the Harvard Business School Yelp study: a one-star rating increase lifts revenue 5-9% for independent restaurants." },
     { type: "match", instruction: "Match each section to a key question or focus.", pairs: [{ term: "Listings", definition: "Can customers find you? Presence and accuracy" }, { term: "Reviews", definition: "Do your customers trust you?" }, { term: "Social", definition: "Do your customers like you?" }, { term: "Website", definition: "Can your customers find you? Speed and content" }], explanation: "Each **principle-area** opens with the guiding question used to frame the conversation (find, trust, like, findability)." },
     { type: "sort", instruction: "Sort these into SEO (organic) vs Advertising (paid) focus.", items: [{ label: "Top 50 search results", correctBucket: "seo" }, { label: "Cost-per-click", correctBucket: "advertising" }, { label: "Google Display Network", correctBucket: "advertising" }, { label: "Keyword rank vs competitors", correctBucket: "seo" }], buckets: [{ id: "seo", label: "SEO (Organic)" }, { id: "advertising", label: "Advertising (Paid)" }], explanation: "**SEO** is organic rankings; **Advertising** highlights SEM/Display metrics like CPC and network presence." }
   ]}


### PR DESCRIPTION
## Summary

Fact-checks and corrects several marketing statistics used in the Attract and Convert learning paths that were either uncredited, outdated, or unverifiable.

**Corrected with a current, cited source:**
- "Less than 1% of Google searchers click page 2" (Backlinko) — added a link to the live study (still accurate, was previously uncited)
- "74% of consumers say positive reviews build trust" — updated to BrightLocal's current headline stat: 85% say positive reviews make them more likely to use a business, with a source link
- "3.5→4 review score can increase revenue 15%" — this framing doesn't appear in the actual HBS/Michael Luca Yelp study. Replaced with the real finding (a one-star rating increase lifts revenue 5-9% for independent restaurants), cited to the HBS paper. Updated the matching knowledge-check question to match.
- "Over 70% of website traffic is mobile" — replaced with the current global split (~51.5% mobile) per Statcounter, with a source link

**Retired (no credible source or replacement exists):**
- "59% of marketers say inbound provides highest quality leads" (HubSpot State of Inbound — the report was discontinued and State of Marketing has no equivalent question)
- "SEO leads convert at 14.6% vs 1.7% outbound" (uncredited, unsourced blog stat)
- "46% of all Google searches have local intent" (traces to a 2018 tweet, never an official figure)

For each retirement, the surrounding prose, flip card, or knowledge-check question was rewritten so the content still reads naturally without the removed stat.

## Test plan
- [ ] `npm run build` in `docusaurus/` to confirm no broken links/build errors
- [ ] Spot-check the four changed pages render correctly, including the updated knowledge-check questions