### PR TITLE
Docs: rename Inbox to Conversations in automations reference (AUT-4491)

### DIFF
--- a/docusaurus/docs/automations/automation-steps-reference.mdx
+++ b/docusaurus/docs/automations/automation-steps-reference.mdx
@@ -155,11 +155,11 @@ Steps marked **(draft)** are in development and may change or be removed before 
 | Add tags to the account | Adds one or more tags to the account. | Available on account-scoped triggers. | When a product is activated, tag the account with the product name for reporting. |
 | Remove tags from the account | Removes one or more tags from the account. | Available on account-scoped triggers. | When a trial ends without conversion, remove the **Active Trial** tag. |
 
-## Inbox
+## Conversations
 
 | Step | Overview | Special Cases | Example Use Cases |
 | --- | --- | --- | --- |
-| Send an Inbox message | Sends a message to the account's Inbox. | Available on account-scoped triggers. | When an account is created, drop a welcome message from the assigned salesperson into the Inbox. |
+| Send a Conversations message | Sends a message to the account's Conversations inbox. | Available on account-scoped triggers. | When an account is created, drop a welcome message from the assigned salesperson into Conversations. |
 | Send a public system message | Sends a public system message visible to everyone on the account. | Available on account-scoped triggers. | When an outage is resolved, post an all-clear system message. |
 | Send an SMS message via Conversations | Sends an SMS message via your Conversations inbox to a contact. | Available on contact-scoped triggers. | When a hot lead is flagged, text the contact a link to book a meeting. |
 | Send an SMS message to a phone number | Sends an SMS to any phone number you specify, including numbers not in your CRM. | | When a lead fills out a high-intent form, send an SMS to the on-call salesperson. |

--- a/docusaurus/docs/automations/automation-triggers-reference.mdx
+++ b/docusaurus/docs/automations/automation-triggers-reference.mdx
@@ -120,14 +120,14 @@ Triggers marked **(draft)** are in development and may change or be removed befo
 | An invoice status changes to past due | Starts the workflow when an invoice's status changes to **Past due**. | | When an invoice goes past due, start a dunning sequence of reminder emails. |
 | A user on an account makes a payment | Starts the workflow when a customer makes a payment. You can filter on success, failure, or both. | | When a payment fails, start a dunning process to ensure payment is collected. |
 
-## Inbox
+## Conversations
 
 | Trigger | Overview | Special Cases | Example Use Cases |
 | --- | --- | --- | --- |
 | A contact communication summary is created | Starts the workflow when an AI-generated communication summary is created for a contact. | | When a summary is created, attach it as a note to the associated opportunity. |
 | Web Chat captures a lead | Starts the workflow when Web Chat captures a new lead. | | When Web Chat captures a lead, create a contact and notify the assigned salesperson. |
 | A contact requests a follow up (AI conversation event) *(draft)* | Starts the workflow when an AI conversation flags a follow-up request from a contact. | | |
-| An Inbox message is sent to (or received from) an account | Starts the workflow when an Inbox message is sent or received on an account. | | When a message is received, log the interaction as an activity on the account. |
+| A Conversations message is sent to (or received from) an account | Starts the workflow when a Conversations message is sent or received on an account. | | When a message is received, log the interaction as an activity on the account. |
 
 ## Manual
 


### PR DESCRIPTION
## JIRA

[AUT-4491](https://vendasta.jira.com/browse/AUT-4491) — "Show updated product names to users"

## Classification

UI/UX naming change (product rename reflected in documentation copy).

## Repo targeted

**Partner Center** docs (`vendasta/partnercenter-docs`).

The Business App docs repo (`vendasta/businessapp-docs`) was also checked — its automations reference pages (`automation-steps.mdx`, `automation-triggers.md`) already use "Conversations" with no remaining "Inbox" naming, so no changes were needed there. No PR is being opened for that repo.

## Summary of documentation updates

The ticket's acceptance criterion is: *"Look for the name 'Inbox' everywhere in automations and update it to be 'Conversations' — names updated in partner and smb automations."*

In the Partner Center automations reference, the "Inbox" trigger/step category and its entries were the only remaining occurrences of the old name:

- `docusaurus/docs/automations/automation-triggers-reference.mdx`
  - `## Inbox` → `## Conversations`
  - Trigger renamed: "An Inbox message is sent to (or received from) an account" → "A Conversations message is sent to (or received from) an account" (overview text updated to match)
- `docusaurus/docs/automations/automation-steps-reference.mdx`
  - `## Inbox` → `## Conversations`
  - Step renamed: "Send an Inbox message" → "Send a Conversations message" (overview and example use case updated to match)

This also resolves an existing inconsistency in `automation-steps-reference.mdx`, where a neighboring row ("Send an SMS message via Conversations") already used the new name while the Inbox-message row hadn't been updated.

## Existing docs updated vs. new docs created

Existing docs updated only — no new pages were created. This is a scoped terminology fix within existing reference tables.

## Placement reasoning

Both edits are inline replacements within existing `## Inbox` sections of the automations trigger/step reference tables — no structural or navigation changes were needed.

## Acceptance criteria coverage

| Criterion | Status |
|---|---|
| Look for "Inbox" everywhere in automations and rename to "Conversations" | ✅ Done — the two remaining automations-reference occurrences were updated |
| Names updated in partner and SMB automations | ✅ Partner Center automations reference updated in this PR; Business App automations docs already used "Conversations" (verified, no change needed) |

## Figma / images

None provided or used — this is a text-only rename based on the ticket description.

## Skills / tools used

- Jira MCP tools (`getJiraIssue`, `getAccessibleAtlassianResources`, `getJiraIssueRemoteIssueLinks`, `searchJiraIssuesUsingJql`) to pull the ticket, its parent epic (AUT-3908, "2026 sand items"), and epic siblings
- Explore subagents (Grep-based) to search both docs repos for all "Inbox" occurrences and distinguish the renamed feature from unrelated generic "inbox" usage

## Assumptions / limitations

- **Rollout check:** AUT-4491's parent epic (AUT-3908, "2026 sand items") is a general backlog/grab-bag epic, not a feature-launch epic — it's still "To Do" only because it never closes, not because this specific rename is gated. Its open sibling tickets were scanned for feature-flag/eligibility/rollout-gating signals (keywords like "flag", "toggle", "eligib", "region", "rollout") and none were found relevant to this rename. AUT-4491 itself is `Done` with merged PRs. Proceeding was judged safe, but this is a heuristic, not a rollout guarantee.
- **Reviewer assignment:** GitHub access in this session is scoped only to the two docs repos, so I couldn't look up the linked code PR(s) or their author(s) to add as a reviewer, and no GitHub PR link surfaced via Jira's remote-links API (only a Confluence "mentioned in" link was found). No reviewer has been assigned as a result — please add the appropriate developer manually.
- **Scope:** Left unchanged several other Partner Center pages that still say "Inbox" as a UI/feature reference (e.g. `business-app/conversations/index.mdx`, `conversations-ai/understanding-lead-capture-notifications.mdx`, `multi-location-business-app/conversations/inbox-in-multi-location.mdx`, and some stale `img/partner-center-inbox/` asset-folder names). These are outside this ticket's stated scope (automations only) and are flagged here for a possible separate follow-up rather than bundled into this change.

---

cc @ahnikakuse @haleyserrano @maryam6samadi


---
_Generated by [Claude Code](https://claude.ai/code/session_012T8AHekPb6JSLf72YkyNZc)_

[AUT-4491]: https://vendasta.jira.com/browse/AUT-4491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ