### PR TITLE
Docs: document Contact Us Modal settings (DALE-1473)

### DIFF
--- a/docusaurus/docs/administration/platform-settings/customize-business-app/page-visibility-settings.mdx
+++ b/docusaurus/docs/administration/platform-settings/customize-business-app/page-visibility-settings.mdx
@@ -137,6 +137,29 @@ The **Customers can start conversations with you** setting controls whether cust
 Even when disabled, customers can still message you after you've initiated a conversation with them. The setting only controls whether they can start new conversations.
 :::
 
+### What can I control in the Contact Us modal?
+
+The **Contact Us Modal** group on this page controls what customers see when they click the **Contact Us** card in Business App navigation. Each option below is independent — turn any combination on or off.
+
+| Setting | What it does |
+|---------|---------------|
+| **Modal description** | A message you write (up to 250 characters) that appears at the top of the modal, above any of the options below. Not tied to any toggle — it's always editable. |
+| **Show assigned salesperson name & email** | Shows or hides the assigned team member's contact card in the modal. |
+| **Customers can start a conversation** | Shows the chat button described above. |
+| **Show a support center link** | Adds a button that opens a URL you specify, in a new tab. Reveals two fields: **Support center URL** (must start with `https://`) and **Button text** (defaults to "Visit support center"). |
+
+**How to configure the support center link:**
+
+1. Go to `Partner Center` → `Accounts` → `Manage Business App` → `Customize Business App` → `Pages` → `Inbox/Messages`
+2. Under `Contact Us Modal`, check `Show a support center link`
+3. Enter the destination in `Support center URL` (must start with `https://`)
+4. Optionally customize `Button text` (defaults to "Visit support center")
+5. Click `Save`
+
+:::info
+If every Contact Us Modal option is off and the modal description is empty, the Contact Us card doesn't appear in the customer's navigation at all.
+:::
+
 ---
 
 ## CRM Page Settings


### PR DESCRIPTION
## JIRA

[DALE-1473: \[FDE\] Custom Support Portal link from Business App](https://vendasta.jira.com/browse/DALE-1473) (Done)

Source RFC: [RFC: Support Center Link in the Contact Us Modal](https://vendasta.jira.com/wiki/spaces/~557058b3851f05f7394b0bad86bc8734cf8501/pages/4391927942/RFC+Support+Center+Link+in+the+Contact+Us+Modal)

## Classification

- **Type:** Configuration / system behavior (partner-facing settings)
- **Repo:** Partner Center (this PR). A companion PR also updates Business App end-user docs, since customers see the resulting modal there.

## Summary of changes

Updated `docusaurus/docs/administration/platform-settings/customize-business-app/page-visibility-settings.mdx`, under the existing **Inbox/Messages Page Settings** section, adding a new subsection **"What can I control in the Contact Us modal?"** covering the new **Contact Us Modal** settings group:
- Standalone modal description (250 char limit, not tied to any toggle)
- **Show assigned salesperson name & email** visibility toggle
- **Show a support center link** toggle, revealing a `https://`-validated URL field and a customizable button-text field (defaults to "Visit support center")
- Step-by-step configuration instructions
- A note on the modal/nav-card hiding itself when nothing is configured to show

The existing "Customers can start conversations with you" (chat) subsection was left untouched — it's part of the same modal but was already documented.

## Existing docs vs. new page

- The exact settings screen this ticket touches (`Customize Business App` → `Pages` → `Inbox/Messages`) was already documented in `page-visibility-settings.mdx` under **Inbox/Messages Page Settings**.
- **Updated existing page** rather than creating a new one — the new settings are additions to that same screen/grouping, per the RFC ("Keep the setting on the existing page-settings screen... group the new controls under a Contact Us Modal heading").

## Placement reasoning

Inserted as a new `###` subsection directly after the existing chat-toggle subsection, within the same `## Inbox/Messages Page Settings` section — keeps all Contact Us modal configuration together in one place, consistent with the page's existing per-page-settings structure.

## Acceptance criteria coverage

The story's original AC (partner specifies a link; clicking the nav card opens a modal to that link) was expanded per the RFC into three independent toggles (assigned-contact visibility, chat, support link) plus a standalone description. This update documents:
- How to enter the support URL and customize the button text ✅
- That the URL must be `https://` ✅
- That the setting is independent of the other two toggles ✅
- That the modal/nav card disappears entirely when nothing is configured ✅

## Figma/visual inputs

None provided or accessible for this ticket; content is based on the written RFC only (no screenshots added).

## Skills used

None of this repo's docs-generation skills apply directly (Partner Center repo has no `generate-help-article`-equivalent skill); edits follow the existing file's structure and this repo's `CLAUDE.md` markdown conventions (sentence-case headings, `→` instead of `>`, Docusaurus callouts).

## Assumptions / limitations

- **No screenshots included** for the new fields — none accessible for this ticket.
- **No parent epic found** for DALE-1473 (confirmed via Jira and Teamwork Graph) — proceeded since the story is `Done` with all linked PRs (14) merged.
- **Reviewer not auto-assigned.** GitHub access for this session is scoped to the docs repos only, so the linked code PRs (in the Business App codebase) couldn't be queried for their author. The story's assignee/RFC author is Kyle Sheasby (ksheasby@vendasta.com) — please add manually if appropriate.

---

@ahnikakuse @haleyserrano @maryam6samadi

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvcutwZvdhQeDuXAFxWRm4)_