### PR TITLE
docs(ai): link Partner Center AI docs to the AI foundations course

### DIFF
--- a/docusaurus/docs/ai/ai-capabilities/configuring-capabilities.md
+++ b/docusaurus/docs/ai/ai-capabilities/configuring-capabilities.md
@@ -4,7 +4,7 @@ sidebar_label: Configuring Capabilities
 sidebar_position: 2
 ---
 
-import { AISparkleIcon } from '@site/src/components/Icons';
+import { AISparkleIcon, GraduationCapIcon } from '@site/src/components/Icons';
 
 This guide walks you through enabling and configuring built-in capabilities for your AI Employees. Follow these steps to set up capabilities that handle common business tasks like lead capture and appointment booking.
 
@@ -230,5 +230,12 @@ Track key metrics to measure capability effectiveness:
 - **Integration Setup**: Connect external systems to enhance capability functionality
 
 Need help with specific capability configurations? Check our [troubleshooting guide](#troubleshooting-common-issues) or contact support for personalized assistance.
+
+<div style={{display: 'flex', alignItems: 'center', gap: '12px', background: 'rgba(60, 154, 99, 0.08)', border: '1px solid rgba(60, 154, 99, 0.35)', borderRadius: '8px', padding: '14px 18px', margin: '16px 0'}}>
+  <span style={{flexShrink: 0}}><GraduationCapIcon size={26} /></span>
+  <span style={{fontSize: '14px', color: 'var(--ifm-font-color-base)'}}>
+    New to how AI Employees work? Take the <a href="/learn/ai-foundations" style={{color: '#3C9A63', fontWeight: 600}}>AI foundations</a> course in Vendasta Learn — Beginner, 6 lessons.
+  </span>
+</div>
 
 

--- a/docusaurus/docs/ai/ai-capabilities/creating-custom-capabilities.md
+++ b/docusaurus/docs/ai/ai-capabilities/creating-custom-capabilities.md
@@ -7,7 +7,7 @@ tags: [ai-capabilities, custom-capabilities, ai-workforce, integrations]
 keywords: [custom capabilities, AI capabilities, tools, integrations, API, AI Employees, prompts, testing]
 ---
 
-import { AISparkleIcon } from '@site/src/components/Icons';
+import { AISparkleIcon, GraduationCapIcon } from '@site/src/components/Icons';
 
 This guide walks you through creating custom capabilities that connect your AI Employees to external systems and APIs. Custom capabilities enable specialized business functions like inventory checking, appointment booking, and order tracking.
 
@@ -424,3 +424,10 @@ The value at the end of the path is the `product_id`.
 :::tip
 For the AI Chat Receptionist, see [Make responses page-aware with the visitor's URL](../ai-workforce/ai-chat-receptionist/index.md#make-responses-page-aware-with-the-visitors-url) for the broader feature overview.
 :::
+
+<div style={{display: 'flex', alignItems: 'center', gap: '12px', background: 'rgba(60, 154, 99, 0.08)', border: '1px solid rgba(60, 154, 99, 0.35)', borderRadius: '8px', padding: '14px 18px', margin: '16px 0'}}>
+  <span style={{flexShrink: 0}}><GraduationCapIcon size={26} /></span>
+  <span style={{fontSize: '14px', color: 'var(--ifm-font-color-base)'}}>
+    New to how AI Employees work? Take the <a href="/learn/ai-foundations" style={{color: '#3C9A63', fontWeight: 600}}>AI foundations</a> course in Vendasta Learn — Beginner, 6 lessons.
+  </span>
+</div>

--- a/docusaurus/docs/ai/ai-capabilities/index.md
+++ b/docusaurus/docs/ai/ai-capabilities/index.md
@@ -6,6 +6,8 @@ tags: [ai-capabilities, capabilities, ai-employees, custom-capabilities, automat
 keywords: [AI capabilities, capabilities, custom capabilities, AI employees, automation, tools, integrations, lead capture, appointment booking]
 ---
 
+import { GraduationCapIcon } from '@site/src/components/Icons';
+
 AI Capabilities are specialized skills that define what your AI Employees can do and how they behave when interacting with customers. Think of capabilities as building blocks that transform a basic AI assistant into a skilled employee who can handle specific business tasks.
 
 ## What are AI Capabilities?
@@ -128,3 +130,12 @@ Use the Explanations feature in Conversations to understand:
 - When the AI chooses not to use a capability and why
 - How well your trigger conditions are working in practice
 :::
+
+---
+
+<div style={{display: 'flex', alignItems: 'center', gap: '12px', background: 'rgba(60, 154, 99, 0.08)', border: '1px solid rgba(60, 154, 99, 0.35)', borderRadius: '8px', padding: '14px 18px', margin: '16px 0'}}>
+  <span style={{flexShrink: 0}}><GraduationCapIcon size={26} /></span>
+  <span style={{fontSize: '14px', color: 'var(--ifm-font-color-base)'}}>
+    New to how AI Employees work? Take the <a href="/learn/ai-foundations" style={{color: '#3C9A63', fontWeight: 600}}>AI foundations</a> course in Vendasta Learn — Beginner, 6 lessons.
+  </span>
+</div>

--- a/docusaurus/docs/ai/ai-workforce/index.mdx
+++ b/docusaurus/docs/ai/ai-workforce/index.mdx
@@ -5,6 +5,8 @@ tags: [ai-workforce, ai, ai-employees, capabilities]
 keywords: [AI workforce, AI employees, capabilities, tools, lead capture, web chat, automations]
 ---
 
+import { GraduationCapIcon } from '@site/src/components/Icons';
+
 AI Employees are digital team members you can configure to automate conversations, answer customer questions, capture leads, book appointments, and more. Each works well out of the box, but can be tailored to fit your business needs.
 
 All AI Employees share a common structure, with configurable elements like their name, purpose, communication channels, capabilities, and knowledge sources. Specific roles (like Chat Receptionist or Voice Receptionist) may include additional options, but the basics are always the same.
@@ -267,5 +269,12 @@ After initial setup, regularly test and optimize your AI Employees to ensure the
 - Keep notes on what works and what doesn't
 - Be patient—optimizing AI Employees is an iterative process that improves over time
 :::
+
+<div style={{display: 'flex', alignItems: 'center', gap: '12px', background: 'rgba(60, 154, 99, 0.08)', border: '1px solid rgba(60, 154, 99, 0.35)', borderRadius: '8px', padding: '14px 18px', margin: '16px 0'}}>
+  <span style={{flexShrink: 0}}><GraduationCapIcon size={26} /></span>
+  <span style={{fontSize: '14px', color: 'var(--ifm-font-color-base)'}}>
+    New to how AI Employees work? Take the <a href="/learn/ai-foundations" style={{color: '#3C9A63', fontWeight: 600}}>AI foundations</a> course in Vendasta Learn — Beginner, 6 lessons.
+  </span>
+</div>
 
 ---

--- a/docusaurus/docs/ai/index.mdx
+++ b/docusaurus/docs/ai/index.mdx
@@ -6,6 +6,8 @@ tags: [ai, ai-workforce, ai-capabilities, automation, partner-center]
 keywords: [AI employees, AI workforce, AI capabilities, chat receptionist, voice receptionist, sales assistant, custom AI employees, knowledge base]
 ---
 
+import { GraduationCapIcon } from '@site/src/components/Icons';
+
 Vendasta's AI platform combines unique business data with AI to automate marketing, sales, and operations — making it easier than ever to attract, convert, and retain customers with less manual work.
 
 ## Why use AI?
@@ -52,3 +54,10 @@ These three components can be mixed and matched to create AI employees that hand
 - **Capabilities** = Instructions on how to behave (proactive, process-based)  
 - **Tools** = Ability to take action in external systems (integration-based)
 :::
+
+<div style={{display: 'flex', alignItems: 'center', gap: '12px', background: 'rgba(60, 154, 99, 0.08)', border: '1px solid rgba(60, 154, 99, 0.35)', borderRadius: '8px', padding: '14px 18px', margin: '16px 0'}}>
+  <span style={{flexShrink: 0}}><GraduationCapIcon size={26} /></span>
+  <span style={{fontSize: '14px', color: 'var(--ifm-font-color-base)'}}>
+    New to how AI Employees work? Take the <a href="/learn/ai-foundations" style={{color: '#3C9A63', fontWeight: 600}}>AI foundations</a> course in Vendasta Learn — Beginner, 6 lessons.
+  </span>
+</div>

--- a/docusaurus/docs/automations/index.mdx
+++ b/docusaurus/docs/automations/index.mdx
@@ -8,6 +8,8 @@ tags: [automations, workflows, automation, partner-center]
 keywords: [automations, workflows, triggers, automation steps, email campaigns, CRM integration]
 ---
 
+import { GraduationCapIcon } from '@site/src/components/Icons';
+
 # Automations overview
 
 Automations help you automate sales and marketing processes. Define workflows in the builder so that when a trigger happens, the platform runs your chosen actions—for example, "When a new client is added, assign a salesperson to the account."
@@ -114,3 +116,10 @@ See [Automation Triggers Reference](./automation-triggers-reference.mdx) and [Au
 - [Automation Templates Overview](./automation-templates-overview.mdx) – Pre-built templates
 
 <a href="https://partners.vendasta.com/automations" target="_blank" rel="noopener">**Create an Automation**</a> (Partner Center)
+
+<div style={{display: 'flex', alignItems: 'center', gap: '12px', background: 'rgba(60, 154, 99, 0.08)', border: '1px solid rgba(60, 154, 99, 0.35)', borderRadius: '8px', padding: '14px 18px', margin: '16px 0'}}>
+  <span style={{flexShrink: 0}}><GraduationCapIcon size={26} /></span>
+  <span style={{fontSize: '14px', color: 'var(--ifm-font-color-base)'}}>
+    New to how AI Employees work? Take the <a href="/learn/ai-foundations" style={{color: '#3C9A63', fontWeight: 600}}>AI foundations</a> course in Vendasta Learn — Beginner, 6 lessons.
+  </span>
+</div>

--- a/docusaurus/src/components/Icons.tsx
+++ b/docusaurus/src/components/Icons.tsx
@@ -81,4 +81,27 @@ export function TaskIcon({ size = 16 }: { size?: number } = {}) {
   );
 }
 
-export default { AISparkleIcon, SettingsIcon, CRMIcon, TaskIcon };
+export function GraduationCapIcon({ size = 16, color = '#3cad6e' }: { size?: number; color?: string } = {}) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke={color}
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      xmlns="http://www.w3.org/2000/svg"
+      style={{ display: 'inline', verticalAlign: 'middle', marginRight: '4px' }}
+    >
+      <path d="M12 4.5 2.5 9l9.5 4.5L21.5 9 12 4.5Z" />
+      <path d="M6.5 11.2v3.4c0 1.1.5 2.15 1.4 2.82C9.1 18.3 10.5 18.75 12 18.75s2.9-.45 4.1-1.33c.9-.67 1.4-1.72 1.4-2.82v-3.4" />
+      <path d="M21 9.6v5.4" />
+      <circle cx="21" cy="16.35" r="0.85" fill={color} />
+      <rect x="19.9" y="17.5" width="2.2" height="2.2" rx="0.5" fill={color} />
+    </svg>
+  );
+}
+
+export default { AISparkleIcon, SettingsIcon, CRMIcon, TaskIcon, GraduationCapIcon };


### PR DESCRIPTION
## Summary
- Adds a "take the course" callout to the bottom of 6 Partner Center AI/automations reference pages, linking back to the **AI foundations** Learn path overview (`/learn/ai-foundations`) — the reverse direction of #811
- All 6 link to the course overview, not individual lessons, so readers start from the beginning rather than jumping into the middle of the path
- Pages updated: `/ai`, `/ai/ai-capabilities`, `/ai/ai-capabilities/configuring-capabilities`, `/ai/ai-capabilities/creating-custom-capabilities`, `/ai/ai-workforce`, `/automations`
- Adds `GraduationCapIcon` to the shared `Icons.tsx`, hand-built to match a reference graphic, in the site's light brand green

## Test plan
- [x] Rendered all 6 changed pages in a headless browser against the local dev server
- [x] Verified the callout and its link to `/learn/ai-foundations` render on all 6 pages
- [x] Confirmed zero new browser console errors on any of the 6 pages (one pre-existing iframe attribute warning on `/automations` is unrelated to this change)
- [ ] Human review of copy/placement per repo convention (learning path content should get a human pass before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)