### PR TITLE
fix: correct broken Snapshot Report link

### DIFF
--- a/docusaurus/docs/administration/platform-settings/customize-business-app/add-your-customers-settings.mdx
+++ b/docusaurus/docs/administration/platform-settings/customize-business-app/add-your-customers-settings.mdx
@@ -191,5 +191,6 @@ Exception: Featured Packages must be configured per market and cannot be set at 
 <details>
 <summary>Where can I learn more about Snapshot Reports?</summary>
 
-Snapshot Reports are marketing needs assessments that can prompt self-signup. To learn more, visit the [Snapshot Report documentation](https://docs.vendasta.com/snapshot-report/what-is-a-snapshot-report).
+Snapshot Reports are marketing needs assessments that can prompt self-signup. To learn more, visit the [Snapshot Report documentation](/snapshot-report/#why-is-snapshot-report-important).
+
 </details>


### PR DESCRIPTION
## Summary
- Fixes a broken link reported via the help form: the "Where can I learn more about Snapshot Reports?" FAQ item on the Add Your Customers settings page linked to `snapshot-report/what-is-a-snapshot-report`, which 404s
- Points the link to the correct existing section (`/snapshot-report/#why-is-snapshot-report-important`)

## Source
Reported by fpublico@vendasta.com via Google Form on 6/4/2026:
- Broken path: Partner Center > Administration > Customize Business App > Add Your Clients > Client self-sign-up > Snapshot Report
- Broken URL: `https://docs.vendasta.com/snapshot-report/what-is-a-snapshot-report`
- Correct URL: `https://docs.vendasta.com/snapshot-report/#why-is-snapshot-report-important`

## Test plan
- [ ] Confirm the link resolves to the "Why is Snapshot Report important?" section on the live site after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)