### PR TITLE
docs: remove deprecated Google Q&A task type references

### DIFF
--- a/docusaurus/docs/fulfillment/task-manager/tasks/creating-managing-tasks.mdx
+++ b/docusaurus/docs/fulfillment/task-manager/tasks/creating-managing-tasks.mdx
@@ -174,7 +174,7 @@ While the system doesn't detail custom task creation templates, you can create r
 <details>
 <summary>What products need to be active for auto-generated tasks?</summary>
 
-Mentions and Reviews tasks require Reputation AI to be active. Social Posts and Socialize tasks require Social AI to be active. Google Q&A tasks require the Google account to be connected in Reputation AI.
+Mentions and Reviews tasks require Reputation AI to be active. Social Posts and Socialize tasks require Social AI to be active.
 
 </details>
 

--- a/docusaurus/docs/fulfillment/task-manager/tasks/index.mdx
+++ b/docusaurus/docs/fulfillment/task-manager/tasks/index.mdx
@@ -37,7 +37,7 @@ Tasks streamline your fulfillment workflow by:
 - **[Creating and managing tasks](./creating-managing-tasks.mdx)** – Create tasks manually, set up auto-generation, task types, account settings
 - **[Finding and organizing tasks](./finding-organizing-tasks.mdx)** – Search, sorting, tags, filtering
 - **[Task communication and collaboration](./task-communication-collaboration.mdx)** – Rich text notes, tagging, public vs private notes, bulk edit, approval
-- **[Specialized task types](./specialized-task-types.mdx)** – Google Q&A, review response tasks, login credentials, account-specific config
+- **[Specialized task types](./specialized-task-types.mdx)** – Review response tasks, login credentials, account-specific config
 
 ## Quick start
 
@@ -71,7 +71,7 @@ Star rating filters use AND logic. Select one star rating at a time for filterin
 <details>
 <summary>How do auto-generated tasks work?</summary>
 
-Tasks are created automatically from account activity and your settings (for example, new reviews, mentions, or Google Q&A) when those task types are enabled for the account.
+Tasks are created automatically from account activity and your settings (for example, new reviews or mentions) when those task types are enabled for the account.
 </details>
 
 <details>

--- a/docusaurus/docs/fulfillment/task-manager/tasks/specialized-task-types.mdx
+++ b/docusaurus/docs/fulfillment/task-manager/tasks/specialized-task-types.mdx
@@ -3,8 +3,8 @@ title: Specialized Task Types
 sidebar_label: Specialized Task Types
 sidebar_position: 5
 description: Handle review response tasks, login credentials management, and other specialized task workflows
-tags: [google-qa, review-responses, login-credentials, specialized-tasks]
-keywords: [google-qa-tasks, review-templates, credentials-management, approval-workflows]
+tags: [review-responses, login-credentials, specialized-tasks]
+keywords: [review-templates, credentials-management, approval-workflows]
 ---
 
 # Specialized Task Types

--- a/docusaurus/docs/marketplace/products/create-manage-custom-products.mdx
+++ b/docusaurus/docs/marketplace/products/create-manage-custom-products.mdx
@@ -230,7 +230,6 @@ Standardize your fulfillment process by automating project and task creation in 
   - *Reviews* — When a customer review is left for businesses.
   - *Mentions* — When the business is mentioned across the web.
   - *Listings* — When a listing is missing or inaccurate.
-  - *Google Q&A* — When a question is asked on Google about the business.
   - Choose whether these are fulfilled by *Vendor* or *Reseller*.
 
 ## Add-ons

--- a/docusaurus/docs/vendor-center/vendor-center-general/task-manager-integration.mdx
+++ b/docusaurus/docs/vendor-center/vendor-center-general/task-manager-integration.mdx
@@ -36,7 +36,6 @@ Unlike project-based fulfillment, event-generated tasks and projects are trigger
    - **Reviews**  - Create a task or project when a customer review is left for businesses
    - **Mentions** - Create a task or project when the business is mentioned across the web
    - **Listings** - Create a task or project when a listing is missing or inaccurate
-   - **Google Q&A** - Create a task or project when a question is asked on Google about the business
 
 4. Select who the project is fulfilled by 
    - **Vendor** - Create projects in your Task Manager


### PR DESCRIPTION
## Summary
- Google discontinued the Q&A API and the feature is now hidden behind a feature flag
- Removes Google Q&A as a task/project trigger option across Marketplace, Vendor Center, and Fulfillment Task Manager docs, updates the related FAQ answers, and cleans up now-orphaned frontmatter tags/keywords

## Test plan
- [ ] Verify no other Partner Center docs reference Google Q&A
- [ ] Confirm Cloud Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)