### PR TITLE
learn: write Train your AI Employee and Build a Custom AI Employee steps

### DIFF
--- a/docusaurus/training/ai-workforce/custom-employee-lab.mdx
+++ b/docusaurus/training/ai-workforce/custom-employee-lab.mdx
@@ -1,11 +1,189 @@
 ---
 title: Build a Custom AI Employee
 sidebar_position: 5
-description: "A hands-on lab: design an employee from an outcome statement and assemble knowledge, capabilities, and tools."
+description: Design an AI Employee from an outcome, set its role and autonomy, connect knowledge and capabilities, add one custom tool, and test it before calling it done.
 ---
 
-:::info Content coming soon!
-This part of the learning path is being built. Check back shortly.
+import KnowledgeCheck from "@site/src/components/KnowledgeCheck";
+import CourseProgressBar from "@site/src/components/CourseProgressBar";
+import SectionFeedback from "@site/src/components/SectionFeedback";
+import InlineHighlighter from "@site/src/components/InlineHighlighter";
+import MarkComplete from "@site/src/components/MarkComplete";
+import LessonHeader from "@site/src/components/LessonHeader";
+import LessonFooter from "@site/src/components/LessonFooter";
+import LabChecklist from "@site/src/components/LabChecklist";
+
+<InlineHighlighter courseId="custom-employee-lab" site="vendasta_learn">
+
+<CourseProgressBar courseId="custom-employee-lab" site="vendasta_learn" />
+
+<LessonHeader
+  difficulty="Intermediate"
+  time="about 18 minutes"
+  required={["Partner Center access on a Professional plan or higher", "A simple API to test against, or use the example in this step"]}
+  lab
+  pathName="Hire your first AI Employee"
+  step={5}
+  totalSteps={7}
+  outcomes={[
+    "Start a custom AI Employee from an outcome statement, not a feature list",
+    "Write a role and connect the knowledge and capabilities that outcome needs",
+    "Set an autonomy level that matches how much you trust the role on day one",
+    "Add one custom capability with a simple tool",
+    "Test against a pass/fail script before calling it done",
+  ]}
+/>
+
+## Start from the outcome
+
+By the end of this step, a custom AI Employee built for one outcome you chose is live, answering from its own knowledge and capable of one real action through a tool you configured. *You are here: Partner Center, on a Professional plan or higher.*
+
+Every employee so far came pre-built. This one starts blank, so the first decision is the outcome, not the employee: "qualify inbound leads before booking" is a real brief, "build a sales bot" is not. Building one costs nothing extra, and there is no limit on how many you create, so the only real constraint is a clear outcome. If the outcome resembles a data analyst, an inside sales representative, or a support role, [the custom AI employee guide](/ai/ai-workforce/custom-ai-employees) has a worked example close to it, worth stealing from rather than starting from nothing.
+
+:::tip Try it now
+Write your outcome in one sentence before you open the configuration panel: what this employee does, and for whom.
 :::
 
-**What you will learn here:** Outcome-first design, writing the role, attaching knowledge, building a custom capability, adding a simple tool, and testing against a pass-fail script.
+## Create the employee
+
+:::info Lab: create the employee and its profile
+You are going to **AI** → **AI Workforce** → **Create**.
+
+<LabChecklist
+  storageKey="custom-employee-lab-1"
+  steps={[
+    <>Give it a name and avatar that fit the role.</>,
+    <>Set its autonomy level. Level 3, Autonomous, is the default, and lets it manage full conversations, capture leads, and book on its own while every conversation stays reviewable. Choose a lower level if you would rather review closely while it is new.</>,
+    <>In Purpose, write the role prompt: who it is, its tone, and the one outcome it exists for.</>,
+  ]}
+  confirm={<>The employee now exists in your AI Workforce roster, with a profile and an autonomy level set.</>}
+/>
+:::
+
+## Give it knowledge and capabilities
+
+:::info Lab: connect knowledge and turn on capabilities
+You are staying on the employee's **Configure** panel.
+
+<LabChecklist
+  storageKey="custom-employee-lab-2"
+  steps={[
+    <>In Knowledge Sources, add the business profile and any website pages or documents the outcome needs.</>,
+    <>In Capabilities, turn on the built-in capabilities that match the outcome, such as lead capture or booking.</>,
+  ]}
+  confirm={<>The employee can now answer from real knowledge and take the actions its outcome needs, using only built-in pieces.</>}
+/>
+:::
+
+## Add one custom capability
+
+Most outcomes need one more thing a built-in capability does not cover: a real action in another system, a price check, an order status, an inventory count. Knowledge only answers from what has been uploaded to it, so an outcome that depends on live information hits a ceiling fast without a live connection. That connection becomes a tool, added inside a custom capability.
+
+:::info Lab: add a capability with a tool
+You are going to **Capabilities** → **Custom Capabilities** → **Add a capability**.
+
+<LabChecklist
+  storageKey="custom-employee-lab-3"
+  steps={[
+    <>Name the capability and describe what it does, for example <code>CheckOrderStatus</code>, "looks up an order's status by order number."</>,
+    <>Add a tool: the method (GET to look something up), the URL, and the parameter it needs, such as an order number.</>,
+    <>Save.</>,
+  ]}
+  confirm={<>The tool now appears on the capability, ready for the AI to call once its instructions say when.</>}
+/>
+:::
+
+For headers, authentication, and every field in detail, [Creating Custom Capabilities walks through the rest](/ai/ai-capabilities/creating-custom-capabilities).
+
+## Write the capability's instructions
+
+Brief the capability the way you would brief a new hire's one task: exactly when to use it, what it needs before it can act, and how to talk about what comes back. "Only call this when the customer asks about an existing order, and get the order number first" holds up in every conversation; "help with orders when it makes sense" does not.
+
+## Test before you call it done
+
+:::info Lab: run the pass/fail script
+You are on the employee's **Try it** page, or its assigned channel.
+
+<LabChecklist
+  storageKey="custom-employee-lab-4"
+  steps={[
+    <>Ask a question that should trigger the capability, and confirm it calls the tool and answers correctly.</>,
+    <>Ask a related question that should not trigger it, and confirm it does not.</>,
+    <>Ask the triggering question again without the information the tool needs, and confirm the employee asks for it instead of guessing.</>,
+  ]}
+  confirm={<>Three questions, three different situations, and the employee handled all three the way its outcome intended.</>}
+/>
+:::
+
+## Where this stops, for now
+
+One tool answering one outcome is a complete employee. Chaining several tools together, or connecting through middleware, is a deeper build for a job that genuinely needs it; the [Tools & Integrations Overview](/ai/ai-capabilities/tools-overview) is where to go next when that day comes.
+
+## What you now have
+
+- A custom AI Employee built around one outcome you named, not a feature list
+- A role, an autonomy level, knowledge, and capabilities, all set from a blank start
+- One custom capability with a working tool, briefed like a new hire's task
+- A pass/fail test result you can trust before anyone else talks to it
+
+<SectionFeedback courseId="custom-employee-lab" site="vendasta_learn" section="content" />
+
+<KnowledgeCheck courseId="custom-employee-lab" site="vendasta_learn"
+  sessionSize={3}
+  intro="Three quick questions on starting from an outcome, sorting knowledge from tools, and testing a new capability."
+  questions={[
+    {
+      type: 'mcq',
+      question: 'You want a custom AI Employee for a landscaping company. Which brief gets you started well?',
+      options: [
+        'Build a helpful bot',
+        'Qualify inbound quote requests and collect the job address before booking a site visit',
+        'Make it sound professional',
+        'Give it every capability available'
+      ],
+      correctIndex: 1,
+      explanation: 'An outcome statement names the result and who it is for. A feature list or a tone note is not enough to design around.'
+    },
+    {
+      type: 'mcq',
+      question: 'The employee needs to check real-time inventory before promising a delivery date. Where does that live?',
+      options: [
+        'A knowledge source, updated daily',
+        'The Purpose field',
+        'A custom capability with a tool that looks up inventory live',
+        'The channel settings'
+      ],
+      correctIndex: 2,
+      explanation: 'Information that changes constantly is better fetched live through a tool than kept as knowledge that goes stale between updates.'
+    },
+    {
+      type: 'mcq',
+      question: 'Why test a question that should NOT trigger the new capability, not just one that should?',
+      options: [
+        'To confirm the employee is not calling the tool when it should not be',
+        'To check the channel is installed correctly',
+        'To see if the plan needs an upgrade',
+        'To test its autonomy level'
+      ],
+      correctIndex: 0,
+      explanation: 'A pass/fail script needs both directions: the capability firing when it should, and staying quiet when it should not.'
+    },
+    {
+      type: 'mcq',
+      question: 'Which capability instruction is ready to ship?',
+      options: [
+        'Help with orders when it makes sense',
+        'Only call CheckOrderStatus when the customer asks about an existing order, after you have the order number',
+        'Be helpful about order status',
+        'Use the order tool sometimes'
+      ],
+      correctIndex: 1,
+      explanation: 'A ready instruction says exactly when to call the tool and what must be known first. Vague instructions like "when it makes sense" leave the AI to guess.'
+    }
+  ]}
+/>
+
+<LessonFooter to="/learn/ai-workforce/autopilot" pathName="Hire your first AI Employee" step={5} totalSteps={7} />
+
+</InlineHighlighter>
+<MarkComplete courseId="custom-employee-lab" site="vendasta_learn" />

--- a/docusaurus/training/ai-workforce/train-your-employee.mdx
+++ b/docusaurus/training/ai-workforce/train-your-employee.mdx
@@ -1,11 +1,174 @@
 ---
 title: Train your AI Employee
 sidebar_position: 4
-description: Knowledge sourcing, price lists, guardrails, and the coach-and-correct loop that makes every answer accurate.
+description: Fix a wrong answer, add a guardrail that stops price hallucination, and build the coach-and-correct habit that keeps every answer accurate.
 ---
 
-:::info Content coming soon!
-This part of the learning path is being built. Check back shortly.
+import KnowledgeCheck from "@site/src/components/KnowledgeCheck";
+import CourseProgressBar from "@site/src/components/CourseProgressBar";
+import SectionFeedback from "@site/src/components/SectionFeedback";
+import InlineHighlighter from "@site/src/components/InlineHighlighter";
+import MarkComplete from "@site/src/components/MarkComplete";
+import LessonHeader from "@site/src/components/LessonHeader";
+import LessonFooter from "@site/src/components/LessonFooter";
+import LabChecklist from "@site/src/components/LabChecklist";
+
+<InlineHighlighter courseId="train-your-employee" site="vendasta_learn">
+
+<CourseProgressBar courseId="train-your-employee" site="vendasta_learn" />
+
+<LessonHeader
+  difficulty="Beginner"
+  time="about 15 minutes"
+  required={["Partner Center access", "An AI Employee with knowledge sources and a capability, such as your receptionist from the last step"]}
+  lab
+  pathName="Hire your first AI Employee"
+  step={4}
+  totalSteps={7}
+  outcomes={[
+    "Audit an AI Employee's answers, prices included, before a client meets it",
+    "Fix a knowledge source that is giving wrong or outdated answers",
+    "Write a guardrail capability that stops price hallucination",
+    "Sort a fix correctly: knowledge is the degree, capabilities are the skill",
+    "Read Explanation to see exactly what an answer used",
+  ]}
+/>
+
+## Audit what it actually knows
+
+By the end of this step, your receptionist from the last step answers your ten hardest questions correctly, prices included, with a guardrail in place so it never invents one again. *You are here: Partner Center, on the same employee you deployed last step.*
+
+Run the ten-question audit again, now that the employee is doing real work: open the Try it test page and ask everything a prospect is likely to ask, prices included. A wrong answer is not a defect, it is a training gap, and every training gap has an address, either a knowledge source that needs fixing or an instruction it never received.
+
+:::tip Try it now
+Open the test page in a fresh incognito window and run the audit before you change anything. Keep the answers that need fixing; the rest of this step fixes them.
 :::
 
-**What you will learn here:** Auditing an employee before clients meet it, fixing knowledge sources, writing a pricing guardrail, right-sizing prompts, and running the ongoing training loop.
+## Fix the source, not the AI
+
+A wrong price usually means the source it searched never had the real number, not that the AI is broken. Copy the package's exact pricing into a clean document and upload it as the authoritative source: auto-imported marketplace content can carry broken links or no usable pricing at all.
+
+:::info Lab: upload a clean price list
+You are going to your employee's **Configure** panel → **Knowledge Sources**.
+
+<LabChecklist
+  storageKey="train-your-employee-lab-1"
+  steps={[
+    <>Write or copy the package's exact prices and details into one document.</>,
+    <>Select <strong>Add knowledge source</strong> and upload it as a file, labeled clearly (for example, "2026 Service Pricing").</>,
+  ]}
+  confirm={<>The price list now appears in <strong>Knowledge Sources</strong>, ready for the AI to search.</>}
+/>
+:::
+
+For every knowledge source type and what belongs in each, [the Knowledge Base guide covers the rest](/ai/knowledge-base).
+
+## Add a guardrail
+
+Knowledge is what the AI looks up when a question calls for it. A rule that must hold on every response belongs in a capability instead, so a guardrail like "quote only from the published list, never estimate" holds even on a question the price list does not directly answer.
+
+:::info Lab: write the pricing guardrail
+You are going to your employee's **Configure** panel → **Capabilities**.
+
+<LabChecklist
+  storageKey="train-your-employee-lab-2"
+  steps={[
+    <>Open the capability that answers pricing questions, or add a custom capability named something like <code>QuotePricing</code>.</>,
+    <>In its instructions, add: quote only the prices in the knowledge base; if a price is not there, capture the visitor's contact details and say a person will follow up.</>,
+    <>Save.</>,
+  ]}
+  confirm={<>The capability now holds the rule, and it applies on every conversation, not only the ones a knowledge lookup happens to catch.</>}
+/>
+:::
+
+Keep the instruction short. Everything an employee has been told shares one working memory, and a long list of rules competes with itself; specific and short beats long every time. Instructions also tend to collect leftover lines from earlier edits, so revisit and trim them now and then rather than only ever adding to them. The same discipline suits a business in a regulated field: rather than answering specifics on medical or legal questions, have the guardrail redirect to a person, and use the word its own customers would use, never a clinical term a business would not use itself.
+
+## Re-test and see why it answered that way
+
+:::info Lab: re-run the audit
+You are back on the **Try it** test page.
+
+<LabChecklist
+  storageKey="train-your-employee-lab-3"
+  steps={[
+    <>Ask the same ten questions again, in a fresh incognito window.</>,
+    <>On any answer worth checking, select <strong>Explanation</strong>.</>,
+  ]}
+  confirm={<>Explanation shows exactly which knowledge source or capability produced that answer, so you know precisely what to adjust if it is still off.</>}
+/>
+:::
+
+## The habit that keeps it accurate
+
+Treat the employee as a new hire rather than a setting: coach it, correct it, and expect the answers to keep improving, the same way a new team member does. The rule behind every fix here is the one behind every fix to come: a wrong answer to a specific question is usually a knowledge gap, and a wrong behavior across every conversation is usually a capability gap. Knowledge is the degree it holds; capabilities are the skill it practices.
+
+Testing on purpose, on your own account, is how gaps surface before a client ever sees them, and a change that turns out wrong is never permanent: undo it and try again. As an employee earns your trust through this loop, its autonomy level can grow with it, from close review to running full conversations on its own, a decision the next step puts in your hands from the very first setup.
+
+## What you now have
+
+- A receptionist whose pricing answers come from one clean, current source
+- A guardrail capability that stops it from ever guessing a price
+- The habit of auditing after every knowledge change, with Explanation to show you why an answer happened
+- The knowledge-versus-capability question, answered, for every fix you make from here on
+
+<SectionFeedback courseId="train-your-employee" site="vendasta_learn" section="content" />
+
+<KnowledgeCheck courseId="train-your-employee" site="vendasta_learn"
+  sessionSize={3}
+  intro="Three quick questions on fixing a wrong answer, sorting knowledge from capabilities, and reading Explanation."
+  questions={[
+    {
+      type: 'mcq',
+      question: 'A customer asks about pricing and your AI Employee makes up a number that is not real. What kind of fix is this?',
+      options: [
+        'A capability fix, because the guardrail failed',
+        'A knowledge fix, because the source it searched does not have the real price',
+        'A channel fix, because the wrong channel is enabled',
+        'An autonomy fix, because the level is set too high'
+      ],
+      correctIndex: 1,
+      explanation: 'An invented price means the source did not have the real number to find. Fix the knowledge first, then add a guardrail so it cannot happen again.'
+    },
+    {
+      type: 'mcq',
+      question: 'Which instruction belongs in a capability rather than a knowledge source?',
+      options: [
+        'Quote only the prices in the price list, every time',
+        'Our spa\'s current price list',
+        'Our hours change seasonally, check the website',
+        'Reviews and testimonials from past customers'
+      ],
+      correctIndex: 0,
+      explanation: 'A rule that must hold on every response belongs in a capability. Facts the AI looks up when relevant belong in knowledge.'
+    },
+    {
+      type: 'mcq',
+      question: 'You want to know exactly which knowledge source or capability produced a specific answer. What do you check?',
+      options: [
+        'The Conversations inbox tab',
+        'The Explanation link on that message',
+        'The AI Workforce roster page',
+        'The plan and billing page'
+      ],
+      correctIndex: 1,
+      explanation: 'Explanation shows the reasoning behind a response, which knowledge it used, and any capability or tool it called.'
+    },
+    {
+      type: 'mcq',
+      question: 'Your receptionist gives a great answer this week and a strange one next week to the same question. What is the right response?',
+      options: [
+        'Turn it off until it is more consistent',
+        'Treat it once and leave it; it will settle on its own',
+        'Keep coaching it the way you would a new hire, correcting what is off as you see it',
+        'Lower its autonomy level permanently'
+      ],
+      correctIndex: 2,
+      explanation: 'The operating mindset is continuous: coach and correct as you go, the way you would with any new team member.'
+    }
+  ]}
+/>
+
+<LessonFooter to="/learn/ai-workforce/custom-employee-lab" pathName="Hire your first AI Employee" step={4} totalSteps={7} />
+
+</InlineHighlighter>
+<MarkComplete courseId="train-your-employee" site="vendasta_learn" />

--- a/learn-revamp/drafts/OUTLINE-ai-workforce-train-and-custom-lab.md
+++ b/learn-revamp/drafts/OUTLINE-ai-workforce-train-and-custom-lab.md
@@ -1,0 +1,126 @@
+# Outline spec: Hire your first AI Employee — steps 4 and 5 (Train your AI Employee, Build a Custom AI Employee)
+
+**Status:** Draft for Shiva review (per HANDOFF.md: Shiva approves outlines and steps within a path; Cal gives per-path critique and PR-level approval). No lesson copy gets written until this is approved.
+**Date:** July 21, 2026
+**Author:** Claude, from the two 360Learning courses Shiva provided (`AI Receptionist Setup & Configuration`, `Meet Your First AI Employee — The AI Receptionist`, both source material for ET-690) plus repo recon.
+**Parents:** learn-tab-ia-spec.md Path 3 lessons 5 and 7, partner-call-insights.md pain point 3 and jobs 4.2/4.8, PROPOSAL-lab-pattern.md, HANDOFF.md, implementation-plan.md execution log.
+**Scope:** Steps 4 and 5 of the path's 7. Steps 1-2 (Meet your AI Workforce, Put a receptionist to work) are already shipped on the branch. Steps 3, 6, 7 (Teach it to book, Autopilot, Sell and manage) are **not** covered here — see "Not in this outline."
+**Coordination note:** HANDOFF.md flags another session as having been mid-restructure of `training/ai-workforce/`. Confirm that is resolved and check `git status` before any of this becomes real lesson copy.
+
+## The angle
+
+Steps 1-2 already taught the roster and the deploy-and-audit decision. These two steps are where the workforce stops being "configured" and starts being **run**: fixing an employee that gave a wrong answer, and building one from nothing for a job the pre-built roster does not cover. Both steps are hands-on under the state-change test in PROPOSAL-lab-pattern.md (fixing knowledge and capabilities changes real state; building a custom employee changes real state), so both carry the `lab` tag.
+
+## Where the two uploaded courses actually landed
+
+The courses are richer on configuration mechanics than the two stub descriptions suggest, but most of that material is **already shipped** in steps 1-2 (chat vs. voice, SMS/A2P, the ten-question audit, where leads land). What is left over maps like this:
+
+| Course material | Where it lands | Notes |
+|---|---|---|
+| Purpose/Role prompt writing, best practices (short sentences, specific tone, unsure-handling) | Step 4, beat 5 (guardrail) and step 5, beat 3 (role prompt) | Confirmed against `ai_workforce_overview.md` and `ai-chat-receptionist/index.mdx`: the field is **Purpose**, labeled **Role** specifically on Chat/Voice Receptionist. Already used correctly in shipped steps. |
+| Knowledge source types (Business Profile, Website Scrape/Follow Links, Uploaded Documents, Auto-Refresh) | Step 4, beats 3-4 | `knowledge-base.md` confirms Business Profile, Website Content, Custom Documents, Manual Entries; "Auto-Refresh" as a named toggle is not confirmed in docs I read — treat as a course claim needing a UI check, not a hard citation. |
+| "Autonomy Level" (default Level 3: Autonomous) | **Included** — Shiva confirmed this directly in the live product on July 21. It doesn't appear in the `businessapp-docs` pages I checked, so that's a documentation gap worth flagging separately, but the feature is real. Folded into Step 5 (where an employee's profile is first set up), with a short callback in Step 4. | Tag as `[CONFIRMED IN-PRODUCT: Shiva, July 2026]` rather than `[DOC]` until the docs team adds a page for it. |
+| Channel setup table, web chat install options, voice call-handling options | Already shipped (step 2) | No new beat needed. |
+| My Listing demo / Try It testing | Already shipped (step 2); reused in step 4's re-test beat | `ai-chat-receptionist/index.mdx` adds a tier gate the course does not mention: My Listing requires **Local SEO Standard** active. Flag if re-citing. |
+| Conversations tabs (Inbox/Closed/Anonymous), Explanation feature, Associated Contacts | Already shipped (step 2); Explanation reused in step 4 | |
+| "Train it like a teammate" loop (review → improve → repeat), guardrails, misconception vs. reality | Step 4, primary spine | Matches `partner-call-insights.md` 4.2 almost beat for beat; the call evidence is more specific (exact price-hallucination and over-prompting language) than the course, so the call evidence leads and the course corroborates. |
+| Elite Web Professionals case study, before/after metrics table | Step 7 (Sell and manage) — **not drafted here** | Good material for that step whenever it gets outlined; flagging so it is not lost. |
+| Full configuration walkthrough (name/photo, capabilities/channels table, demo testing) | Step 5, reframed | The course configures the **pre-built** Chat Receptionist; step 5 is building a **custom** employee from blank. Same underlying screens (Profile, Capabilities, Knowledge, test), different starting point — confirmed consistent with `custom-ai-employees/index.md`. |
+
+## Source map
+
+| Source | Role | Constraint |
+|---|---|---|
+| `AI Receptionist Setup & Configuration` (360Learning, uploaded) | Configuration mechanics, best practices, demo testing | Tag `[COURSE]`; every course claim gets cross-checked against a `[DOC]` before it can stand alone. Unresolved course claims do not ship (same discipline as `[SYN]` in the skill file). |
+| `Meet Your First AI Employee — The AI Receptionist` (360Learning, uploaded) | Value framing, training loop, guardrails, case study | Same `[COURSE]` discipline. |
+| `businessapp-docs` `business-app/ai/ai-workforce/ai_workforce_overview.md`, `ai-chat-receptionist/index.mdx`, `ai/knowledge-base.md`, `ai-capabilities/index.mdx`, `ai-capabilities/creating-custom-capabilities.md`, `ai-workforce/custom-ai-employees/index.md` | Canonical product facts for both steps | Verified directly this session (see mapping table above for what did and did not check out). |
+| `learn-revamp/partner-call-insights.md` sections 3 and 4.2, 4.8 | Field evidence: the exact CS metaphors ("knowledge is the degree, capabilities are the skill," "go break it," "garbage in, garbage out") and the price-hallucination story | `[CALL]`, already vetted into the IA spec; carried forward, not re-derived. |
+| `learn-revamp/learn-tab-ia-spec.md` Path 3, lessons 5 and 7 | The canonical scope for these two steps, pre-dating the course upload | Primary scope authority where it conflicts with the courses. |
+| `learn-revamp/drafts/PROPOSAL-lab-pattern.md` | Lab anatomy (Lab callouts, go/do/confirm, "What you now have") | Provisional — see structural decision 1. |
+
+## Decided by Shiva (July 21)
+
+1. **Difficulty.** Step 4 stays Beginner (it's the natural next move after step 2). Step 5 is Intermediate, since it's the first step where the learner touches something more technical (setting up a real tool/API call). This is just a small label shown at the top of the step, telling the learner how hard it is before they start — it doesn't move the step or change the order; step 4 still comes right before step 5.
+2. **The "reset to default" button.** Not naming a specific button in the copy. Instead of saying "click X button," the lesson will just say something true either way, like "you can always undo a change" — safe regardless of the exact UI, and nothing to verify before writing.
+3. **Step 5's boundary with the Builder track.** Keeping step 5 light: one simple example (a single lookup, like checking a price or an order status), and pointing anyone who wants to do more toward the more technical Builder section Cal owns, rather than teaching deep API/webhook stuff here.
+4. **Every step is a lab.** Shiva's standing direction: every step under the Learn tab gets the full lab treatment (the `lab` tag and the `:::info Lab:` callout pattern from PROPOSAL-lab-pattern.md), not just the steps that pass the narrower "state-change test" in that proposal. Both steps in this outline already used the lab pattern, so no change needed here, but this is now the rule for every future step in this path (and presumably the whole Learn tab), including ones that read as conceptual today (Meet your AI Workforce, Sell and manage). Noting this so it carries into the next outlines, and flagging that the already-shipped steps 1-2 may want a retrofit pass at some point to match, though that's not part of this outline.
+5. **Autonomy Level is real — include it.** See the mapping table above; folded into Step 5.
+
+6. **Sensitive-vertical guardrail.** Keep it, framed as a good-practice tip rather than an official product rule: for businesses in fields like healthcare or legal services, the AI avoids giving specific professional advice and hands off to a person, and refers to "customers" rather than "patients" or "clients" in a clinical sense. Sourced from partner-call evidence, not official documentation — worded so the copy never claims it's a documented feature.
+
+## Still open
+
+None. All open items are resolved.
+
+---
+
+## Step 4: Train your AI Employee (Beginner, lab, ~15 min)
+
+**Outcomes:**
+- Audit an AI Employee's answers, prices included, before a client meets it.
+- Fix a knowledge source that is producing wrong or outdated answers.
+- Write a guardrail capability that stops price hallucination.
+- Sort a fix correctly using "knowledge is the degree, capabilities are the skill."
+- Re-test with Explanation and read what the AI actually used to answer.
+
+**Ground (first sentence under first heading):** by the end of this step, your own receptionist from step 2 answers your ten hardest questions correctly, with a guardrail in place so it never invents a price again. Environment: your own Partner Center, the same employee step 2 deployed.
+
+**Beats:**
+1. Opening descriptor: an AI Employee only ever answers with what it was given; a wrong answer is a training gap, not a defect. [SYN, voice rule 3 — coaching framing, not error framing]
+2. Callback by concept (no step numbers) to the ten-question audit from earlier: run it again, deliberately, on the employee now doing real work. [CALL 4.2 beat 1; COURSE both PDFs' audit/FAQ framing corroborates]
+3. Lab: fix the source, not the AI. Copy real package and price details into a clean document and upload it to Knowledge Sources as the authoritative source; auto-imported marketplace content can carry broken links or no usable pricing. [DOC knowledge-base.md "Custom Documents"; CALL 4.2 beats 2-3]
+4. The Knowledge Base vs. Capabilities split, taught at the moment it matters: knowledge is retrieved when relevant; anything that must hold in *every* response belongs in a capability instead. [DOC knowledge-base.md "Knowledge base vs. capabilities" tip]
+5. Lab: write and save a guardrail capability — quote only from the published list, never generalize, otherwise capture contact details and offer a human. [DOC ai-capabilities/creating-custom-capabilities.md steps 2-3 "Writing effective capability prompts"; CALL 4.2 beat 4]
+6. Prompt-length discipline: instructions compete with each other in one working memory; short and specific outperforms long. [CALL "over-prompting"; COURSE "best practices: short sentences"]
+7. Sensitive-vertical aside, one line: regulated businesses redirect rather than answer specifics directly, in the client's own vocabulary. Framed as a good-practice tip, not a cited product rule. [CALL 4.2 beat 7 — decided, keep]
+8. Lab: re-run the audit against the new knowledge and guardrail. Use Explanation on any answer to see exactly which knowledge or capability produced it. [DOC ai-chat-receptionist/index.mdx "Monitor and improve"; knowledge-base.md Explanation FAQ]
+9. The operating mindset, in the field's own words: a new employee, not a setting — coach and correct continuously; garbage in, garbage out. [CALL, pain point 3 mental model]
+10. The sandbox habit: deliberately testing an employee to find its gaps is the fastest way to improve it; a change that goes wrong can always be undone. [CALL pain point 3; worded so it holds true without naming a specific button — decided]
+11. Short callback: as an employee earns trust through this training loop, its autonomy level can move with it (introduced properly in the next step's build). [SYN — forward pointer only, no step number named]
+
+**Components:** LessonHeader (`lab`, Beginner, ~15 min, Required: "Partner Center access," "An AI Employee with Knowledge Sources and a Capability, such as your receptionist from step 2"). Two to three `:::info Lab:` callouts (upload the price list; write the guardrail capability; re-test with Explanation). "What you now have" before the knowledge check. LessonFooter → `/learn/ai-workforce/custom-employee-lab`.
+
+**Knowledge check:** placement (does this belong in knowledge or a capability); what Explanation shows; why a short guardrail beats a long one; the "degree vs. skill" framing applied to a new scenario.
+
+---
+
+## Step 5: Build a Custom AI Employee (Intermediate, lab, ~18 min)
+
+**Outcomes:**
+- Start a custom AI Employee from an outcome statement, not a feature list.
+- Write a role prompt and connect the knowledge and capabilities that outcome needs.
+- Set an autonomy level that matches how much you trust the role on day one.
+- Add one custom capability with a simple tool.
+- Test against a pass/fail script before calling it done.
+
+**Ground:** by the end of this step, a custom AI Employee built for one outcome you chose is live, answering from its own knowledge and capable of one real action through a tool you configured. Environment: your own Partner Center.
+
+**Beats:**
+1. Opening descriptor: every employee so far came pre-built; this one starts blank, defined entirely by what it needs to accomplish. [DOC custom-ai-employees/index.md "start as a blank slate"]
+2. Outcome-first design: name the result before naming the employee ("qualify inbound leads before booking," not "build a sales bot"). The three built-in custom examples (Data Analyst, Inside Sales Representative, Support Employee) are patterns to steal from, not a checklist. [DOC custom-ai-employees/index.md "When to build" list; CALL 4.8 beat 1 "start from the outcome, work backwards"]
+3. Lab: create the employee (name, avatar, profile), set its autonomy level, and write its role prompt — personality, voice, and behavioral rules the rest of the build runs on. Level 3: Autonomous is the default: it manages full conversations, collects leads, and books appointments on its own, and every conversation stays reviewable. [CONFIRMED IN-PRODUCT: Shiva, July 2026 — not yet in businessapp-docs, flagged as a docs gap; DOC custom-ai-employees/index.md setup steps 1-2 for the rest of the profile]
+4. Lab: connect the knowledge sources and turn on the built-in capabilities the outcome needs (for example, lead capture, booking). [DOC custom-ai-employees/index.md setup steps 3-4]
+5. Lab: add one custom capability with a simple tool — an ID, a description, a method and URL, the parameters it needs before it can act. [DOC creating-custom-capabilities.md steps 2-4, "Example custom capability: Product information lookup"]
+6. Writing the capability prompt: say exactly when to call the tool, what must be known first, and how to use what comes back — brief it like a new hire's task, not a paragraph of context. [DOC creating-custom-capabilities.md "Writing effective capability prompts"; CALL 4.8 beat 2 "draft with an AI assistant, then trim"]
+7. Lab: assign a channel (web chat is fastest to test) and run a pass/fail script — a phrasing that should trigger the capability, one that should not, one with missing information. [DOC creating-custom-capabilities.md step 5, "Testing and troubleshooting"]
+8. Where this stops: chaining multiple tools and systems through middleware and webhooks is deeper water than one employee needs on day one; [doc link to the integration landscape] when a job needs more than this. [Deferral, matches AI foundations step 5's pattern; honors HANDOFF's builder-track boundary — decided]
+
+**Components:** LessonHeader (`lab`, Intermediate, ~18 min, Required: "AI Workforce admin access," "A simple API to test against, or use the lookup pattern in the linked guide"). Three to four `:::info Lab:` callouts (create + role prompt; knowledge + capabilities; custom capability + tool; test). "What you now have" before the knowledge check. LessonFooter → `/learn/ai-workforce/autopilot`.
+
+**Knowledge check:** outcome-first vs. feature-first placement; knowledge vs. capability vs. tool triage on a new scenario; what the pass/fail test catches that one chat message does not.
+
+---
+
+## Not in this outline (scope fences)
+
+- **Teach it to book** (step 3): calendars, booking links, business-hours call routing. Neither uploaded course touches this at all. `businessapp-docs` has substantial My Meetings / booking-links material (`crm/My meetings/`) confirmed present; needs its own outline pulling from there plus `learn-tab-ia-spec.md` lesson 4, not from the courses.
+- **Put your workforce on autopilot** (step 6): smart lists and automations. Not covered by the courses; separate outline from `partner-call-insights.md` 4.3/4.10 and the automations docs.
+- **Sell and manage** (step 7): the Elite Web Professionals case study and before/after metrics table from course 2 are good material here, noted in the mapping table above, but the step's primary scope (positioning, champion wedge, adoption tiers, packaging/pricing) comes from `learn-tab-ia-spec.md` lesson 10 and is not drafted in this outline.
+- No webhook, middleware, or multi-tool chaining depth in step 5 — that is the Builder track's territory.
+
+## Changelog
+
+- **v4** (July 21, 2026): Sensitive-vertical guardrail line confirmed — keep it, framed as a good-practice tip rather than a documented feature. Every open item is now resolved; ready to move to lesson copy.
+- **v3** (July 21, 2026): Difficulty confirmed (step 4 Beginner, step 5 Intermediate — it's just a label, doesn't change step order). Reset-to-default wording settled (describe the behavior, don't name a button). Step 5's stop point confirmed against what the Builder track owner would want. Only the sensitive-vertical guardrail line is still open, re-asked in plain language in chat.
+- **v2** (July 21, 2026): Shiva confirmed Autonomy Level is real in-product — restored, folded into Step 5's build beat plus a callback in Step 4. Locked in "every Learn tab step is a lab" as standing direction, both steps already matched it. Renumbered the remaining open decisions.
+- **v1** (July 21, 2026): initial outline, built from the two 360Learning courses Shiva uploaded for ET-690, cross-checked against `businessapp-docs` (connected this session), `partner-call-insights.md`, `learn-tab-ia-spec.md`, and `PROPOSAL-lab-pattern.md`.


### PR DESCRIPTION
What this is

Adds two lessons to the "Hire your first AI Employee" learning path at /learn/ai-workforce/: Train your AI Employee (step 4) and Build a Custom AI Employee (step 5, lab). Closes out the 360Learning-course-to-Learn-tab work tracked in ET-690.

Files

docusaurus/training/ai-workforce/train-your-employee.mdx — was a stub, now written
docusaurus/training/ai-workforce/custom-employee-lab.mdx — was a stub, now written
learn-revamp/drafts/OUTLINE-ai-workforce-train-and-custom-lab.md — the approved outline and decision record behind both steps, kept for review history

What each step covers

Train your AI Employee: re-running the ten-question audit on a live employee, fixing a knowledge source instead of guessing, adding a guardrail capability so pricing answers never get invented, reading Explanation to see why an answer happened, and the ongoing coach-and-correct habit.
Build a Custom AI Employee (lab): starting from an outcome statement, creating a blank employee (profile, autonomy level, role prompt), connecting knowledge and built-in capabilities, adding one custom capability with a simple tool, writing the capability's instructions, and a pass/fail test before calling it done.

Source material: the two 360Learning courses for ET-690 (AI Receptionist Setup & Configuration, Meet Your First AI Employee), cross-checked against businessapp-docs and this repo's own /docs/ai/ tree, plus existing partner-call evidence already in learn-revamp/partner-call-insights.md.

Decisions baked in (see the outline doc for full reasoning)

Both steps use the full lab pattern from PROPOSAL-lab-pattern.md (Lab callouts, LabChecklist, "What you now have").
Step 4 is tagged Beginner, step 5 Intermediate.
The AI Employee autonomy level (Level 3: Autonomous default) is included and confirmed directly in-product — it isn't documented anywhere in businessapp-docs yet, which is worth flagging to that docs team separately.
Step 5 stops at one simple tool and defers anything with chained tools/webhooks to the Builder track, to stay out of Cal's territory.
A "reset to default" safety net is described by behavior only, without naming a specific button, since that UI wasn't independently verified.

Not in this PR: steps 3 (Teach it to book), 6 (Autopilot), and 7 (Sell and manage) are still stubs — they need their own outlines and aren't sourced from the uploaded courses.

Testing: checked both files by hand against the working reference implementation (run-your-first-snapshot.mdx) and confirmed all JSX/markdown syntax is balanced. Could not run a full npm run build in the sandbox this was drafted in — recommend running that locally before merge.