### PR TITLE
docs(learn): link AI foundations lessons to Partner Center docs

### DIFF
--- a/docusaurus/training/ai-foundations/agents-and-automations-together.mdx
+++ b/docusaurus/training/ai-foundations/agents-and-automations-together.mdx
@@ -31,7 +31,7 @@ import LessonFooter from "@site/src/components/LessonFooter";
 
 ## Two kinds of help
 
-Workflows carry the routine; a worker stands at the judgment moments. Composing the two deliberately starts with telling them apart: the [automation](/automations) is a workflow you design, and the AI Employee is a worker you brief. Each deserves exactly one sentence:
+Workflows carry the routine; a worker stands at the judgment moments. Composing the two deliberately starts with telling them apart: the [automation](/automations) is a workflow you design, and the [AI Employee](/ai) is a worker you brief. Each deserves exactly one sentence:
 
 - **An automation is deterministic:** the same trigger runs the same steps and produces the same result, every time.
 - **An AI Employee is agentic:** it reads each situation and exercises judgment, so no two interactions are handled identically.

--- a/docusaurus/training/ai-foundations/context-is-everything.mdx
+++ b/docusaurus/training/ai-foundations/context-is-everything.mdx
@@ -65,7 +65,7 @@ Fresh beats abundant, too. A lean library of current documents outperforms a lar
 
 ## See exactly what an answer used
 
-Every AI Employee answer is auditable. Open any response in Conversations and select **Explanation** to see which knowledge the AI retrieved and referenced for that specific reply. It is the fastest way to tune a library: when an answer misses, the Explanation shows you whether the right knowledge was missing, outdated, or crowded out.
+Every AI Employee answer is auditable. Open any response in Conversations and select **[Explanation](/ai/ai-workforce)** to see which knowledge the AI retrieved and referenced for that specific reply. It is the fastest way to tune a library: when an answer misses, the Explanation shows you whether the right knowledge was missing, outdated, or crowded out.
 
 :::tip Try it now
 Open one client's website and write two short lists: three questions their customers ask that the site answers, and three it does not. The second list is the start of that client's written knowledge entries, and it took you two minutes.

--- a/docusaurus/training/ai-foundations/from-work-to-ai-workforce.mdx
+++ b/docusaurus/training/ai-foundations/from-work-to-ai-workforce.mdx
@@ -62,7 +62,7 @@ For the first time, there is something to put on the other end of a workflow: a 
 
 ## The merger is the platform
 
-Put the two together and you have the platform's whole story. **Automations** carry the rule-shaped work: deterministic, dependable, the same steps every time. **AI Employees** stand at the judgment moments: agentic, conversational, deciding what each situation deserves, around the clock. And each hands work to the other. A workflow sends the review request; an AI Employee answers the review it brings back. An AI Employee captures a lead in webchat; a workflow starts the follow-up the moment the chat ends.
+Put the two together and you have the platform's whole story. **[Automations](/automations)** carry the rule-shaped work: deterministic, dependable, the same steps every time. **[AI Employees](/ai)** stand at the judgment moments: agentic, conversational, deciding what each situation deserves, around the clock. And each hands work to the other. A workflow sends the review request; an AI Employee answers the review it brings back. An AI Employee captures a lead in webchat; a workflow starts the follow-up the moment the chat ends.
 
 The whole story fits in three sentences: a business already automates the routine; what it could never automate was the conversation and the judgment, so that work always waited for staffed hours; now there is a worker for it, it never clocks out, and it works hand in hand with the automation already in place.
 

--- a/docusaurus/training/ai-foundations/instructions-that-scale.mdx
+++ b/docusaurus/training/ai-foundations/instructions-that-scale.mdx
@@ -31,7 +31,7 @@ import LessonFooter from "@site/src/components/LessonFooter";
 
 ## Skills you switch on
 
-Instructions are the context source you shape most directly, and the platform organizes them into capabilities: discrete skills you enable for an AI Employee, like capture a lead, book an appointment, or answer from knowledge. Each capability is a set of instructions, sometimes with a tool attached, and an employee can carry several at once. Here is where they sit in the whole:
+Instructions are the context source you shape most directly, and the platform organizes them into [capabilities](/ai/ai-capabilities): discrete skills you enable for an AI Employee, like capture a lead, book an appointment, or answer from knowledge. Each capability is a set of instructions, sometimes with a tool attached, and an employee can carry several at once. Here is where they sit in the whole:
 
 <div style={{border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)', padding: '8px', background: '#ffffff', marginBottom: '28px'}}>
 
@@ -74,6 +74,10 @@ Structure helps too: short lines and numbered steps outperform paragraphs, for m
 
 :::tip Try it now
 Pick one thing a client's receptionist does every day and write it as a capability brief in three sentences: when to act, what must be true first, and what done looks like. That is instruction-writing, and you just did it.
+:::
+
+:::info Go deeper
+Ready to configure one for real? [The capabilities overview](/ai/ai-capabilities) covers the full anatomy, [configuring capabilities](/ai/ai-capabilities/configuring-capabilities) walks through the built-in skills, and [creating custom capabilities](/ai/ai-capabilities/creating-custom-capabilities) covers building your own.
 :::
 
 <SectionFeedback courseId="instructions-that-scale" site="vendasta_learn" section="content" />

--- a/docusaurus/training/ai-foundations/taking-action.mdx
+++ b/docusaurus/training/ai-foundations/taking-action.mdx
@@ -54,7 +54,7 @@ Sooner or later a client asks the reasonable question: "so the AI can just do th
 2. **Each doorway is scoped to one job.** The availability checker checks availability. Adding a second job means deliberately adding a second doorway.
 3. **The AI never holds the keys.** Credentials for connected systems stay outside the conversation and outside the model. The employee uses the doorway; it never sees what unlocks the door.
 
-Judgment stays where it belongs, too: with you. Which doorways exist, and which employees get them, is a configuration decision a person makes, and reviewing how they are used is part of running a workforce. The **Explanation** view covers this side as well: it shows which tools an answer called and what came back, so every action is as auditable as every fact.
+Judgment stays where it belongs, too: with you. Which doorways exist, and which employees get them, is a configuration decision a person makes, and reviewing how they are used is part of running a workforce. The **[Explanation](/ai/ai-workforce)** view covers this side as well: it shows which tools an answer called and what came back, so every action is as auditable as every fact.
 
 :::tip Try it now
 Name one system a client uses every day: their booking software, their point of sale, their online store. Now write the single question a receptionist could answer instantly with a doorway into it. That question is a tool waiting to be configured.


### PR DESCRIPTION
## Summary
- Adds inline links from the 5 AI foundations Learn lessons to the Partner Center docs that cover the concepts they teach (previously zero Partner Center links existed in this path)
- Adds one `:::info Go deeper` callout on `instructions-that-scale.mdx`, bundling the three capabilities docs, since that lesson's whole subject is capabilities
- `how-ai-employees-think.mdx` is intentionally untouched — no Partner Center doc currently covers its content (only an external Business App docs link exists there already)
- No existing lesson prose was reworded; every change is additive (a linked word/phrase or the one new callout)

## Test plan
- [x] Started the local Docusaurus dev server and rendered all 5 changed lesson pages in a headless browser
- [x] Verified every new/existing link resolves to the correct `href` on each page
- [x] Verified the new "Go deeper" callout renders visually distinct from the existing "Try it now" tips
- [x] Confirmed zero browser console errors on any of the 5 pages
- [ ] Human review of wording/placement per repo convention (learning path content should get a human pass before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)