### PR TITLE
Standardize lab colors across the LEARN tab

### DIFF
--- a/docusaurus/src/components/LabCallout.tsx
+++ b/docusaurus/src/components/LabCallout.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+interface LabCalloutProps {
+  /** What this lab section does, e.g. "create the employee and its profile" */
+  title: string;
+  children: React.ReactNode;
+}
+
+export default function LabCallout({
+  title,
+  children,
+}: LabCalloutProps): JSX.Element {
+  return (
+    <div className="lab-callout">
+      <p className="lab-callout__title">
+        <span className="lab-callout__badge">Lab</span>
+        {title}
+      </p>
+      <div className="lab-callout__body">{children}</div>
+    </div>
+  );
+}

--- a/docusaurus/src/components/LabChecklist.tsx
+++ b/docusaurus/src/components/LabChecklist.tsx
@@ -11,8 +11,8 @@ interface LabChecklistProps {
 
 const STORAGE_PREFIX = "vendasta_learn_lab_";
 
-const GREEN = "#3F9B63";
-const NAVY = "#072337";
+const LAB_PURPLE = "var(--lab-purple)";
+const LAB_PURPLE_BG = "var(--lab-purple-bg)";
 
 export default function LabChecklist({
   storageKey,
@@ -79,7 +79,7 @@ export default function LabChecklist({
                 marginTop: "0.3rem",
                 width: "1rem",
                 height: "1rem",
-                accentColor: GREEN,
+                accentColor: LAB_PURPLE,
                 cursor: "pointer",
                 flexShrink: 0,
               }}
@@ -104,17 +104,17 @@ export default function LabChecklist({
         style={{
           marginTop: "0.75rem",
           padding: "0.6rem 0.9rem",
-          borderLeft: `3px solid ${done ? GREEN : "#c9ced3"}`,
+          borderLeft: `3px solid ${done ? LAB_PURPLE : "#c9ced3"}`,
           borderRadius: "0 6px 6px 0",
-          background: done ? "#e8f4ed" : "transparent",
-          color: NAVY,
+          background: done ? LAB_PURPLE_BG : "transparent",
+          color: "var(--Vendasta-Navy, #072337)",
           opacity: done ? 1 : 0.75,
           transition: "background 0.25s ease, border-color 0.25s ease",
         }}
       >
         {done && (
           <span
-            style={{ color: GREEN, fontWeight: 700, marginRight: "0.45rem" }}
+            style={{ color: LAB_PURPLE, fontWeight: 700, marginRight: "0.45rem" }}
           >
             &#10003;
           </span>

--- a/docusaurus/src/css/custom.css
+++ b/docusaurus/src/css/custom.css
@@ -15,6 +15,8 @@
   --ifm-color-primary-lightest: #3cad6e;
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
+  --lab-purple: #432874;
+  --lab-purple-bg: #e2d9f3;
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
@@ -1930,8 +1932,8 @@ div[class*="language-"] pre {
 }
 
 .lesson-header__tag--lab {
-  background: #e2d9f3;
-  color: #432874;
+  background: var(--lab-purple-bg);
+  color: var(--lab-purple);
 }
 
 .lesson-header__position {
@@ -1981,6 +1983,43 @@ div[class*="language-"] pre {
   color: #2e8555;
   font-weight: 700;
   margin-right: 0.4rem;
+}
+
+/* Lab instruction box (LabCallout component) */
+.lab-callout {
+  border-left: 4px solid var(--lab-purple);
+  background: var(--lab-purple-bg);
+  border-radius: 0 8px 8px 0;
+  padding: 1rem 1.25rem;
+  margin: 1.5rem 0;
+}
+
+.lab-callout__title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0 0 0.75rem;
+  font-weight: 700;
+  color: var(--lab-purple);
+}
+
+.lab-callout__badge {
+  background: var(--lab-purple);
+  color: #fff;
+  border-radius: 4px;
+  padding: 0.15rem 0.5rem;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  flex-shrink: 0;
+}
+
+.lab-callout__body {
+  color: var(--ifm-font-color-base);
+}
+
+.lab-callout__body > :last-child {
+  margin-bottom: 0;
 }
 
 /* End-of-lesson footer (LessonFooter component) */

--- a/docusaurus/training/ai-workforce/autopilot.mdx
+++ b/docusaurus/training/ai-workforce/autopilot.mdx
@@ -12,6 +12,7 @@ import MarkComplete from "@site/src/components/MarkComplete";
 import LessonHeader from "@site/src/components/LessonHeader";
 import LessonFooter from "@site/src/components/LessonFooter";
 import LabChecklist from "@site/src/components/LabChecklist";
+import LabCallout from "@site/src/components/LabCallout";
 
 <InlineHighlighter courseId="autopilot" site="vendasta_learn">
 
@@ -37,7 +38,7 @@ import LabChecklist from "@site/src/components/LabChecklist";
 
 By the end of this step, one real automation is live on your own account, running without you touching it again. *You are here: Partner Center, the same account you have been building on since step 2.* The workforce so far only acts when spoken to; this step is what runs when nobody is in the conversation at all.
 
-:::info Lab: build a smart list
+<LabCallout title="build a smart list">
 You are going to **CRM** → **Lists** → **Create**.
 
 <LabChecklist
@@ -49,11 +50,11 @@ You are going to **CRM** → **Lists** → **Create**.
   ]}
   confirm={<>Matching contacts populate immediately, and keep populating as new ones match: the list itself is the trigger, no manual upkeep required.</>}
 />
-:::
+</LabCallout>
 
 ## Pair it with an automation
 
-:::info Lab: connect the list to an action
+<LabCallout title="connect the list to an action">
 You are going to **Automations** → **Create automation**.
 
 <LabChecklist
@@ -65,11 +66,11 @@ You are going to **Automations** → **Create automation**.
   ]}
   confirm={<>Every contact who lands on the smart list now sets off the automation, with no one needing to notice they arrived.</>}
 />
-:::
+</LabCallout>
 
 Three starter recipes cover most of what a workforce needs autopilot for. Building the first one end to end is worth doing now; the other two follow the exact same shape once the pattern clicks.
 
-:::info Lab: ship the nurture recipe
+<LabCallout title="ship the nurture recipe">
 You are back in **Automations**.
 
 <LabChecklist
@@ -81,7 +82,7 @@ You are back in **Automations**.
   ]}
   confirm={<>A form submission now starts a nurture campaign on its own, the moment the contact lands on the list.</>}
 />
-:::
+</LabCallout>
 
 The other two follow the same shape, one trigger and one or two steps: a new-lead list paired with a CRM sales task for the contact plus an SMS acknowledgment, so a person and the lead both hear something right away; and, once a completed-job integration is in place, a jobs-done list paired with a review-request campaign for the company.
 

--- a/docusaurus/training/ai-workforce/custom-employee-lab.mdx
+++ b/docusaurus/training/ai-workforce/custom-employee-lab.mdx
@@ -12,6 +12,7 @@ import MarkComplete from "@site/src/components/MarkComplete";
 import LessonHeader from "@site/src/components/LessonHeader";
 import LessonFooter from "@site/src/components/LessonFooter";
 import LabChecklist from "@site/src/components/LabChecklist";
+import LabCallout from "@site/src/components/LabCallout";
 
 <InlineHighlighter courseId="custom-employee-lab" site="vendasta_learn">
 
@@ -46,7 +47,7 @@ Write your outcome in one sentence before you open the configuration panel: what
 
 ## Create the employee
 
-:::info Lab: create the employee and its profile
+<LabCallout title="create the employee and its profile">
 You are going to **AI** → **AI Workforce** → **Create**.
 
 <LabChecklist
@@ -58,11 +59,11 @@ You are going to **AI** → **AI Workforce** → **Create**.
   ]}
   confirm={<>The employee now exists in your AI Workforce roster, with a profile and an autonomy level set.</>}
 />
-:::
+</LabCallout>
 
 ## Give it knowledge and capabilities
 
-:::info Lab: connect knowledge and turn on capabilities
+<LabCallout title="connect knowledge and turn on capabilities">
 You are staying on the employee's **Configure** panel.
 
 <LabChecklist
@@ -73,7 +74,7 @@ You are staying on the employee's **Configure** panel.
   ]}
   confirm={<>The employee can now answer from real knowledge and take the actions its outcome needs, using only built-in pieces.</>}
 />
-:::
+</LabCallout>
 
 ## Add one custom capability
 
@@ -81,7 +82,7 @@ Most outcomes need one more thing a built-in capability does not cover: a real a
 
 This step uses a real, working endpoint so you are testing against an actual response, not a hypothetical one: [dummyjson.com](https://dummyjson.com), a free public test API that needs no authentication. Its `/carts` endpoint stands in for an order-lookup system. Give it an order number from 1 to 50 and it returns that order's total, its discounted total, how many products and total items it contains, and the products themselves (name, quantity, and line total for each). It is not a real Vendasta or client order system — it exists so the tool you configure here behaves exactly like the one you would later point at a client's real order API, with a live response to check your work against instead of guessing whether the capability is wired up correctly.
 
-:::info Lab: add a capability with a tool
+<LabCallout title="add a capability with a tool">
 You are going to **Capabilities** → **Custom Capabilities** → **Add a capability**.
 
 <LabChecklist
@@ -93,7 +94,7 @@ You are going to **Capabilities** → **Custom Capabilities** → **Add a capabi
   ]}
   confirm={<>The tool now appears on the capability, ready for the AI to call once its instructions say when.</>}
 />
-:::
+</LabCallout>
 
 Path parameters, query parameters, headers, and every field in detail: [Creating Custom Capabilities walks through the rest](/ai/ai-capabilities/creating-custom-capabilities).
 
@@ -103,7 +104,7 @@ Brief the capability the way you would brief a new hire's one task: exactly when
 
 ## Test before you call it done
 
-:::info Lab: run the pass/fail script
+<LabCallout title="run the pass/fail script">
 You are on the employee's **Try it** page, or its assigned channel.
 
 <LabChecklist
@@ -115,7 +116,7 @@ You are on the employee's **Try it** page, or its assigned channel.
   ]}
   confirm={<>Three questions, three different situations, and the employee handled all three the way its outcome intended.</>}
 />
-:::
+</LabCallout>
 
 ## Where this stops, for now
 

--- a/docusaurus/training/ai-workforce/teach-it-to-book.mdx
+++ b/docusaurus/training/ai-workforce/teach-it-to-book.mdx
@@ -12,6 +12,7 @@ import MarkComplete from "@site/src/components/MarkComplete";
 import LessonHeader from "@site/src/components/LessonHeader";
 import LessonFooter from "@site/src/components/LessonFooter";
 import LabChecklist from "@site/src/components/LabChecklist";
+import LabCallout from "@site/src/components/LabCallout";
 
 <InlineHighlighter courseId="teach-it-to-book" site="vendasta_learn">
 
@@ -37,7 +38,7 @@ import LabChecklist from "@site/src/components/LabChecklist";
 
 By the end of this step, your receptionist from the last step can book a real meeting on a real calendar, and knows exactly what to do with a call outside business hours. *You are here: Partner Center, on the same employee steps 2 and 4 build on.* An employee that only answers is a receptionist who never puts anything on the books; booking is what turns a good conversation into a kept appointment.
 
-:::info Lab: connect a calendar
+<LabCallout title="connect a calendar">
 You are going to **CRM** → **My Meetings**.
 
 <LabChecklist
@@ -48,7 +49,7 @@ You are going to **CRM** → **My Meetings**.
   ]}
   confirm={<>Your calendar shows as connected in Meeting Settings, which lets My Meetings both check for conflicts and create events automatically once a booking is confirmed.</>}
 />
-:::
+</LabCallout>
 
 For the full setup, including switching providers later, [Setting up calendar integration walks through the rest](/crm/my-meetings/setting-up-calendar-integration).
 
@@ -56,7 +57,7 @@ For the full setup, including switching providers later, [Setting up calendar in
 
 Pick a URL slug, then set your availability windows and the buffer time you want before and after a meeting. My Meetings offers durations of 15, 30, 45, or 60 minutes, or a custom length; decide which one your receptionist should offer before you test it.
 
-:::info Lab: build one booking link
+<LabCallout title="build one booking link">
 You are staying in **My Meetings** → **Manage booking links** → **Create event type**.
 
 <LabChecklist
@@ -68,7 +69,7 @@ You are staying in **My Meetings** → **Manage booking links** → **Create eve
   ]}
   confirm={<>One event type exists with a working link, ready to hand to your receptionist in the next section.</>}
 />
-:::
+</LabCallout>
 
 ## The team event, done right
 
@@ -76,7 +77,7 @@ For a group instead of one person, create a **team event** rather than several p
 
 ## Enable the capability
 
-:::info Lab: turn on Book Appointments
+<LabCallout title="turn on Book Appointments">
 You are on your receptionist's **Configure** panel → **Capabilities**.
 
 <LabChecklist
@@ -87,7 +88,7 @@ You are on your receptionist's **Configure** panel → **Capabilities**.
   ]}
   confirm={<>Your receptionist can now offer real time slots, collect the booking details it needs, and create the event automatically.</>}
 />
-:::
+</LabCallout>
 
 If an older capability on the same employee only records a caller's preferred time without actually booking anything, replace it with Book Appointments: a preference is not a kept meeting.
 
@@ -99,7 +100,7 @@ One limit is worth knowing before a client asks: Book Appointments does not coll
 
 Business-hours routing is the pattern worth building once and reusing everywhere: transfer during hours, capture the lead after. Rather than folding this logic into an existing capability's prompt, give it a custom capability of its own.
 
-:::info Lab: build the routing capability
+<LabCallout title="build the routing capability">
 You are on **Capabilities** → **Custom Capabilities** → **Add a capability**.
 
 <LabChecklist
@@ -112,13 +113,13 @@ You are on **Capabilities** → **Custom Capabilities** → **Add a capability**
   ]}
   confirm={<>The capability checks the time against the business's real hours and branches correctly, every time it runs.</>}
 />
-:::
+</LabCallout>
 
 Do not build a second after-hours capture from scratch: the Capture Lead Information capability your receptionist already runs after hours can extend to ask which department the caller wanted, the same way any other question gets added to its prompt.
 
 ## Test both directions
 
-:::info Lab: confirm both branches
+<LabCallout title="confirm both branches">
 You are on the **Try it** test page or the assigned channel.
 
 <LabChecklist
@@ -129,7 +130,7 @@ You are on the **Try it** test page or the assigned channel.
   ]}
   confirm={<>Both directions work exactly as the routing capability describes them.</>}
 />
-:::
+</LabCallout>
 
 {/* TODO(ET-740): once the builder-track "wire booking into an outside system" step exists, uncomment — "If a client needs bookings to land in their own outside system, that's a deeper build — [here's where to go for it](/learn/builder/...)." */}
 

--- a/docusaurus/training/ai-workforce/train-your-employee.mdx
+++ b/docusaurus/training/ai-workforce/train-your-employee.mdx
@@ -12,6 +12,7 @@ import MarkComplete from "@site/src/components/MarkComplete";
 import LessonHeader from "@site/src/components/LessonHeader";
 import LessonFooter from "@site/src/components/LessonFooter";
 import LabChecklist from "@site/src/components/LabChecklist";
+import LabCallout from "@site/src/components/LabCallout";
 
 <InlineHighlighter courseId="train-your-employee" site="vendasta_learn">
 
@@ -48,7 +49,7 @@ Open the test page in a fresh incognito window and run the audit before you chan
 
 A wrong price usually means the source it searched never had the real number, not that the AI is broken. Copy the package's exact pricing into a clean document and upload it as the authoritative source: auto-imported marketplace content can carry broken links or no usable pricing at all.
 
-:::info Lab: upload a clean price list
+<LabCallout title="upload a clean price list">
 You are going to your employee's **Configure** panel → **Knowledge Sources**.
 
 <LabChecklist
@@ -59,7 +60,7 @@ You are going to your employee's **Configure** panel → **Knowledge Sources**.
   ]}
   confirm={<>The price list now appears in <strong>Knowledge Sources</strong>, ready for the AI to search.</>}
 />
-:::
+</LabCallout>
 
 For every knowledge source type and what belongs in each, [the Knowledge Base guide covers the rest](/ai/knowledge-base).
 
@@ -67,7 +68,7 @@ For every knowledge source type and what belongs in each, [the Knowledge Base gu
 
 Knowledge is what the AI looks up when a question calls for it. A rule that must hold on every response belongs in a capability instead, so a guardrail like "quote only from the published list, never estimate" holds even on a question the price list does not directly answer.
 
-:::info Lab: write the pricing guardrail
+<LabCallout title="write the pricing guardrail">
 You are going to your employee's **Configure** panel → **Capabilities**.
 
 <LabChecklist
@@ -79,13 +80,13 @@ You are going to your employee's **Configure** panel → **Capabilities**.
   ]}
   confirm={<>The capability now holds the rule, and it applies on every conversation, not only the ones a knowledge lookup happens to catch.</>}
 />
-:::
+</LabCallout>
 
 Keep the instruction short. Everything an employee has been told shares one working memory, and a long list of rules competes with itself; specific and short beats long every time. Instructions also tend to collect leftover lines from earlier edits, so revisit and trim them now and then rather than only ever adding to them. The same discipline suits a business in a regulated field: rather than answering specifics on medical or legal questions, have the guardrail redirect to a person, and use the word its own customers would use, never a clinical term a business would not use itself.
 
 ## Re-test and see why it answered that way
 
-:::info Lab: re-run the audit
+<LabCallout title="re-run the audit">
 You are back on the **Try it** test page.
 
 <LabChecklist
@@ -96,7 +97,7 @@ You are back on the **Try it** test page.
   ]}
   confirm={<>Explanation shows exactly which knowledge source or capability produced that answer, so you know precisely what to adjust if it is still off.</>}
 />
-:::
+</LabCallout>
 
 ## The habit that keeps it accurate
 

--- a/docusaurus/training/growth-engine/read-the-snapshot.mdx
+++ b/docusaurus/training/growth-engine/read-the-snapshot.mdx
@@ -12,6 +12,7 @@ import MarkComplete from "@site/src/components/MarkComplete";
 import LessonHeader from "@site/src/components/LessonHeader";
 import LessonFooter from "@site/src/components/LessonFooter";
 import LabChecklist from "@site/src/components/LabChecklist";
+import LabCallout from "@site/src/components/LabCallout";
 
 <InlineHighlighter courseId="read-the-snapshot" site="vendasta_learn">
 
@@ -42,7 +43,7 @@ Northside Dental's report came back the way most do: a strong grade worth celebr
 
 Before an owner ever sees the report, you shape it. Details carry the grades: a wrong address or a stale primary category grades the business against the wrong industry, and every section inherits the mistake.
 
-:::info Lab: prepare the report for the conversation
+<LabCallout title="prepare the report for the conversation">
 You are going to your prospect's account in **Partner Center**.
 
 <LabChecklist
@@ -57,7 +58,7 @@ You are going to your prospect's account in **Partner Center**.
   ]}
   confirm={<>The report now shows a business the owner will recognize, measured against rivals they care about, in the order you plan to walk it.</>}
 />
-:::
+</LabCallout>
 
 Turning a section off for every report at once happens at the template level, and [the customization guide covers every option](/snapshot-report/snapshot-report-customization).
 

--- a/docusaurus/training/growth-engine/run-your-first-snapshot.mdx
+++ b/docusaurus/training/growth-engine/run-your-first-snapshot.mdx
@@ -12,6 +12,7 @@ import MarkComplete from "@site/src/components/MarkComplete";
 import LessonHeader from "@site/src/components/LessonHeader";
 import LessonFooter from "@site/src/components/LessonFooter";
 import LabChecklist from "@site/src/components/LabChecklist";
+import LabCallout from "@site/src/components/LabCallout";
 import SnapshotCreateIcon from "./img/snapshot-create-icon.svg";
 
 <InlineHighlighter courseId="run-your-first-snapshot" site="vendasta_learn">
@@ -46,7 +47,7 @@ This path follows one prospect through the whole motion: Northside Dental, a cli
 
 The account is the prospect's home in your workspace, and creating it also creates the linked CRM company, so your sales activity and the service record stay connected from the first touch. Two details carry the report: the **primary category**, because every grade is benchmarked against the business's industry, and the **salesperson**, because a report is sent from a person, and that person is you.
 
-:::info Lab: create your prospect's account
+<LabCallout title="create your prospect's account">
 You are going to **Partner Center** → **Accounts** → **Manage Accounts**.
 
 <LabChecklist
@@ -60,13 +61,13 @@ You are going to **Partner Center** → **Accounts** → **Manage Accounts**.
   ]}
   confirm={<>The business now appears in <strong>Manage Accounts</strong>, and the platform has created its linked CRM company for you.</>}
 />
-:::
+</LabCallout>
 
 For every field and option along the way, [this guide covers creating accounts](/accounts/manage-accounts/create-accounts). And when you want the platform to surface prospects for you instead, [Find Leads searches local businesses from the CRM](/crm/companies) and creates company records in bulk.
 
 ## Run the report
 
-:::info Lab: run the Snapshot Report
+<LabCallout title="run the Snapshot Report">
 You are staying in **Manage Accounts**.
 
 <LabChecklist
@@ -77,13 +78,13 @@ You are staying in **Manage Accounts**.
   ]}
   confirm={<>The report is now generating on the account.</>}
 />
-:::
+</LabCallout>
 
 The report gathers data over its first 24 hours and keeps enriching for seven days, so the seven-day mark is the fullest picture of the business. That timing is a selling rhythm: run the report when you pick the prospect, and present it when it has the most to say.
 
 ## Hear the moment it is ready
 
-:::info Lab: turn on the Snapshot Ready notification
+<LabCallout title="turn on the Snapshot Ready notification">
 You are going to **Partner Center** → **Administration** → **Client Notifications**.
 
 <LabChecklist
@@ -94,7 +95,7 @@ You are going to **Partner Center** → **Administration** → **Client Notifica
   ]}
   confirm={<>You now get an alert when any report finishes generating, typically within 24 hours of its creation.</>}
 />
-:::
+</LabCallout>
 
 ## What the grades measure
 


### PR DESCRIPTION
## Summary
- The "Lab" badge, the `:::info Lab: ...` instruction boxes, and the `LabChecklist` component each used a different, unrelated color (purple / default Docusaurus blue / green), so a single lab step showed three unrelated palettes.
- Added shared `--lab-purple` / `--lab-purple-bg` CSS variables (`docusaurus/src/css/custom.css`), used by the existing `Lab` badge, a new `LabCallout` component, and `LabChecklist`.
- Added `LabCallout` component to replace the generic blue `:::info Lab: ...` admonitions (19 occurrences across 6 files) with a purple-themed box carrying its own "Lab" badge.
- Recolored `LabChecklist`'s checkbox accent, done-state border/background, and checkmark from green to the shared purple; confirm-box text now uses the sitewide navy variable instead of a duplicated hex.

## Files touched
- `docusaurus/src/css/custom.css`
- `docusaurus/src/components/LabCallout.tsx` (new)
- `docusaurus/src/components/LabChecklist.tsx`
- `docusaurus/training/ai-workforce/{autopilot,custom-employee-lab,teach-it-to-book,train-your-employee}.mdx`
- `docusaurus/training/growth-engine/{read-the-snapshot,run-your-first-snapshot}.mdx`

## Test plan
- [x] `npm run typecheck` — passes with only pre-existing, unrelated `Cannot find namespace 'JSX'` errors (present in untouched files too)
- [x] `npm run build` — succeeds; only pre-existing broken-link/anchor warnings unrelated to this change
- [ ] Visual check in a running dev server that lab badges/callouts/checklists render consistently in light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)