### PR TITLE
docs(business-app): add "Recommended for your business" cards configuration sub-article

### DIFF
--- a/docusaurus/docs/business-app/ai-onboarding-experience.mdx
+++ b/docusaurus/docs/business-app/ai-onboarding-experience.mdx
@@ -183,6 +183,10 @@ Each card's button adapts to the account's state:
 
 When an SMB completes an upgrade, payment is collected through **Vendasta Payments** if you have it enabled — the SMB enters their card and checks out right from Home. If you don't use Vendasta Payments, the upgrade is sent to you as an **order** to process through your normal flow.
 
+:::tip
+For a full breakdown of how each card decides what to show and how to configure the upgrade path per product, see [Customizing the "Recommended for your business" cards](/business-app/recommended-cards-configuration).
+:::
+
 ## How SMBs dismiss the cards
 
 SMBs stay in control of their own dashboard. Both the work-done card and the product upgrade cards can be dismissed:
@@ -284,6 +288,7 @@ The AI onboarding experience is available to Early Access partners first. To tur
 
 ## Related
 
+- [Customizing the "Recommended for your business" cards](/business-app/recommended-cards-configuration) — how the upgrade cards decide what to show, and configuring each product's upgrade path
 - [Home Overview](/business-app/home) — the Business App Home dashboard your clients see
 - [Customizing the welcome email](/accounts/manage-users/welcome-email) — the classic welcome email and Marketing Campaign workaround
 - [Manage Users](/accounts/manage-users) — creating and managing Business App users

--- a/docusaurus/docs/business-app/recommended-cards-configuration.mdx
+++ b/docusaurus/docs/business-app/recommended-cards-configuration.mdx
@@ -1,0 +1,73 @@
+---
+title: Customizing the "Recommended for your business" cards
+sidebar_label: Recommended cards
+sidebar_position: 4
+description: How the product upgrade cards on Business App Home decide what to show, and how to configure each product's upgrade path so the cards drive the outcome you want.
+tags: [business-app, home, upgrades, marketplace, editions, ai, early-access]
+keywords: [recommended for your business, upgrade cards, get started, contact us, self-serve upgrade, store packages, contact sales, edition upgrade, Vendasta Payments]
+---
+
+# Customizing the "Recommended for your business" cards
+
+The **Recommended for \[business name\]** cards on Business App Home let an SMB add your core AI products — Local SEO, Conversations AI, Reputation AI, and Social AI — without leaving Home. They're part of the [AI onboarding experience](/business-app/ai-onboarding-experience).
+
+Each card leads with a benefit headline and a button. **What the button does is driven entirely by your own product setup** — whether you sell the product, whether it's already active, and how you've configured its upgrade path. This page explains how a card decides what to show and how to configure the outcome you want.
+
+## Watch the overview
+
+<div style={{position: 'relative', paddingBottom: '56.25%', height: 0, overflow: 'hidden', borderRadius: '8px', border: '1px solid #e0e0e0', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}}>
+  <iframe src="https://drive.google.com/file/d/1FUvA18eq7GKz0P2KMKL4CgFKP8PM-hqV/preview" style={{position: 'absolute', top: 0, left: 0, width: '100%', height: '100%'}} frameBorder="0" allow="autoplay" allowFullScreen title="Customizing the Recommended for your business cards"></iframe>
+</div>
+
+{/* NOTE: this Google video must be shared publicly (Anyone with the link) for partners to play it. */}
+
+## How a card decides what to show
+
+These cards are designed to move SMBs up to the **Pro (or higher)** edition of a product. A card evaluates your setup for that product and the account's current state, then shows one of the following:
+
+| The card shows | When |
+|---|---|
+| **Get started** | You sell the product with an upgrade path clients can complete themselves — either a **self-serve upgrade** or **store packages** to display. Opens the upgrade flow right in Business App. |
+| **Contact us** | You sell the product but route upgrades to your team (**Contact sales**). Opens the contact card in Business App instead of a checkout. |
+| **Open \[product\]** | The product is already active at **Pro or higher**. The card becomes a link straight into the product. |
+| **Activating. This will only take a few moments.** | The product is mid-provisioning. No button appears until it finishes. |
+| *(the card is hidden)* | You don't sell the product, or the account is suspended. |
+
+In short: **if you sell the product and have an upgrade turned on, the card shows.** If the SMB is on a Pro/Premium edition already, the card links them into the product. If they're on Standard or have no active edition, the card invites the upgrade with **Get started** or **Contact us**, depending on how you've set the product up.
+
+## Configuring the upgrade path for each product
+
+You control the button by configuring each product's upgrade path in Partner Center. The same setup that governs how clients buy and upgrade elsewhere is what these cards follow — there's nothing separate to configure for the cards themselves.
+
+Go to **Partner Center → Marketplace → Manage Products** and open the product (Local SEO, Conversations AI, Reputation AI, or Social AI). In the product's settings, choose how a client can move up an edition:
+
+- **Self-serve upgrade** — the client completes the upgrade themselves. The card shows **Get started**.
+- **Store packages** — you surface your store packages for the client to choose from. The card shows **Get started** and opens those options.
+- **Contact sales** — the upgrade is handled by your team. The card shows **Contact us**, which opens the contact card in Business App.
+
+:::tip
+Want the cards to drive self-serve revenue? Configure your core products for a **self-serve upgrade** (or store packages) so the cards show **Get started** rather than **Contact us**.
+:::
+
+### How the client completes an upgrade
+
+When the card shows **Get started**, the upgrade follows your existing commerce setup — the cards don't change how you get paid:
+
+- **If you use Vendasta Payments**, the client enters their card and **buys the upgrade** right from Home.
+- **If you don't use Vendasta Payments**, the upgrade is submitted to you as an **order** to process through your normal flow.
+
+For how an edition upgrade is billed (including proration on Vendasta's own products), see [Edition changes and proration](/marketplace/products/edition-changes).
+
+## Turning the cards off
+
+If you'd rather not show the upgrade cards at all, you can turn them off for every SMB. Go to **Partner Center → Administration → Customize Business App → Pages → Home**, and under **Page Features** clear **"Recommended for your business" cards**. Remember to click **Save**.
+
+:::info
+This toggle controls the whole section for all of your SMBs. Individual SMBs can also dismiss cards for themselves — see [How SMBs dismiss the cards](/business-app/ai-onboarding-experience#how-smbs-dismiss-the-cards).
+:::
+
+## Related
+
+- [AI onboarding experience](/business-app/ai-onboarding-experience) — the onboarding email and Home cards this section is part of
+- [Edition changes and proration](/marketplace/products/edition-changes) — how upgrades are billed
+- [Manage Products](/marketplace/products) — configuring your products and their upgrade paths


### PR DESCRIPTION
Adds a sub-article to the **AI onboarding experience** page: **[Customizing the "Recommended for your business" cards](docusaurus/docs/business-app/recommended-cards-configuration.mdx)**.

## What it covers
- **Embedded overview video.**
- **How a card decides what to show** — a table mapping the partner's product setup to the card state: **Get started**, **Contact us**, **Open [product]** (Pro+ active), **Activating…**, or hidden.
- **Configuring the upgrade path per product** (Local SEO, Conversations AI, Reputation AI, Social AI) in **Marketplace → Manage Products**: self-serve upgrade / store packages → **Get started**; Contact sales → **Contact us**.
- **How the upgrade completes** — Vendasta Payments (client buys) vs. an order submitted to the partner.
- **Turning the cards off** from Customize Business App.

## Cross-links
- Added a tip in the AI onboarding page's "Product upgrade cards" section and a Related entry pointing here.
- Links out to [Edition changes and proration](/marketplace/products/edition-changes) for upgrade billing.

Placed at `sidebar_position: 4`, directly after the AI onboarding experience page. Structural checks pass (no stray blockquotes, callouts balanced, all internal links resolve); relying on the PR build check for full verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)