### PR TITLE
docs: refresh outdated stats and blog specs in training content

### DIFF
--- a/docusaurus/training/products/attract/local-seo-listings/introduction-to-seo.mdx
+++ b/docusaurus/training/products/attract/local-seo-listings/introduction-to-seo.mdx
@@ -40,8 +40,8 @@ SEO is about understanding what people are searching for online, the answers the
 
 ### The numbers
 
-- **81% of consumers** search online before buying
-- **84% of clicks** are organic rather than paid ads
+- **97% of consumers** read online reviews before choosing a local business, checking an average of 6 review sites before deciding (BrightLocal, 2026 Local Consumer Review Survey)
+- Organic still wins the click, for now. Across major search categories, organic results capture **66–84% of clicks** depending on industry, but that share has fallen 11–23 percentage points year-over-year as paid ad placements expand (Similarweb data, via Search Engine Land, Jan 2026)
 
 Prospective buyers search online for helpful product information, price comparisons, and trustworthy reviews. Searchers often skip advertisements and click on organic search results to find what they're looking for. These are the **trusted** positions brands want to be in.
 
@@ -121,7 +121,7 @@ SEO Network provides you and your clients with a dashboard where everything is c
   <span className="in-practice__icon">💬</span>
   <div className="in-practice__body">
     <span className="in-practice__label">In Practice</span>
-    <p>A client's website isn't getting traffic. You explain that 84% of clicks are organic—they need to rank. You recommend Boostability for full-service optimization (keywords, links, content, profiles) or SEO Network for a transparent dashboard showing every link and ranking. You use the terminology: onsite optimization for their content, offsite for backlinks. They understand the value and sign up.</p>
+    <p>A client's website isn't getting traffic. You explain that organic results still capture the majority of clicks in most categories, but paid ads are eating into that share fast, so ranking well matters more than ever. You recommend Boostability for full-service optimization (keywords, links, content, profiles) or SEO Network for a transparent dashboard showing every link and ranking. You use the terminology: onsite optimization for their content, offsite for backlinks. They understand the value and sign up.</p>
   </div>
 </div>
 
@@ -132,7 +132,7 @@ SEO Network provides you and your clients with a dashboard where everything is c
 ## Key Resources
 
 <FlipCardGrid>
-  <FlipCard front="81% / 84%" back="Search before buying. Organic over paid." subtext="Stats" />
+  <FlipCard front="97% / 66–84%" back="Reviews drive decisions. Organic still leads, but the gap is closing." subtext="Stats" />
   <FlipCard front="Alpha SEO" back="Integrated analysis and optimization." subtext="Marketplace" />
   <FlipCard front="Boostability" back="Full-service. 4–6 specialists. Reporting." subtext="Marketplace" />
   <FlipCard front="SEO Network" back="Dashboard. Links + content + rankings." subtext="Marketplace" />

--- a/docusaurus/training/products/attract/local-seo-listings/search-engine-marketing.mdx
+++ b/docusaurus/training/products/attract/local-seo-listings/search-engine-marketing.mdx
@@ -73,7 +73,7 @@ Local search engine optimization is a branch of SEO that focuses on optimizing a
 1. **Local SEO helps local businesses climb higher** in the ranking of local search results. For example, the Google 3-Pack displays the top three results of a local SERP using the searcher's location.
 2. **Local SEO, as it pertains to Google Business Profile (GBP), is the only way to be found** when someone searches on Google Maps. The business location needs to be added through GBP.
 
-**68% of all online experiences** begin with a query through a search engine, and SEO alone drives 1,000% more traffic than just using organic social media.
+Organic search drives roughly **10x more site traffic than organic social media** (~53% of traffic vs. ~5%, per a 2025 SE Ranking study)—a gap search-first businesses can't afford to ignore.
 
 ### How Local SEO benefits a business
 

--- a/docusaurus/training/products/engage/websites/get-your-clients-selling-online.mdx
+++ b/docusaurus/training/products/engage/websites/get-your-clients-selling-online.mdx
@@ -124,7 +124,7 @@ Ecommerce is a type of transaction—an exchange of goods and services—that oc
 
 **A monumental jump**
 
-In just six short weeks, ecommerce grew by 11%—effectively equalling a decade's worth of growth. This proves that the time to provide scalable ecommerce solutions for your clients is now. You can start by offering them WordPress Hosting Standard or the Accelerated Templated Website Plus tier.
+US ecommerce sales grew 9.8% year-over-year in Q1 2026 and 12.2% year-over-year in May 2026 (U.S. Census Bureau)—consistent, compounding growth quarter after quarter. This proves that the time to provide scalable ecommerce solutions for your clients is now. You can start by offering them WordPress Hosting Standard or the Accelerated Templated Website Plus tier.
 
 **Set up your WooCommerce store**
 

--- a/docusaurus/training/vendasta-services/grow-your-agency-with-marketing-experts.mdx
+++ b/docusaurus/training/vendasta-services/grow-your-agency-with-marketing-experts.mdx
@@ -115,7 +115,7 @@ Our dedicated team writes blogs and website copy. Give us a topic and instructio
 
 ### Services
 
-- **Blog Posts:** 500 words, relevant stock image, hyperlinks to external non-competitor sources. SEO-optimized. SEO-Enhanced add-on available.
+- **Blog Posts:** 1,500 words, two relevant stock images, hyperlinks to external non-competitor sources. SEO is built in—no separate add-on required.
 - **Website Copy:** Content Call included. We create copy for new sites or rebrands. With Website Support, we post to the site; otherwise we deliver via Word document.
 
 ### Benefits
@@ -209,7 +209,7 @@ WordPress Hosting for WordPress sites. Task Manager for any service. Turnaround:
   <FlipCard front="Listings" back="Listing Builder + Task Manager. GBP. Apple. Bing." subtext="Required" />
   <FlipCard front="Social" back="Task Manager + Social Marketing. 1x Week. Page Build." subtext="Required" />
   <FlipCard front="Reviews" back="Reputation + Customer Voice. Up to 10 or Unlimited." subtext="Required" />
-  <FlipCard front="Content" back="Task Manager. 500 words. 5 business days." subtext="Required" />
+  <FlipCard front="Content" back="Task Manager. 1,500 words. 5 business days." subtext="Required" />
   <FlipCard front="Ads" back="Task Manager only. 3+ months recommended." subtext="Required" />
   <FlipCard front="Web" back="WordPress Hosting + Task Manager. 5–10 days." subtext="Required" />
 </FlipCardGrid>
@@ -224,7 +224,7 @@ WordPress Hosting for WordPress sites. Task Manager for any service. Turnaround:
     { type: "mcq", question: "In order to use our Listing Claim service, you need these products:", options: ["Listing Distribution and Reputation Management", "Listing Builder and Task Manager", "Listing Sync Pro and Social Marketing", "Task Manager only"], correctIndex: 1, explanation: "Listings Management requires Listing Builder and Task Manager for any listing service; Google Business Profile Posts also requires Social Marketing." },
     { type: "mcq", question: "We currently don't publish posts on this platform:", options: ["Facebook", "Instagram", "LinkedIn", "Tumblr"], correctIndex: 3, explanation: "Social Media Content lists Facebook, Instagram, LinkedIn, X, Google Business Profile, and Pinterest—not Tumblr." },
     { type: "mcq", question: "Review Responses: What should happen when a positive review comes in?", options: ["Defer it until month-end reporting", "Respond to it immediately", "Publish a draft and wait for SMB approval first"], correctIndex: 1, explanation: "Reviews Management says positive reviews get immediate responses; negative ones go out for approval." },
-    { type: "mcq", question: "How long are the blogs Vendasta's Marketing Services team writes?", options: ["Up to 250 words", "Up to 500 words", "Up to 750 words", "Up to 1000 words"], correctIndex: 1, explanation: "Content specifies 500-word blogs plus stock imagery and external hyperlinks." },
+    { type: "mcq", question: "How long are the blogs Vendasta's Marketing Services team writes?", options: ["Up to 500 words", "Up to 1,000 words", "Up to 1,500 words", "Up to 2,000 words"], correctIndex: 2, explanation: "Content specifies 1,500-word blogs plus two stock images, built-in SEO, and external hyperlinks." },
     { type: "mcq", question: "Which of these services are offered by the Digital Ads team?", options: ["Facebook Bot", "E-commerce", "Google & Bing Ads, Facebook & Instagram Ads, and Landing Page", "Only Google Ads"], correctIndex: 2, explanation: "Digital Advertising lists Search, Social, Display, Dynamic Facebook Auto, YouTube, plus call tracking, landing pages, and banners." },
     { type: "mcq", question: "Our Marketing Services team can build websites on which platform?", options: ["Wix", "Duda", "WordPress", "Drupal"], correctIndex: 2, explanation: "Web Design focuses on WordPress builds—called out as the most popular CMS for these projects." },
     { type: "mcq", question: "What's the average turnaround time for a website build?", options: ["18 production days", "15–25 production days", "5–10 production days", "30–45 production days"], correctIndex: 2, explanation: "Web Design notes builds finish in 5, 7, or 10 business days depending on size." }


### PR DESCRIPTION
## Summary
- Updated SEO/ecommerce statistics to current, sourced figures (BrightLocal 2026, Similarweb via Search Engine Land, SE Ranking, U.S. Census Bureau) across three Attract/Engage learning path pages
- Corrected Marketing Services blog specs in the Vendasta Services learning path: 500 words to 1,500 words, two stock images, SEO built-in (no add-on) — updated both the content page and its quiz question/answer

## Test plan
- [ ] Preview build in Docusaurus and visually confirm stat callouts and FlipCard content render correctly
- [ ] Confirm the updated quiz question/answer displays correctly and the new correct index matches the new options