### PR TITLE
Remove outdated white-label presentation section from Business App intro

### DIFF
--- a/docusaurus/training/products/engage/business-app/introduction-to-business-app.mdx
+++ b/docusaurus/training/products/engage/business-app/introduction-to-business-app.mdx
@@ -21,7 +21,6 @@ Welcome to the Vendasta Academy's Business App Masterclass! During this course, 
 - How Business App helps local businesses attract, convert, and engage customers
 - The recommended product package and what each product does
 - How to perform impactful demos and follow Vendasta's sales playbook
-- How to use the white-label presentation to pitch to SMB prospects
 :::
 
 ---
@@ -59,28 +58,6 @@ The recommended package includes:
 Business App streamlines these essential elements into one platform for exceptional customer experiences.
 
 ---
-
-<div className="principle-area"><span className="principle-area__icon">📽️</span>Optional: White-Label Presentation</div>
-
-We've created a white-label version of the Business App presentation you can use with your SMB prospects.
-
-### How to use the deck
-
-1. Make a copy of the presentation
-
-2. Edit the theme
-
-3. Replace logos and image elements in the theme with your own branding
-
-4. Replace the colors in the theme to match your brand
-
-5. Exit the theme editor and change any remaining elements as needed
-
-6. Delete (or hide) the how-to slides, then practice and deliver your pitch!
-
-:::tip Presentation Link
-See the course materials for the link to the Google Slides presentation.
-:::
 
 <div className="in-practice">
   <span className="in-practice__icon">💬</span>


### PR DESCRIPTION
## Summary
- Removed the "Optional: White-Label Presentation" section (how-to-use-the-deck steps and Google Slides link callout) from `introduction-to-business-app.mdx` — it's no longer relevant
- Dropped the corresponding "How to use the white-label presentation to pitch to SMB prospects" bullet from the "What You'll Learn" tip box

## Test plan
- [x] `npx docusaurus build` succeeds (pre-existing broken-link/anchor warnings elsewhere in the site are unrelated to this file)
- [ ] Spot-check the page renders correctly in the deployed preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)