### PR TITLE
Docs: booking form prefills known contact details (VS-1374)

### DIFF
--- a/docusaurus/docs/crm/my-meetings/book-a-meeting-from-crm-contacts.mdx
+++ b/docusaurus/docs/crm/my-meetings/book-a-meeting-from-crm-contacts.mdx
@@ -25,6 +25,8 @@ This feature **sends the contact an email** so they can choose their own time sl
 
 The contact receives an email containing your booking link. They click the link, choose an available date and time, and confirm the booking. The meeting is then added to your calendar automatically.
 
+Because the link is generated from the contact's profile, the booking form automatically fills in their known name, email, and phone number — so they don't have to re-enter details already on file. These fields stay fully editable, so the contact can update or clear any value before confirming, and any detail that isn't on file is simply left blank for them to fill in.
+
 ## Customizing the invitation email
 
 The subject and description of the meeting request email come from the **Customize invitation email** settings on each event type. To personalize the message:


### PR DESCRIPTION
## JIRA
[VS-1374](https://vendasta.jira.com/browse/VS-1374) — Contact prefill from query params in the new booking form

## Classification
- **Type:** UI/UX change (guest-facing booking form behavior)
- **Repo targeted:** Partner Center

## Summary
When a meeting request is sent from a CRM contact's profile, the booking link is now tied to that contact's record. This update documents that the booking form the contact sees automatically fills in their known name, email, and phone number, so they don't have to re-enter information already on file.

## Existing vs. new docs
**Updated existing page** — `docusaurus/docs/crm/my-meetings/book-a-meeting-from-crm-contacts.mdx`

## Placement reasoning
This page already documents the exact flow the change affects (sending a meeting request from a CRM contact's profile → contact receives an email with a booking link → contact books). The new behavior is a direct extension of that flow, so it was added as a short paragraph immediately after the existing description of what happens when the contact clicks the link — no new page or section was warranted.

## Acceptance criteria coverage
| Acceptance criterion | Covered |
|---|---|
| Opening the form with supported query params prefills matching contact fields | ✅ |
| Prefilled fields are editable — the guest can change or clear any value | ✅ |
| Missing/empty params leave fields blank; no errors | ✅ |
| Query-param values are never auto-submitted and never grant access | ✅ (implied via "before confirming" framing; exact param names/mechanics are intentionally omitted as a technical implementation detail not appropriate for end-user docs) |

## Figma / images
None provided or used. Ticket description and acceptance criteria (text) were the only source material.

## Skills used
- Manual validation against this repo's markdown rules (no `>` characters, sentence-case headings, frontmatter format) — no dedicated pre-push skill exists in this repo

## Assumptions / limitations
- The story's parent epic (VS-925, "Tech Improvements") is a general tech-debt tracking epic and is still "In Progress." Its one open sibling ticket (VS-1363, proto cleanup) is unrelated tech debt with no feature-gating, flag, or eligibility signals, so this was treated as safe to document rather than held pending rollout.
- Could not confirm the exact PR author(s)/reviewer from linked GitHub PRs — this session's GitHub access is scoped only to `vendasta/businessapp-docs` and `vendasta/partnercenter-docs`, not the implementing repos (galaxy/meetings/bookme-client). No reviewer was set as a result.
- Documentation intentionally describes user-visible behavior only (what prefills, that it's editable, that missing data leaves blanks) and does not enumerate specific query parameter names, since those aren't meant to be manually constructed by end users and weren't specified as user-facing configuration in the source ticket.

@ahnikakuse @haleyserrano @maryam6samadi

---
_Generated by [Claude Code](https://claude.ai/code/session_01MakUTaVYknN8JVgeX7RPHU)_

[VS-1374]: https://vendasta.jira.com/browse/VS-1374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ