### PR TITLE
docs(business-app): note that the classic welcome email can be resent

### DIFF
--- a/docusaurus/docs/business-app/ai-onboarding-experience.mdx
+++ b/docusaurus/docs/business-app/ai-onboarding-experience.mdx
@@ -124,6 +124,10 @@ You don't have to create a brand-new user to use the onboarding email. You can s
 
 This is handy for re-triggering the experience for someone already set up — and it's also the easiest way to see the real email yourself: add yourself as a user on the account and send it to your own inbox.
 
+:::note
+The classic **welcome email** is always available too. To send it after a user has been created, open the **options menu (⋮)** next to the user's name — either on the account or in **Accounts → Manage Users** — and click **Resend Welcome Email**.
+:::
+
 <img src={require('./img/ai-onboarding-create-user.png').default} alt="The Create User form with the 'Send Onboarding Email' checkbox selected by default and a Preview button beside it" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
 
 ### Previewing before you send
@@ -246,7 +250,14 @@ Note that turning off the "AI has done the work" card in Customize Business App 
 <details>
 <summary>Do I have to use the onboarding email instead of the welcome email?</summary>
 
-In the create-user flow the onboarding email is selected by default and replaces the classic welcome email for that user. It's the recommended way to bring new SMBs into Business App because it shows value up front. If you'd rather send the classic welcome email, clear the **Send Onboarding Email** checkbox. For fully custom messaging, you can also use a Marketing Campaign.
+No. In the create-user flow the onboarding email is selected by default and replaces the classic welcome email for that user, because it shows value up front — but it's your choice. If you'd rather send the classic welcome email, clear the **Send Onboarding Email** checkbox. For fully custom messaging, you can also use a Marketing Campaign.
+
+</details>
+
+<details>
+<summary>Can I still send the classic welcome email after a user is created?</summary>
+
+Yes. The classic welcome email is always available. Open the **options menu (⋮)** next to the user's name — either on the account or in **Accounts → Manage Users** — and click **Resend Welcome Email**. This is useful for password resets or any time you'd prefer the standard welcome email over the onboarding email.
 
 </details>
 


### PR DESCRIPTION
Small follow-up to the merged **AI onboarding experience** page ([#799](https://github.com/vendasta/partnercenter-docs/pull/799)).

Adds reassurance that partners can still send the classic welcome email after a user has been created:

- **Note banner** under "Sending it to an existing user" — open the user's **options menu (⋮)** (on the account or in **Accounts → Manage Users**) and click **Resend Welcome Email**.
- **New FAQ** — "Can I still send the classic welcome email after a user is created?" with the same steps.
- Tightened the neighboring "Do I have to use the onboarding email…" answer to open with a clear "No."

🤖 Generated with [Claude Code](https://claude.com/claude-code)