### PR TITLE
Fix broken Getting Started link on homepage

### DIFF
--- a/docusaurus/docs/index.mdx
+++ b/docusaurus/docs/index.mdx
@@ -14,7 +14,7 @@ Your comprehensive resource for all Vendasta platform tools and features. Explor
 <div className="container homepage-top-section">
   <div className="row homepage-row-edge homepage-top-row">
     <div className="col col--4">
-      <Link className="card-link" to="category/getting-started">
+      <Link className="card-link" to="/getting-started">
         <div className="card">
           <div className="card__header">
             <h3>Getting Started</h3>


### PR DESCRIPTION
## Summary
- Homepage "Getting Started" card linked to `category/getting-started`, a generated-index route that no longer exists (404)
- Points it to `/getting-started` instead, matching the working link already used elsewhere on the same page

Jira: https://vendasta.jira.com/browse/DOC-782

## Test plan
- [x] Verified `/getting-started` resolves to `docusaurus/docs/getting-started/index.mdx`
- [ ] Click the "Getting Started" homepage card in a local build and confirm it no longer 404s