### PR TITLE
docs: article verifications for July 28

### DIFF
--- a/docusaurus/docs/crm/contacts/crm-default-contact-fields.mdx
+++ b/docusaurus/docs/crm/contacts/crm-default-contact-fields.mdx
@@ -4,138 +4,136 @@ sidebar_label: Default contact fields
 description: Learn about the default contact properties in the CRM system
 ---
 
-# CRM default contact fields
-
 Contact properties store information about a contact that you work with, such as their name, or the last time you reached out to them. Default properties are created in each contact to store important information. Some of the properties, such as the last engagement date, are automatically populated.
 
-:::info Field Extensions
+:::info Field extensions
 Beyond the default fields listed below, your CRM may include additional contact fields depending on:
 
 - **Product integrations** - Different Vendasta products may add specialized contact fields
 - **Third-party integrations** - Connected services (email platforms, social media, advertising tools) can extend available fields  
 - **Custom field configurations** - Your organization may have added custom contact fields
-- **Feature enablements** - Certain features unlock additional data fields when activated
+- **Feature enablements** - Certain features enable additional data fields when activated
 - **API integrations** - External systems connected via API may contribute additional contact properties
 
 The fields shown here represent the core default set available to all accounts.
 :::
 
-## Basic Contact Information
+## Basic contact information
 
-1. **First name:** The given or first name of the contact
-2. **Last name:** The family or last name of the contact  
-3. **Email:** The primary email address of the contact used for communication and identification
-4. **Phone number:** The contact's primary phone number for voice communication
-5. **Additional phone number:** A secondary phone number for the contact
-6. **Job title:** The position or job title of the contact within their organization
-7. **Role:** Role of the contact
-8. **Seniority:** The level of seniority or authority of the contact within their organization
-9. **LinkedIn URL:** The URL of the contact's LinkedIn profile for professional networking
-10. **Primary company:** The primary company record associated with the contact in the CRM
-11. **Company website:** Name of the contact's company website (may be set independently from associated company)
+1. `First name`: The given or first name of the contact
+2. `Last name`: The family or last name of the contact  
+3. `Email`: The primary email address of the contact used for communication and identification
+4. `Phone number`: The contact's primary phone number for voice communication
+5. `Additional phone number`: A secondary phone number for the contact
+6. `Job title`: The position or job title of the contact within their organization
+7. `Role`: Role of the contact
+8. `Seniority`: The level of seniority or authority of the contact within their organization
+9. `LinkedIn URL`: The URL of the contact's LinkedIn profile for professional networking
+10. `Primary company`: The primary company record associated with the contact in the CRM
+11. `Company website`: Name of the contact's company website (may be set independently from associated company)
 
-## Personal Information & Preferences
+## Personal information & preferences
 
-12. **Birthday:** The contact's birth date
-13. **Birth year:** The birth year of the contact
-14. **Gender:** Gender of the contact (e.g., 'male', 'female', 'other')
-15. **Timezone:** Timezone of the contact (e.g., 'America/New_York')
-16. **Interests:** Contact's interests (e.g., 'Hiking', 'Skiing', 'Cooking', 'Paintball')
-17. **Skills:** Contact's professional skills and expertise (e.g., 'Java', 'Python', 'Javascript')
-18. **Message:** Message sent from contact, commonly input by the contact on intake forms
+12. `Birthday`: The contact's birth date
+13. `Birth year`: The birth year of the contact
+14. `Gender`: Gender of the contact (e.g., 'male', 'female', 'other')
+15. `Timezone`: Timezone of the contact (e.g., 'America/New_York')
+16. `Interests`: Contact's interests (e.g., 'Hiking', 'Skiing', 'Cooking', 'Paintball')
+17. `Skills`: Contact's professional skills and expertise (e.g., 'Java', 'Python', 'Javascript')
+18. `Message`: Message sent from contact, commonly input by the contact on intake forms
 
-## Address Information
+## Address information
 
-19. **Street address line 1:** First line of the contact's physical street address
-20. **Street address line 2:** Second line of the contact's physical street address
-21. **City/locality:** City or locality of the contact's primary location
-22. **State/province/region:** State, province, or region of the contact's primary location
-23. **Zip/postal code:** Zip or postal code of the contact's primary location
-24. **Country:** The country where the contact is located
+19. `Street address line 1`: First line of the contact's physical street address
+20. `Street address line 2`: Second line of the contact's physical street address
+21. `City/locality`: City or locality of the contact's primary location
+22. `State/province/region`: State, province, or region of the contact's primary location
+23. `Zip/postal code`: Zip or postal code of the contact's primary location
+24. `Country`: The country where the contact is located
 
-## Lead Management & Scoring
+## Lead management & scoring
 
-25. **Lifecycle stage:** Lifecycle stage of the contact (e.g., 'Lead')
-26. **Lead score:** The calculated lead score of the contact based on engagement and behavior
-27. **Lead quality:** The calculated lead quality of the contact
-28. **Tags:** User-defined keywords or labels that can be used to categorize contacts
+25. `Lifecycle stage`: Lifecycle stage of the contact (e.g., 'Lead')
+26. `Lead score`: The calculated lead score of the contact based on engagement and behavior
+27. `Lead quality`: The calculated lead quality of the contact
+28. `Tags`: User-defined keywords or labels that can be used to categorize contacts
 
-## Activity & Engagement Tracking
+## Activity & engagement tracking
 
-29. **Last activity date:** The date of the last recorded activity associated with the contact
-30. **Last engagement date:** The date of the last engagement from the contact  
-31. **Last contact date:** Date of last contact with the contact
-32. **Next task ID:** The unique identifier of the next task assigned to the contact
-33. **Next task due date:** Date indicating when the next task of the contact is due for completion
+29. `Last activity date`: The date of the last recorded activity associated with the contact
+30. `Last engagement date`: The date of the last engagement from the contact  
+31. `Last contact date`: Date of last contact with the contact
+32. `Next task ID`: The unique identifier of the next task assigned to the contact
+33. `Next task due date`: Date indicating when the next task of the contact is due for completion
 
-## Email Campaign Tracking
+## Email campaign tracking
 
-34. **Last campaign email sent date:** Last campaign email sent for the contact
-35. **Last campaign email sent name:** Name of last campaign email sent for the contact
-36. **Last campaign email open date:** Last campaign email opened by the contact
-37. **Last campaign email clicked date:** Last campaign email clicked by the contact  
-38. **Last campaign email bounced date:** Last campaign email bounced for the contact
-39. **Last campaign email dropped date:** Last campaign email dropped date for the contact
+34. `Last campaign email sent date`: Last campaign email sent for the contact
+35. `Last campaign email sent name`: Name of last campaign email sent for the contact
+36. `Last campaign email open date`: Last campaign email opened by the contact
+37. `Last campaign email clicked date`: Last campaign email clicked by the contact  
+38. `Last campaign email bounced date`: Last campaign email bounced for the contact
+39. `Last campaign email dropped date`: Last campaign email dropped date for the contact
 
-## Sales Email Tracking
+## Sales email tracking
 
-40. **Last sales email sent date:** Date of last sales email sent by salesperson to the contact
-41. **Last sales email received date:** Date of last sales email sent by the contact to salesperson
+40. `Last sales email sent date`: Date of last sales email sent by salesperson to the contact
+41. `Last sales email received date`: Date of last sales email sent by the contact to salesperson
 
-## SMS Campaign Tracking
+## SMS campaign tracking
 
-42. **Last campaign SMS sent date:** Last campaign SMS sent to the contact
-43. **Last campaign SMS sent name:** Name of last campaign SMS sent to the contact
-44. **Last campaign SMS delivered date:** Last campaign SMS delivered date for the contact
-45. **Last campaign SMS undelivered date:** Date when SMS failed to be delivered to the contact
-46. **Last campaign SMS failed date:** Date when SMS failed to send to the contact
+42. `Last campaign SMS sent date`: Last campaign SMS sent to the contact
+43. `Last campaign SMS sent name`: Name of last campaign SMS sent to the contact
+44. `Last campaign SMS delivered date`: Last campaign SMS delivered date for the contact
+45. `Last campaign SMS undelivered date`: Date when SMS failed to be delivered to the contact
+46. `Last campaign SMS failed date`: Date when SMS failed to send to the contact
 
-## Consent & Privacy Management
+## Consent & privacy management
 
-47. **Marketing email consent:** The current status for the contact's marketing email consent
-48. **Marketing email consent timestamp:** The timestamp when the marketing email consent was last updated
-49. **Marketing email consent source:** The source or method that updated the marketing email consent field
-50. **SMS consent:** The current status for the contact's SMS marketing consent
-51. **SMS consent timestamp:** The timestamp in which the SMS consent was updated
-52. **SMS consent source:** The source or method that updated the SMS consent field
+47. `Marketing email consent`: The current status for the contact's marketing email consent
+48. `Marketing email consent timestamp`: The timestamp when the marketing email consent was last updated
+49. `Marketing email consent source`: The source or method that updated the marketing email consent field
+50. `SMS consent`: The current status for the contact's SMS marketing consent
+51. `SMS consent timestamp`: The timestamp in which the SMS consent was updated
+52. `SMS consent source`: The source or method that updated the SMS consent field
 
-## Attribution & Source Tracking
+## Attribution & source tracking
 
-53. **Record source:** Name of the app or external system that created the contact (e.g., 'Salesforce', 'Hubspot', 'Gmail')
-54. **Record source drill down 1:** Record source drill down level 1 of the contact
-55. **Record source drill down 2:** Record source drill down level 2 of the contact
-56. **Original source:** Lead attribution original source of the contact
-57. **Original source drill down 1:** Lead attribution original source drill down level 1
-58. **Original source drill down 2:** Lead attribution original source drill down level 2
+53. `Record source`: Name of the app or external system that created the contact (e.g., 'Salesforce', 'Hubspot', 'Gmail')
+54. `Record source drill down 1`: Record source drill down level 1 of the contact
+55. `Record source drill down 2`: Record source drill down level 2 of the contact
+56. `Original source`: Lead attribution original source of the contact
+57. `Original source drill down 1`: Lead attribution original source drill down level 1
+58. `Original source drill down 2`: Lead attribution original source drill down level 2
 
-## UTM & Campaign Attribution
+## UTM & campaign attribution
 
-59. **UTM campaign:** The campaign of the UTM parameters for the contact
-60. **UTM medium:** The medium of the UTM parameters for the contact (e.g., 'cpc', 'email', 'social', 'organic', 'referral', 'affiliate', 'display', 'video', 'audio', 'sms', 'direct', 'other')
-61. **UTM source:** The source of the UTM parameters for the contact
-62. **UTM content:** The content of the UTM parameters for the contact  
-63. **UTM term:** The term of the UTM parameters for the contact (e.g., 'running+shoes', 'black+friday+sale', etc.)
+59. `UTM campaign`: The campaign of the UTM parameters for the contact
+60. `UTM medium`: The medium of the UTM parameters for the contact (e.g., 'cpc', 'email', 'social', 'organic', 'referral', 'affiliate', 'display', 'video', 'audio', 'sms', 'direct', 'other')
+61. `UTM source`: The source of the UTM parameters for the contact
+62. `UTM content`: The content of the UTM parameters for the contact  
+63. `UTM term`: The term of the UTM parameters for the contact (e.g., 'running+shoes', 'black+friday+sale', etc.)
 
-## Click Tracking IDs
+## Click tracking IDs
 
-64. **GCLID:** Google click ID used to create the contact
-65. **FBCLID:** Facebook click ID used to create the contact
-66. **MSCLKID:** Microsoft click ID used to create the contact
+64. `GCLID`: Google click ID used to create the contact
+65. `FBCLID`: Facebook click ID used to create the contact
+66. `MSCLKID`: Microsoft click ID used to create the contact
 
-## System Fields
+## System fields
 
-67. **ID:** Unique identifier assigned to each contact
-68. **External ID:** An identifier used by external systems or databases to reference the contact
-69. **Updated date:** The date when the contact record was last updated
-70. **Created date:** The date when the contact record was created
+67. `ID`: Unique identifier assigned to each contact
+68. `External ID`: An identifier used by external systems or databases to reference the contact
+69. `Updated date`: The date when the contact record was last updated
+70. `Created date`: The date when the contact record was created
 
-## Platform-Specific Information (Partner Center Only)
+## Platform-specific information (Partner Center only)
 
-71. **Platform SSC contact IDs:** Identifies the SSC contact, which may be associated with zero or more account groups
-72. **Platform user ID:** Identifier for contact's underlying IAM user
-73. **Salesperson:** The salesperson in the platform
-74. **Additional salespeople:** Additional salespeople in the platform
+71. `Platform SSC contact IDs`: Identifies the SSC contact, which may be associated with zero or more account groups
+72. `Platform user ID`: Identifier for contact's underlying IAM user
+73. `Salesperson`: The salesperson in the platform
+74. `Additional salespeople`: Additional salespeople in the platform
 
-:::tip Viewing All Available Fields
-To see the complete list of contact fields available in your specific CRM instance, navigate to any contact record and click the "View all properties" or "More fields" option. This will show both default and integration-specific fields enabled for your account.
+:::tip Viewing all available fields
+To see the complete list of contact fields available in your specific CRM instance, navigate to any contact record and click the `View all properties` or `More fields` option. This will show both default and integration-specific fields enabled for your account.
 :::

--- a/docusaurus/docs/crm/my-meetings/customizing-meeting-recording-settings.mdx
+++ b/docusaurus/docs/crm/my-meetings/customizing-meeting-recording-settings.mdx
@@ -32,17 +32,17 @@ Use the steps below to access and customize your meeting settings.
 
 ### How to access meeting settings
 
-1. Navigate to the **My Meetings** section.
-2. Select **Meeting Settings**.
+1. Navigate to the `My Meetings` section.
+2. Select `Meeting Settings`.
 
 ### How to locate bot settings
 
 1. Scroll to the bottom of the meeting settings page.
-2. Locate the **Bot Settings** section.
+2. Locate the `Bot Settings` section.
 
 ### How to customize note-taker and compliance announcement
 
-In the **Bot Settings** section, you can:
+In the `Bot Settings` section, you can:
 
 - Change the name of your note-taker.
 - Turn the compliance announcement on or off.

--- a/docusaurus/docs/crm/my-meetings/scenario-based-example.mdx
+++ b/docusaurus/docs/crm/my-meetings/scenario-based-example.mdx
@@ -70,7 +70,7 @@ In this scenario, Alex just finished a discovery call with Sarah, the owner of a
 
 **Follow-up:** "We'll check the report next Friday to see if that Patience Score hits a 7."
 
-## Key takeaways for the SMB owner
+## Key takeaways for the sales manager
 
 - **Don't attack the rep:** Use the AI scores as "the third person in the room" to keep the feedback objective.
 - **Use the Guide:** Have the Score Improvement Guide open so the rep can see the "correct" phrases to use.

--- a/docusaurus/docs/crm/my-meetings/understanding-ai-insights.mdx
+++ b/docusaurus/docs/crm/my-meetings/understanding-ai-insights.mdx
@@ -129,11 +129,11 @@ Calls are scored against world-class strategies on a scale of 1 to 10. This help
 
 ## How to use the meeting analysis report
 
-To make this report truly effective for a busy business owner, you should not just look at the numbers. You should look for the patterns.
+To make this report truly effective, don't just look at the numbers. Look for the patterns.
 
 Below are specific ways to use these scores to coach your team, with real-world SMB scenarios to visualize the impact.
 
-## Strategic recommendations for SMB owners
+## Strategic recommendations for sales managers
 
 ### 1. Identify the expert's trap (talk time vs. question rate)
 


### PR DESCRIPTION
## Summary
- Fixed audience-language slips in the AI insights/coaching articles that addressed the SMB client instead of the partner's sales manager (the actual reader)
- Converted bolded UI elements and CRM field names to inline code per style guide (recording settings, contact fields)
- Fixed heading casing (title case to sentence case) and removed a duplicate H1 and a prohibited term ("unlock") in the contact fields reference
- Verified all links (Loom demo embed, inbound anchor link from `email-subscription-preferences.mdx`) still resolve correctly

## Verified articles
- `docusaurus/docs/crm/my-meetings/understanding-ai-insights.mdx`
- `docusaurus/docs/crm/my-meetings/score-improvement-guide.mdx` (Pass, no changes)
- `docusaurus/docs/crm/my-meetings/scenario-based-example.mdx`
- `docusaurus/docs/crm/my-meetings/customizing-meeting-recording-settings.mdx`
- `docusaurus/docs/crm/contacts/crm-default-contact-fields.mdx`

## Test plan
- [x] Verified all internal/external links resolve
- [x] Confirmed inbound anchor link (`#consent--privacy-management`) still resolves after heading case fix
- [ ] Live-product spot check recommended for AI insights metric names and CRM field list (noted in issue comments)

Closes #832
Closes #831
Closes #830
Closes #829
Closes #828

🤖 Generated with [Claude Code](https://claude.com/claude-code)