### PR TITLE
docs: add Security and privacy page (SOC 2 reporting + Trust Center)

### DIFF
--- a/docusaurus/docs/administration/advanced/service-accounts/index.mdx
+++ b/docusaurus/docs/administration/advanced/service-accounts/index.mdx
@@ -6,6 +6,10 @@ sidebar_position: 3
 
 This section covers the management of service accounts for automated access and system-to-system integrations within the Vendasta platform.
 
+:::info API and access security
+Vendasta maintains a current SOC 2® Type 2 report covering its security controls. For details on how automated access and API keys are secured, see [Security and privacy](/getting-started/security-and-privacy) or visit the [Vendasta Trust Center](https://trust.vendasta.com/).
+:::
+
 ## Service account management
 
 - Account Creation - Set up service accounts for automated processes

--- a/docusaurus/docs/administration/advanced/single-sign-on/index.mdx
+++ b/docusaurus/docs/administration/advanced/single-sign-on/index.mdx
@@ -9,6 +9,10 @@ sidebar_position: 4
 
 Single Sign-On (SSO) lets clients access Vendasta products using your organization's logins. SSO is available for partners on **Premium** or **Custom** subscriptions. Configure it from **Partner Center** → **Administration** → **Advanced** → **Single Sign-On**.
 
+:::info Authentication security
+Vendasta maintains a current SOC 2® Type 2 report covering its security controls. For details on how authentication and access are secured, see [Security and privacy](/getting-started/security-and-privacy) or visit the [Vendasta Trust Center](https://trust.vendasta.com/).
+:::
+
 ## What SSO is
 
 SSO in Partner Center is an authentication mechanism that lets users access the platform with a single set of credentials. It streamlines the login process and improves user experience by enabling access without repeatedly entering usernames and passwords for different services.

--- a/docusaurus/docs/administration/commerce/vendasta-payments/index.mdx
+++ b/docusaurus/docs/administration/commerce/vendasta-payments/index.mdx
@@ -11,6 +11,10 @@ keywords: [vendasta-payments, stripe-connection, account-verification, payment-c
 
 Invoice, bill, and collect payment for all of your services through a single, integrated platform. Provide your local business clients with a seamless buying experience—all in one place, and all under your brand.
 
+:::info Payment security
+Vendasta maintains a current SOC 2® Type 2 report covering its security controls, and payments are processed through Stripe. For details on how payment and platform data is secured, see [Security and privacy](/getting-started/security-and-privacy) or visit the [Vendasta Trust Center](https://trust.vendasta.com/).
+:::
+
 <div
   className="wistia_responsive_padding"
   style={{ padding: '56.25% 0 0 0', position: 'relative' }}

--- a/docusaurus/docs/administration/data-management/index.mdx
+++ b/docusaurus/docs/administration/data-management/index.mdx
@@ -7,6 +7,10 @@ description: Learn about Data Management in Vendasta's platform including CRM ob
 
 Data management provides tools for organizing your business data through custom fields, sales pipelines, and scoring systems. Use them to capture business-specific information, track sales processes, and prioritize leads.
 
+:::info Data security and privacy
+Vendasta maintains a current SOC 2® Type 2 report covering its security controls. For details on how your data is secured and processed, see [Security and privacy](/getting-started/security-and-privacy) or visit the [Vendasta Trust Center](https://trust.vendasta.com/).
+:::
+
 ## What it is
 
 Data management has three core parts:

--- a/docusaurus/docs/getting-started/partner-onboarding.mdx
+++ b/docusaurus/docs/getting-started/partner-onboarding.mdx
@@ -1,7 +1,7 @@
 ---
 title: Partner Onboarding
 description: Guide to Vendasta partner onboarding including your free session and how to get additional training support.
-sidebar_position: 2
+sidebar_position: 4
 ---
 
 # Partner Onboarding

--- a/docusaurus/docs/getting-started/partner-troubleshooting-guide.mdx
+++ b/docusaurus/docs/getting-started/partner-troubleshooting-guide.mdx
@@ -1,7 +1,7 @@
 ---
 title: Partner Troubleshooting Guide
 description: Troubleshooting guides to help resolve common platform issues before escalating to Vendasta Support
-sidebar_position: 3
+sidebar_position: 5
 ---
 
 # Partner Troubleshooting Guide

--- a/docusaurus/docs/getting-started/security-and-privacy.mdx
+++ b/docusaurus/docs/getting-started/security-and-privacy.mdx
@@ -1,0 +1,53 @@
+---
+id: security-and-privacy
+title: Security and privacy
+sidebar_label: Security and privacy
+sidebar_position: 3
+description: How Vendasta secures partner and client data, and where to find SOC 2 reporting and privacy documentation through the Vendasta Trust Center.
+keywords: [security, privacy, soc 2, trust center, data protection, gdpr]
+---
+
+# Security and privacy
+
+You trust Vendasta with sensitive business data and rely on Vendasta to be a responsible custodian of your clients' data as well. Vendasta protects that data with independently audited controls, and its security posture is maintained to meet the standards expected across the industries you serve.
+
+This page explains Vendasta's approach at a high level and points you to where the underlying documentation lives. The [Vendasta Trust Center](https://trust.vendasta.com/) is the source of record for everything below.
+
+:::info Vendasta Trust Center
+For security documentation, privacy policies, and reporting, visit the [Vendasta Trust Center](https://trust.vendasta.com/). Send any security question from you or your clients there first, or email [security@vendasta.com](mailto:security@vendasta.com).
+:::
+
+## SOC 2® reporting
+
+Vendasta maintains a current System and Organization Controls (SOC 2®) Type 2 report, issued by an independent auditor.
+
+A SOC 2 Type 2 report examines the design and operating effectiveness of an organization's controls over a defined period, measured against the Trust Services Criteria (security, availability, processing integrity, confidentiality, and privacy). It gives your own auditors and security teams the detail they need for vendor risk management.
+
+The report itself is confidential and its use is restricted. Vendasta shares it with you and others who need it for due diligence, typically under a non-disclosure agreement. Because the report is gated, this page does not reproduce its contents.
+
+## Request the SOC 2® report and security documentation
+
+When you or your client's security team needs to complete a vendor review, request access through the [Vendasta Trust Center](https://trust.vendasta.com/):
+
+- **SOC 2 report** – Available on request; access to gated documents may require a non-disclosure agreement
+- **Security control summary** – The current, published summary of Vendasta's controls
+- **Subprocessors** – The current list of third-party subprocessors Vendasta uses
+
+For anything the Trust Center does not answer, contact [security@vendasta.com](mailto:security@vendasta.com).
+
+## Privacy and data protection
+
+Vendasta's privacy practices govern how data is collected, processed, and protected across the platform. The following are available through the [Trust Center](https://trust.vendasta.com/):
+
+- **Customer Privacy Policy** – How Vendasta handles personal data
+- **Cookie Policy** – How cookies and similar technologies are used
+- **California Privacy Rights** – Disclosures for California residents
+- **GDPR** – The data subject policy and procedure, and the personal data breach incident response procedure
+
+## Related settings
+
+Several Partner Center settings connect to how access and data are secured in your own account:
+
+- **[Single Sign-On](../administration/advanced/single-sign-on/index.mdx)** – Let clients access products with your organization's logins
+- **[Service accounts](../administration/advanced/service-accounts/index.mdx)** – Manage automated access and API keys for integrations
+- **[Data management](../administration/data-management/index.mdx)** – Organize and control your business data

--- a/docusaurus/docs/index.mdx
+++ b/docusaurus/docs/index.mdx
@@ -133,6 +133,12 @@ New to Vendasta? Here are your essential next steps:
             </li>
             <li>
               <div>
+                <a href="https://trust.vendasta.com/" target="_blank" rel="noopener noreferrer">Vendasta Trust Center</a>
+                <p className="home-link-desc">Review security, privacy, and SOC 2® reporting.</p>
+              </div>
+            </li>
+            <li>
+              <div>
                 <a href="https://developers.vendasta.com/platform/ZG9jOjEwMTkzMDg0-overview?_gl=1*ybazqq*_gcl_au*MTYzNTcxODcyNi4xNzUyNTg5MjI1" target="_blank" rel="noopener noreferrer">API Documentation</a>
                 <p className="home-link-desc">Explore Vendasta APIs and integration guides.</p>
               </div>

--- a/docusaurus/docusaurus.config.ts
+++ b/docusaurus/docusaurus.config.ts
@@ -105,6 +105,10 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       '@docusaurus/plugin-client-redirects',
       {
         redirects: [
+          // Security & privacy: convenience aliases to the Security and privacy page
+          { from: '/security', to: '/getting-started/security-and-privacy' },
+          { from: '/trust-center', to: '/getting-started/security-and-privacy' },
+          { from: '/security-and-compliance', to: '/getting-started/security-and-privacy' },
           // Commerce: order processing/activation article merged into Creating and Managing Orders
           { from: '/commerce/orders/order-processing-and-activation', to: '/commerce/orders/creating-and-managing-orders' },
           // --- Learn restructure (2026-07): TRAINING -> LEARN, paths + lifecycle libraries ---
@@ -448,6 +452,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <a href="https://www.vendasta.com/terms/" target="_blank" rel="noopener noreferrer">Terms of Service</a>
             <a href="https://www.vendasta.com/privacy/" target="_blank" rel="noopener noreferrer">Privacy Policy</a>
             <a href="https://www.vendasta.com/gdpr/" target="_blank" rel="noopener noreferrer">GDPR</a>
+            <a href="/getting-started/security-and-privacy">SOC 2</a>
           </nav>
         </div>
       `,


### PR DESCRIPTION
## What this adds

A **Security and privacy** page under Getting Started (between *Getting Started Guides* and *Partner Onboarding*) plus supporting links. It explains Vendasta's security posture at a high level and routes all detail to the [Vendasta Trust Center](https://trust.vendasta.com/).

**The page is a pointer, not a reproduction.** Per the constraint that the SOC 2 report is confidential and gated behind an NDA, the page does not restate report contents, states no auditor opinion, and does not enumerate controls or subprocessors — it links to the Trust Center for all of that.

### Changes
- **New page:** `getting-started/security-and-privacy`
- **SOC 2 info callouts** on Single Sign-On, Service accounts, Data management, and Vendasta Payments
- **Docs home:** a Vendasta Trust Center link; **footer:** a SOC 2 link beside GDPR
- **Redirects:** `/security`, `/trust-center`, `/security-and-compliance` → the new page
- Renumbered Partner Onboarding and Troubleshooting sidebar positions to make room

### AICPA compliance
Wording follows the AICPA SOC communications and logo guidelines:
- Mark written **SOC 2®** (® on first reference), used as an adjective; report tier **Type 2**
- No "certification"/"compliant" language (a SOC examination is not a certification)
- No auditor opinion stated publicly
- AICPA SOC 2 logo **not** displayed (would require AICPA registration + a hyperlink to aicpa.org/soc4so)

### Verification
- `npm run build` passes; page and all links verified in local preview
- Merges cleanly into current `master` (branched just before the build-lab breakout merged; no conflicts)

### Notes for reviewer
- **Approved by Davin (Security)** on the content.
- Recommend a **Legal/Compliance** glance since this is public-facing attestation/privacy language.
- Open question left for Security to confirm long-term: the "maintains a *current* SOC 2® Type 2 report" claim assumes annual reissue.
