### PR TITLE
docs: verify and fix flagged review-due article (July 10)

### DIFF
--- a/docusaurus/docs/accounts/reports/executive-report-advertising.mdx
+++ b/docusaurus/docs/accounts/reports/executive-report-advertising.mdx
@@ -31,7 +31,7 @@ You and your clients can see what's happening across all your digital marketing 
 ### Connecting ad accounts
 1. With Advertising Intelligence activated, connect your Facebook Ads and/or Google Ads accounts to the product
 2. Go to the Executive Report in Business App and select a time period
-3. Under the "Advertising" section, you'll see subsections for "Facebook Ads" and "Google Ads" (depending on which accounts are connected)
+3. Under the `Advertising` section, you'll see subsections for `Facebook Ads` and `Google Ads` (depending on which accounts are connected)
 
 ### Viewing performance data
 In the Executive Report, you can view the summary of both your Facebook Ads and Google Ads campaigns in a unified advertising section. This provides a comprehensive view of your advertising performance across platforms.
@@ -44,7 +44,7 @@ Updated advertising data in the Executive Report is populated every Sunday, star
 
 ## Supported advertising platforms
 
-The Executive Report currently supports advertising data from:
+The Executive Report supports advertising data from:
 - **Google Ads** (via Advertising Intelligence)
 - **Facebook Ads** (via Advertising Intelligence)
 

--- a/docusaurus/docs/accounts/reports/executive-report-advertising.mdx
+++ b/docusaurus/docs/accounts/reports/executive-report-advertising.mdx
@@ -49,3 +49,7 @@ The Executive Report supports advertising data from:
 - **Facebook Ads** (via Advertising Intelligence)
 
 Both platforms provide the same core metrics (ROI, spend, impressions, clicks, conversions) and comparison data to help you demonstrate advertising value to your clients.
+
+:::note
+Advertising Intelligence can also connect Microsoft Ads accounts, but Microsoft Ads data does not appear in this Executive Report section. View Microsoft Ads performance directly in Advertising Intelligence instead.
+:::

--- a/docusaurus/docs/business-app/demoing-business-app-to-clients.mdx
+++ b/docusaurus/docs/business-app/demoing-business-app-to-clients.mdx
@@ -152,7 +152,7 @@ Reputation AI pulls reviews from multiple sources into one dashboard and lets cl
 
 **What to show them:**
 
-Advertising Intelligence connects to the client's existing ad accounts (Google Ads, Microsoft Ads) and displays performance reporting in one dashboard.
+Advertising Intelligence connects to the client's existing ad accounts (Google Ads, Facebook Ads, Microsoft Ads) and displays performance reporting in one dashboard.
 
 **How to demo it:**
 
@@ -163,7 +163,7 @@ Advertising Intelligence connects to the client's existing ad accounts (Google A
 
 **What to say to your client:**
 
-> "This dashboard pulls performance data from your ad accounts. If you're running Google Ads or Microsoft Ads, we can connect those accounts here so you can see how your campaigns are performing. This doesn't create or manage ads—it just gives you clean reporting in one place."
+> "This dashboard pulls performance data from your ad accounts. If you're running Google Ads, Facebook Ads, or Microsoft Ads, we can connect those accounts here so you can see how your campaigns are performing. This doesn't create or manage ads—it just gives you clean reporting in one place."
 
 **Success check:**
 - Client understands this is a reporting tool, not an ad manager
@@ -249,7 +249,7 @@ Google and Facebook reviews can be responded to directly from the dashboard. Rev
 <details>
 <summary>Does Advertising Intelligence run ads?</summary>
 
-No. Advertising Intelligence is a reporting dashboard. It connects to existing ad accounts (Google Ads, Microsoft Ads) and displays performance metrics in one place. It does not create or manage ad campaigns.
+No. Advertising Intelligence is a reporting dashboard. It connects to existing ad accounts (Google Ads, Facebook Ads, Microsoft Ads) and displays performance metrics in one place. It does not create or manage ad campaigns.
 </details>
 
 <details>


### PR DESCRIPTION
## Summary
- Verified `executive-report-advertising.mdx`, flagged by the review-due bot (149 days untouched)
- Converted quoted UI section labels to inline code and removed an implied-recency "currently" phrase for evergreen compliance
- Resolved an SME question left on this issue by a prior verification pass: `executive-report-advertising.mdx` and `business-app/demoing-business-app-to-clients.mdx` disagreed on which ad platforms Advertising Intelligence supports (Google+Facebook vs. Google+Microsoft). Confirmed with SME: Advertising Intelligence supports all three (Google Ads, Facebook Ads, Microsoft Ads), but the Executive Report's Advertising section only surfaces Google Ads and Facebook Ads data. Updated `demoing-business-app-to-clients.mdx` (which was missing Facebook Ads) and added a clarifying note to `executive-report-advertising.mdx` about the scope distinction
- Verification reports and the SME resolution were posted as comments on the linked issue; the `question` label has been removed

## Test plan
- [ ] Confirm the weekly Sunday advertising data-update cadence is still accurate
- [ ] Confirm Microsoft Ads data is indeed absent from the Executive Report's Advertising section (not just undocumented)
- [ ] `npm run build` passes in `docusaurus/`

Closes #723

🤖 Generated with [Claude Code](https://claude.com/claude-code)