### PR TITLE
Docs: Duplicate social connection error in Multi-Location Social (SM-4180)

### DIFF
--- a/docusaurus/docs/multi-location-business-app/social/multi-location-import-csv.mdx
+++ b/docusaurus/docs/multi-location-business-app/social/multi-location-import-csv.mdx
@@ -62,6 +62,14 @@ Previously, you could only schedule one social post at a time. This feature remo
 
 <img src={require('./img/multi-location-CSV-location.png').default} alt="CSV Upload Location Selection" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
 
+:::warning
+If two or more of the locations you choose share the same Facebook, Instagram, LinkedIn, or X connection, you can't save the post. You'll see:
+
+**"Posts cannot be saved because the same Facebook/Instagram/LinkedIn/X connection is linked to multiple locations to stop duplicate posts. To continue, either remove this social connection from the other location(s) or remove the affected location."**
+
+Where possible, the message names the specific location. Remove the shared connection from the other location, or remove the affected location, then continue.
+:::
+
 8. (Optional) Enable `Upload as drafts` to save posts without scheduling
 
 <img src={require('./img/multi-location-CSV-drafts.png').default} alt="CSV Upload Location Drafts" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
@@ -219,5 +227,12 @@ It enables automatic localization of posts per location using AI Knowledge and S
 <summary>What if a location doesn't have AI configuration?</summary>
 
 The original multi-location content will be used without personalization.
+
+</details>
+
+<details>
+<summary>Why can't I save posts to some of the locations I chose?</summary>
+
+This happens when two or more of the chosen locations share the same Facebook, Instagram, LinkedIn, or X connection. Import CSV blocks saving in this case to prevent duplicate posts. Remove the shared connection from the other location(s), or remove the affected location, then continue.
 
 </details>

--- a/docusaurus/docs/multi-location-business-app/social/multi-location-social-posting.mdx
+++ b/docusaurus/docs/multi-location-business-app/social/multi-location-social-posting.mdx
@@ -43,6 +43,14 @@ By default, all locations are selected. Click Refine Locations to select locatio
 2. **Geography** - select locations by country or by state/province 
 3. **Location** - select specific locations that you want to include in your post
 
+:::warning
+If two or more of your selected locations share the same Facebook, Instagram, LinkedIn, or X connection, you can't save the post. You'll see:
+
+**"Posts cannot be saved because the same Facebook/Instagram/LinkedIn/X connection is linked to multiple locations to stop duplicate posts. To continue, either remove this social connection from the other location(s) or remove the affected location."**
+
+Where possible, the message names the specific location. Remove the shared connection from the other location, or remove the affected location, then save the post again.
+:::
+
 ### Viewing recent and scheduled posts
 
 In **Recent** and **Scheduled**, each post appears once for Facebook and Google Business Profile. Click **all locations** to see which accounts the post was published to. Click an **individual account name** to open that location’s view.
@@ -103,4 +111,10 @@ Clicking a location will open a side panel with more details specific to the loc
 Multi-location posting supports **Facebook**, **Instagram**, and **Google Business Profile** only. Other platforms your locations may have connected — such as LinkedIn or X — are not available for multi-location posts and must be posted to individually from each location's own Social AI app.
 
 **Instagram requirements:** Instagram posting requires Social AI **Pro**. Locations on Social AI Standard will not receive Instagram posts from a multi-location campaign, even if Instagram is connected to their account. The post will still publish to their Facebook and Google Business Profile pages.
+</details>
+
+<details>
+<summary>Why can't I save a post to some of my selected locations?</summary>
+
+This happens when two or more of your selected locations share the same Facebook, Instagram, LinkedIn, or X connection. Multi-location social posting blocks saving in this case to prevent duplicate posts. Remove the shared connection from the other location(s), or remove the affected location, then save the post again.
 </details>


### PR DESCRIPTION
## JIRA

[SM-4180](https://vendasta.jira.com/browse/SM-4180) — [ML] Display Proper Error Message When Saving Posts to AGIDs with Duplicate Social Connections

## Classification

UI/UX change — new validation error message surfaced in Multi-Location Social workflows.

## Repo targeted

**Partner Center** only. This story affects the Multi-Location Social composer and Import CSV workflows, which are documented exclusively in this repo (`docusaurus/docs/multi-location-business-app/social/`). The Business App docs repo has no equivalent multi-location group composer content and required no changes, so no PR was opened there.

## Summary of changes

When a Multi-Location Social group contains locations that share the same Facebook, Instagram, LinkedIn, or X connection, saving a post to those locations is now blocked with an explanatory error. Documented this in both places it applies:

- **`multi-location-social-posting.mdx`** — added a warning callout after the "Refine Locations" step (single-post composer workflow) and a new FAQ entry.
- **`multi-location-import-csv.mdx`** — added a warning callout after the location/platform selection step (Import CSV workflow) and a new FAQ entry.

Existing pages were updated in place; no new page was created, since the content fit cleanly into the two docs that already cover these exact workflows.

## Placement reasoning

`multi-location-social-posting.mdx` documents the "Refine Locations" step of the single-post composer, and `multi-location-import-csv.mdx` documents the location/network selection step of the CSV import flow — these are the exact points in each workflow where the ticket says the error surfaces. Adding the callout at that step, plus a matching FAQ entry, keeps the explanation next to the action a reader would be taking when they hit it, without duplicating content across pages.

## Acceptance criteria coverage

- ✅ ML → Single Post workflow error message documented (`multi-location-social-posting.mdx`)
- ✅ ML → Import CSV workflow error message documented (`multi-location-import-csv.mdx`)
- ✅ Noted that the message names the specific location where possible
- ✅ Scoped explicitly to Multi-Location Social (both docs are ML-only by definition)

## Figma / images

None provided on the ticket. The ticket instead included screenshots of the working error state in the demo and production environments (attached directly to the JIRA issue), which were used as the source for the exact error copy.

## Skills used

None of the repo's packaged skills matched this task (no `pre-push-validation` skill exists in this repo); relied on manual doc discovery/grep and a full `npm run build` to confirm no build errors or new broken links were introduced.

## Assumptions / limitations

- The parent epic ([SM-1337](https://vendasta.jira.com/browse/SM-1337)) is still "To Do" — it's a long-running, no-new-features UX umbrella epic. Checked its other children for rollout-gating signals (feature flags, eligibility, region restrictions) and found none relevant to this specific feature. The story's own JIRA comments and attached screenshots confirm the change is already verified and live in production, so proceeding was treated as safe.
- Could not verify or tag the actual code-review developer(s) as PR reviewer: this session's GitHub access is scoped to the `businessapp-docs` and `partnercenter-docs` repos only, not the engineering repo where SM-4180's linked PRs live. No reviewer was set as a result — please add manually if needed.

@ahnikakuse @haleyserrano @maryam6samadi

---
_Generated by [Claude Code](https://claude.ai/code/session_01DACHcpqWycKsea6vcYk6Ce)_

[SM-4180]: https://vendasta.jira.com/browse/SM-4180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SM-1337]: https://vendasta.jira.com/browse/SM-1337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ