### PR TITLE
docs(crm): add WhatsApp and Email to CRM record sources list

### DIFF
--- a/docusaurus/docs/crm/index.mdx
+++ b/docusaurus/docs/crm/index.mdx
@@ -166,8 +166,10 @@ You can view a record's source to understand how it was created or see its prope
 - **`Facebook Messenger`:** Created from conversations initiated through `Facebook Messenger`.
 - **`Google Business Messages`:** Created from conversations on `Google Business Messages`.
 - **`Instagram Messaging`:** Created from `Instagram` direct messaging.
+- **`WhatsApp`:** Created from conversations initiated through `WhatsApp`, or when contacts are synced from a connected `WhatsApp` contact book.
 - **`Inbox`:** Manually created in Vendasta `Inbox`.
 - **`SMS`:** Records of conversations initiated through inbound SMS.
+- **`Email`:** Created from inbound email conversations received in `Inbox`.
 - **`GingrApp`:** Created through the `Gingr` integration.
 - **`Jobber`:** Created through the `Jobber` integration.
 - **`HubSpot`:** Created or updated through the `HubSpot` integration via two-way sync of Contact and Company records.


### PR DESCRIPTION
## Problem
The CRM overview's "Record sources" list on docs.vendasta.com is missing two sources the platform stamps on contact records: WhatsApp and Email. WhatsApp contacts created from inbound conversations have always been stamped with the "WhatsApp" record source, and vendasta/conversation#2643 recently extended that stamping to contacts created by the initial WhatsApp contact-book sync when a connection is first set up — but the source value was never documented. The missing Email source was noticed while making this update.

## Solution
Add `WhatsApp` and `Email` entries to the Record sources list in `docs/crm/index.mdx`, matching the wording style of the existing channel entries.

Note for docs owners: two more source values exist in the CRM localization map but are not in the documented list — `AI Voice Receptionist` (stamped in the conversation service) and `Coupon Form` (stamping service not verified). Left out of this PR pending verification; may be worth adding.

## Todos
- [x] Verify stamped source values against code and prod data
- [x] `npm run build` passes in `docusaurus/` (verified locally; pre-existing broken-link warnings on unrelated pages only)

[CRMAAS-3055]

@vendasta/documentation-pr-reviewers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CRMAAS-3055]: https://vendasta.jira.com/browse/CRMAAS-3055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

