### PR TITLE
Docs: Personalization failed badge for multi-location posts (SM-4194)

### DIFF
--- a/docusaurus/docs/multi-location-business-app/social/manage-posts-social-multi-location.mdx
+++ b/docusaurus/docs/multi-location-business-app/social/manage-posts-social-multi-location.mdx
@@ -50,6 +50,7 @@ When viewing drafts, use the filter type that matches your workflow:
 - You can see where a post exists (draft, scheduled, published) across all linked locations.  
 - Clicking on a **social network icon** will take you directly to that network view for the selected location.  
 - For failed posts, you’ll see the exact location where the post failed and the related error message.  
+- If personalizing the content for one or more locations fails, the post displays a **Personalization failed** badge instead. Hovering over the badge shows: *Personalization for each location couldn't be completed. Please delete this post and create a new one to try again.* This applies on both web and mobile.  
 
 ### Editing posts
 
@@ -164,4 +165,10 @@ The draft is removed from the multi-location group and all associated single-loc
 <summary>Are failed posts automatically retried?</summary>
 
 No. You’ll need to manually edit and reschedule the failed post.
+</details>
+
+<details>
+<summary>What does the "Personalization failed" badge mean?</summary>
+
+This badge appears on a multi-location post when personalizing the content for one or more locations couldn't be completed. Unlike other failed posts, you can't edit or reattempt these — delete the post and create a new one to try again.
 </details>


### PR DESCRIPTION
## JIRA
[SM-4194](https://vendasta.jira.com/browse/SM-4194) — Localization - Personalization failed and Tooltip

## Classification
UI/UX change — new error state (badge + tooltip) for multi-location social posts.

## Repo targeted
Partner Center (multi-location workflow documentation)

## Summary of updates
Updated the existing **Manage Posts in Multi-Location Social** article (`docusaurus/docs/multi-location-business-app/social/manage-posts-social-multi-location.mdx`):

- Added a bullet under "Viewing posts across all locations" documenting the **Personalization failed** badge that replaces the standard per-location error message when content personalization fails for one or more locations, including the exact tooltip copy.
- Added a new FAQ entry clarifying that, unlike other failed posts, these can't be edited or reattempted — the post must be deleted and recreated.

## Existing docs updated vs. new docs created
Updated existing documentation. No new page was created — the article already documents the "Failed" tab and per-location error surfacing for multi-location posts, so this new failure mode fits directly alongside it.

## Placement reasoning
This is the Partner Center article that already covers multi-location post statuses (Drafts/Scheduled/Published/Failed) and per-location error detail, making it the natural home for this new failure state rather than a new page.

## Acceptance criteria coverage
1. "Personalization failed" badge displayed on the post — documented.
2. Tooltip text on hover — documented verbatim.
3. Applicable to web and mobile — documented.
4. Applicable to multi-location only — documented (this doc is scoped entirely to multi-location).

## Figma / images
None provided directly on the ticket usable here (two Jira attachments show the production UI, but they aren't accessible as image assets for this repo). Documentation is text-based per the acceptance criteria and confirmed via ticket comments describing the production behavior.

## Skills used
None of the repo's specific skills applied; changes were validated manually against this repo's CLAUDE.md markdown rules (no `>` blockquote characters, closed `<details>`/`<summary>` tags, valid frontmatter).

## Assumptions / limitations
- The parent epic (SM-1337, "UX Improvements — Social Marketing & Business App Social") is not marked Done and is a large, ongoing umbrella epic (~95 linked tickets spanning many unrelated features). No sibling tickets under it show feature-flag/eligibility/rollout-gating signals for this specific personalization-failure badge. The story itself is Done, and ticket comments from the developer confirm the change is live in production ("The changes has been moved to production...").
- Per the linked PR (`vendasta/galaxy#33519`), edit/schedule actions are hidden for posts in this failed state — only delete-and-recreate is supported. Called out explicitly since the existing "Can I fix failed posts?" FAQ (for generic failures) says edit/reattempt is possible — this new FAQ entry distinguishes the personalization-failure case.
- No screenshot was added since the Jira attachments weren't accessible as image files for this repo.

cc @ahnikakuse @haleyserrano @maryam6samadi

---
_Generated by [Claude Code](https://claude.ai/code/session_013s1HRtkXAHLbPHGsib7kUj)_

[SM-4194]: https://vendasta.jira.com/browse/SM-4194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ