### PR TITLE
docs: article verifications for August 4

### DIFF
--- a/docusaurus/docs/vendor-center/vendor-center-general/what-are-custom-products.mdx
+++ b/docusaurus/docs/vendor-center/vendor-center-general/what-are-custom-products.mdx
@@ -2,6 +2,7 @@
 title: "Create a product"
 sidebar_label: Create a product
 sidebar_position: 1
+description: Learn how to create products, editions, and add-ons in Vendor Center or Partner Center, and how to customize pricing, marketing, and integrations.
 ---
 
 Just like the products you'll find in the Vendasta Marketplace, you can sell the products you create in your store on their own, package and sell them together with other products and services, activate them for your customers, and bill for them using Vendasta Payments.
@@ -22,7 +23,7 @@ Naturally, some of the things you sell will be more complicated than others. Tha
 
 ## Editions
 
-Editions are versions of your product that represent different levels of service, functionality, or pricing options that you might offer. Customers can choose an edition of your product to buy and later upgrade or downgrade to a different edition when their needs change.
+Editions are versions of your product that represent different levels of service, functionality, or pricing options that you offer. Customers can choose an edition of your product to buy and later upgrade or downgrade to a different edition when their needs change.
 
 Editions of a product share marketing material and add-ons, but each edition can have its own price settings.
 
@@ -42,53 +43,53 @@ You can create a product from either Partner Center or Vendor Center:
 
 ### Partner Center
 
-Go to **Marketplace** → **Products**, then click `Create product` in the top right corner.
+Go to `Marketplace` → `Products`, then click `Create product` in the top right corner.
 
 ![Create product button in Partner Center](./img/partner-center-create-product.png)
 
 ### Vendor Center
 
-1. From Partner Center, click **Open Vendor Center** — it appears in the left sidebar under **Marketplace** or in the top right corner beside `Create product`.
-2. In Vendor Center, go to **Products**, then click `Add Product` in the top right corner.
+1. From Partner Center, click `Open Vendor Center`, which appears in the left sidebar under `Marketplace` or in the top right corner beside `Create product`.
+2. In Vendor Center, go to `Products`, then click `Add Product` in the top right corner.
 
 ![Add Product button in Vendor Center](./img/vendor-center-add-product.png)
 
-Both paths open the same product creation flow. When you click the button, an **Add Product** dialog opens. Work through the four steps:
+Both paths open the same product creation flow. When you click the button, an `Add Product` dialog opens. Work through the four steps:
 
-1. **Basic Info** — Enter the product name, select the product type, and upload an image.
-2. **Pricing** — Set your price and billing options.
-3. **Marketing** — Add marketing materials for your product listing.
-4. **Confirmation** — Review your choices.
+1. `Basic Info`: Enter the product name, select the product type, and upload an image.
+2. `Pricing`: Set your price and billing options.
+3. `Marketing`: Add marketing materials for your product listing.
+4. `Confirmation`: Review your choices.
 
 ![Add Product dialog with Basic Info step](./img/add-product-dialog.png)
 
-When you finish these steps, you can **Publish to store** to make the product available immediately, or **Continue editing in Vendor Center** for more options.
+When you finish these steps, you can `Publish to store` to make the product available immediately, or `Continue editing in Vendor Center` for more options.
 
 ## Customize in Vendor Center
 
 If you choose to continue editing, you'll land on your product page in Vendor Center. Here you have access to more options across several tabs:
 
-- **Product info** — Refine the product name, type, icon, short description, and vendor contact email. This is also where you set the pricing model, prices, billing period, subscription terms, trials, and editions, plus product activation and order forms.
-- **Marketing** — Add and manage marketing materials for your Marketplace listing.
-- **Integration** — Configure SSO, fulfillment, and product access. See [Integrate your product](./integrate-your-product).
-- **Add-ons** — Create add-ons to sell alongside your product.
-- **Compare product** — Open your product in the Marketplace to preview how it will look when published, and suspend new activations.
+- `Product info`: Refine the product name, type, icon, short description, and vendor contact email. This is also where you set the pricing model, prices, billing period, subscription terms, trials, and editions, plus product activation and order forms.
+- `Marketing`: Add and manage marketing materials for your Marketplace listing.
+- `Integration`: Configure SSO, fulfillment, and product access. See [Integrate your product](./integrate-your-product).
+- `Add-ons`: Create add-ons to sell alongside your product.
+- `Compare product`: Open your product in the Marketplace to preview how it will look when published, and suspend new activations.
 
 ![Product info tab in Vendor Center](./img/vendor-center-product-info.png)
 
 ### Related guides
 
-- [Set your product's price](./set-your-products-price) — Adjust pricing and choose from Fixed, Variable, or Contact Sales models
-- [Order form guide](../vendor-onboarding-guide/order-form-guide) — Order forms and fulfillment settings
-- [Task Manager integration](./task-manager-integration) — For service vendors: fulfillment tracking
-- [Create projects](./create-projects) — For service vendors: project creation and tracking
+- [Set your product's price](./set-your-products-price): Adjust pricing and choose from Fixed, Variable, or Contact Sales models
+- [Order form guide](../vendor-onboarding-guide/order-form-guide): Order forms and fulfillment settings
+- [Task Manager integration](./task-manager-integration): For service vendors: fulfillment tracking
+- [Create projects](./create-projects): For service vendors: project creation and tracking
 
 ## Frequently asked questions
 
 <details>
 <summary>Can I add a link to my custom product?</summary>
 
-You can add a link to your custom product in Vendor Center under the "Integration" tab. When active on an account, your custom product then appears in the product menu in Business App and is clickable. You can link to external dashboards, websites, and even eBooks.
+You can add a link to your custom product in Vendor Center under the `Integration` tab. When active on an account, your custom product then appears in the product menu in Business App and is clickable. You can link to external dashboards, websites, and even eBooks.
 
 1. Navigate to Vendor Center from the 9-box menu in the top right-hand corner of your Partner Center dashboard.
 
@@ -96,15 +97,15 @@ You can add a link to your custom product in Vendor Center under the "Integratio
 
 ![Custom product in Vendor Center menu](../img/partner-center/vendor-center-faqs/custom-product-vendor-center-menu.jpg)
 
-3. At the top of the screen, select the "Integration" tab.
+3. At the top of the screen, select the `Integration` tab.
 
 ![Integration tab in custom product](../img/partner-center/vendor-center-faqs/custom-product-integration-tab.jpg)
 
-4. Under "Access and SSO", add a link under "Product access URL".
+4. Under `Access and SSO`, add a link under `Product access URL`.
 
 ![Product access URL field](../img/partner-center/vendor-center-faqs/custom-product-access-url.jpg)
 
-5. Click "Save".
+5. Click `Save`.
 
 You can choose to have a custom URL per activation. If you check off this box, you will be able to add a specific URL to the order form for each individual activation.
 
@@ -113,7 +114,7 @@ You can choose to have a custom URL per activation. If you check off this box, y
 <details>
 <summary>Can I add a new category in Vendor Center?</summary>
 
-Partners cannot add a custom/new category in Vendor Center for their own custom product(s). Partners can only choose from the default LMI (Local Marketing Index) categories available in **Vendor Center** → **Marketing**. The selected category (primary and secondary) will determine where your custom product will appear in the Marketplace.
+Partners cannot add a custom/new category in Vendor Center for their own custom product(s). Partners can only choose from the default LMI (Local Marketing Index) categories available in `Vendor Center` → `Marketing`. The selected category (primary and secondary) will determine where your custom product will appear in the Marketplace.
 
 ![Vendor Center category selection screen](../img/partner-center/vendor-center-faqs/vendor-center-categories-1.jpg)
 

--- a/docusaurus/docs/vendor-center/vendor-onboarding-guide/marketing-requirements-guidelines-marketplace-vendors.mdx
+++ b/docusaurus/docs/vendor-center/vendor-onboarding-guide/marketing-requirements-guidelines-marketplace-vendors.mdx
@@ -4,21 +4,19 @@ sidebar_label: Marketing requirements
 description: Learn about the marketing requirements and guidelines for Marketplace vendors.
 ---
 
-# Marketing Requirements and Guidelines for Marketplace Vendors
+## Category selection
 
-## Category Selection
-
-Choose a category that best represents your product for the consumer. The category will help users find your product within our Marketplace. Think about which category a user would look in to find your specific product.
+Choose a category that best represents your product for partners. The category will help partners find your product within our Marketplace. Think about which category a partner would look in to find your specific product.
 
 ![Category Selection](./img/partner-center/vendor-onboarding-guide/category-selection.jpg)
 
 ## Product Card
 
-### Requirements for Product Card Images
+### Requirements for product card images
 
-Your product card image serves as a digital storefront within our Marketplace. It should be visually appealing and help users understand your product at a glance.
+Your product card image serves as a digital storefront within our Marketplace. It should be visually appealing and help partners understand your product at a glance.
 
-#### Card Image Guidelines:
+#### Card image guidelines
 - Dimensions: 370px x 200px
 - Format: JPG/PNG
 - File size: Maximum 5MB
@@ -28,11 +26,11 @@ Your product card image serves as a digital storefront within our Marketplace. I
 
 ![Card Image Examples](./img/partner-center/vendor-onboarding-guide/card-images-examples.jpg)
 
-### Requirements for Product Icon
+### Requirements for product icon
 
 Your product icon appears in multiple places throughout the platform, representing your brand and product.
 
-#### Icon Image Guidelines:
+#### Icon image guidelines
 - Dimensions: Square format (1:1 ratio), minimum 192px x 192px recommended
 - Format: JPG/PNG (transparent PNG preferred)
 - Quality: High resolution, clearly visible at small sizes
@@ -40,15 +38,15 @@ Your product icon appears in multiple places throughout the platform, representi
 
 ![Icon Image Examples](./img/partner-center/vendor-onboarding-guide/icon-image-examples.jpg)
 
-## Marketing Requirements
+## Marketing requirements
 
-### End User Marketing Materials
+### End user marketing materials
 
 Provide marketing materials that our partners can use to promote your product to their end-customers. These materials should explain the value of your product in simple terms that end-users will understand.
 
 ![End User Marketing](./img/partner-center/vendor-onboarding-guide/end-user-marketing.jpg)
 
-### User Benefits
+### User benefits
 
 Clearly articulate the benefits of your product for end-users. How does it solve their problems? What value does it provide?
 
@@ -56,15 +54,15 @@ Clearly articulate the benefits of your product for end-users. How does it solve
 
 ### FAQs
 
-Provide a list of frequently asked questions and their answers to help users understand your product better.
+Provide a list of frequently asked questions and their answers to help end-users understand your product better.
 
 ![FAQs](./img/partner-center/vendor-onboarding-guide/faqs.jpg)
 
-## Gallery Images
+## Gallery images
 
 Include high-quality screenshots or images that showcase your product's interface and features. These images will help potential customers understand how your product works and what to expect.
 
-### Gallery Image Guidelines:
+### Gallery image guidelines
 - Dimensions: 800px x 600px (4:3 ratio) or 1920px x 1080px (16:9 ratio)
 - Format: JPG/PNG
 - Content: Screenshots of your product interface, features in action
@@ -73,7 +71,7 @@ Include high-quality screenshots or images that showcase your product's interfac
 
 ![Gallery Images](./img/partner-center/vendor-onboarding-guide/gallery-images.jpg)
 
-## Best Practices for Marketing Success
+## Best practices for marketing success
 
 1. **Focus on Benefits**: Clearly communicate how your product solves specific problems for end-users.
 

--- a/docusaurus/docs/vendor-center/vendor-onboarding-guide/operational-requirements-for-marketplace-vendors.mdx
+++ b/docusaurus/docs/vendor-center/vendor-onboarding-guide/operational-requirements-for-marketplace-vendors.mdx
@@ -1,9 +1,8 @@
 ---
 title: Operational Requirements for Marketplace Vendors
 sidebar_label: Operational requirements
+description: Learn the operational requirements for structuring products, editions, add-ons, and pricing before your product reaches general availability in the Marketplace.
 ---
-
-# Operational requirements for Marketplace Vendors
 
 You must meet or exceed these operational requirements before your product or service reaches general availability.
 
@@ -22,14 +21,14 @@ You can offer multiple paid tiers; each tier is an **Edition** in the Marketplac
 
 ![Product Creation](./img/partner-center/vendor-onboarding-guide/product-creation.jpg)
 
-1. **Basic info:** name, category, vertical, description, etc.
-2. **Integration settings:** SSO, Fulfillment, etc.
+1. `Basic info`: name, category, vertical, description, etc.
+2. `Integration settings`: SSO, Fulfillment, etc.
 
 ![Integration Settings](./img/partner-center/vendor-onboarding-guide/integration-settings.jpg)
 
-3. **Editions:** feature list, price, minimum, term, etc.
-4. **Content:** logos, screenshots, documents, videos, etc.
-5. **Visibility:** approval status
+3. `Editions`: feature list, price, minimum, term, etc.
+4. `Content`: logos, screenshots, documents, videos, etc.
+5. `Visibility`: approval status
 
 ### Multi-purchase
 

--- a/docusaurus/docs/vendor-center/vendor-onboarding-guide/order-form-guide.mdx
+++ b/docusaurus/docs/vendor-center/vendor-onboarding-guide/order-form-guide.mdx
@@ -27,50 +27,50 @@ Avoid using an order form when possible, since it adds purchase friction. If you
 
 ## Creating an order form
 
-1. Navigate to **Vendor Center** → **Product Name** → **Product Info** → **Product Activation** → **Order Form**, then toggle **Use a custom order form**.
-2. Choose any necessary **Basic Information. AccountID** and **Company Name** are recommended.
-   - These are **optional** by default to avoid completed order forms from containing irrelevant information. If you require any of this information check them off.
+1. Navigate to `Vendor Center` → `Product Name` → `Product Info` → `Product Activation` → `Order Form`, then toggle `Use a custom order form`.
+2. Choose any necessary Basic Information fields. `AccountID` and `Company Name` are recommended.
+   - These are `optional` by default to avoid completed order forms from containing irrelevant information. If you require any of this information, check them off.
 
-**Selecting the Primary Contact** will not result in obtaining required contact information. The Primary Contact will automatically populate any existing user on the account.
+Selecting the `Primary Contact` option will not result in obtaining required contact information. The `Primary Contact` field will automatically populate any existing user on the account.
 
-**Selecting Salesperson** will only provide you with the Reseller's assigned Salesperson on the account which will not result in obtaining required contact information.
+Selecting `Salesperson` will only provide you with the Reseller's assigned Salesperson on the account, which will not result in obtaining required contact information.
 
-3. **Additional Information fields** (optional) will enforce the Reseller to backfill required information on their or their client's account.
-4. To add a custom field, click **Add Form Field** and expand the New Form Field item that will have appeared.
-5. The **Order Form Footer** should be used to include information regarding the order itself such as service level agreements and is displayed to both the Reseller and their client.
+3. `Additional Information` fields (optional) will require the Reseller to backfill required information on their or their client's account.
+4. To add a custom field, click `Add Form Field` and expand the `New Form Field` item that appears.
+5. The `Order Form Footer` should be used to include information regarding the order itself such as service level agreements and is displayed to both the Reseller and their client.
 
 ### Types of form fields
 
 There are various types of form fields available. Underneath each is an example of that field as it would appear in Partner Center when activating a product:
 
-- **Files** – Used to request specific files.
-- **Drop Down** – A multi-option field where you can add options by selecting Add Option.
-- **Check Box** — Allows you to present the user with a single option in the form of a checkbox.
-- **Text Area** – An open-ended input that allows users to type long answers. This is especially useful when requesting a description.
-- **Text Box** – An input box that allows users to enter text for simple answers. You can add a prefix and suffix to this, as well as add regex validation (answers must be in a specific format).
-  - One example might be that you want users to enter their website. You may start with a prefix of 'www.' and a suffix of '.com'.
-- **End User** – Requires a user on the account to be selected as a designated user of the product. This field is commonly used in tandem with a seat-based billing model.
+- `Files`: Used to request specific files.
+- `Drop Down`: A multi-option field where you can add options by selecting Add Option.
+- `Check Box`: Allows you to present the user with a single option in the form of a checkbox.
+- `Text Area`: An open-ended input that allows users to type long answers. This is especially useful when requesting a description.
+- `Text Box`: An input box that allows users to enter text for simple answers. You can add a prefix and suffix to this, as well as add regex validation (answers must be in a specific format).
+  - For example, if you want users to enter their website, you can add a prefix of `www.` and a suffix of `.com`.
+- `End User`: Requires a user on the account to be selected as a designated user of the product. This field is commonly used in tandem with a seat-based billing model.
   - This can be handy if there is an initial user that needs to be set up with different permissions than all other users on the Account.
-  - If you mark this field as required, and there are no users on the Account it will force the admin to go back and add a user to the Account before they can activate your product.
+  - If you mark this field as required, and there are no users on the Account, it will force the admin to go back and add a user to the Account before they can activate your product.
 
 **Requirements**
 
-Form Fields can either be left as optional or Required. Requirements are often used for contact information, domains, digital advertising collateral, or shipping information for example.
+Form Fields can either be left as optional or Required. Requirements are often used for contact information, domains, digital advertising collateral, or shipping information, for example.
 
 **Which persona will see the order form?**
 
-Each form field requires you to choose whether it is **Hidden from end users** or **Office editable only**.
+Each form field requires you to choose whether it is `Hidden from end users` or `Office editable only`.
 
-**Hidden from end users** hides your question from the reseller's client, so the Reseller must provide a response. Select this option if you need specific Reseller contact information.
+`Hidden from end users` hides your question from the reseller's client, so the Reseller must provide a response. Select this option if you need specific Reseller contact information.
 
-**Office editable only** lets end users see the form field but not provide a response. Making this selection means you may want the end user to be informed of certain configurations, but not be able to change them.
+`Office editable only` lets end users see the form field but not provide a response. Making this selection means you may want the end user to be informed of certain configurations, but not be able to change them.
 
 ### Asking for contact information
 
 You may need to get in touch with either the Reseller or their client if you provide an initial onboarding or the SKU is a service. 
 
 :::warning Primary Contact does not provide required contact info
-Selecting the Primary Contact may not give you the contact information you need. The Primary Contact field automatically populates a user from the account. Use custom order form fields to capture the required contact information.
+Selecting the `Primary Contact` may not give you the contact information you need. The `Primary Contact` field automatically populates a user from the account. Use custom order form fields to capture the required contact information.
 :::
 
 ![](./img/partner-center/vendor-onboarding-guide/order-form-contact-info.png)
@@ -79,21 +79,21 @@ Selecting the Primary Contact may not give you the contact information you need.
 
 **If you will communicate with the Reseller OR their client:**
 
-Start with a question for the Reseller to identify who you are able to communicate with. This question should be **Required** and **Hidden from end users** and works best in the form of a Drop Down form field.
+Start with a question for the Reseller to identify who you are able to communicate with. This question should be `Required` and `Hidden from end users` and works best in the form of a `Drop Down` form field.
 
 ![](./img/partner-center/vendor-onboarding-guide/order-form-dropdown.png)
 
 :::tip Best practice
-Include a **Check Box** that is **Required** and **Hidden from end users** for the Reseller to acknowledge that by choosing "End user", you will contact their customer directly and this will not be a white-labelled product.
+Include a `Check Box` that is `Required` and `Hidden from end users` for the Reseller to acknowledge that by choosing `End User`, you will contact their customer directly and this will not be a white-labelled product.
 :::
 
-Lastly, ensure you ask for the contact's name and contact information as **Required** and **Hidden from end users** Form Fields. Here's an example of the full order form requesting contact information if you don't have a preference for which persona you interact with on the project:
+Lastly, ensure you ask for the contact's name and contact information as `Required` and `Hidden from end users` Form Fields. Here's an example of the full order form requesting contact information if you don't have a preference for which persona you interact with on the project:
 
 ![](./img/partner-center/vendor-onboarding-guide/order-form-contact-full.png)
 
 **If you will be communicating with the Reseller only:**
 
-Your questions should be **Required** and **Hidden from end users** and include hint text that lets the Reseller know that you will only be in communication with them directly. Here's an example of the full order form when you will only be communicating with the Reseller:
+Your questions should be `Required` and `Hidden from end users` and include hint text that lets the Reseller know that you will only be in communication with them directly. Here's an example of the full order form when you will only be communicating with the Reseller:
 
 ![](./img/partner-center/vendor-onboarding-guide/order-form-reseller-only.png)
 

--- a/docusaurus/docs/vendor-center/vendor-onboarding-guide/technical-requirements.mdx
+++ b/docusaurus/docs/vendor-center/vendor-onboarding-guide/technical-requirements.mdx
@@ -4,4 +4,4 @@ sidebar_label: Technical requirements
 description: Technical integration requirements for vendors in the Vendasta Marketplace
 ---
 
-If you want your Product distributed in the Vendasta Marketplace, then there is a set of integrations that all distributed products must implement. To get started, you can find all the required features in the [Marketplace Documentation](https://developers.vendasta.com/vendor/2e2cafd289899-getting-started) and at [developers.vendasta.com](https://developers.vendasta.com/).
+If you want your product distributed in the Vendasta Marketplace, then there is a set of integrations that all distributed products must implement. To get started, you can find all the required features in the [Marketplace Documentation](https://developers.vendasta.com/vendor/2e2cafd289899-getting-started) and at [developers.vendasta.com](https://developers.vendasta.com/).


### PR DESCRIPTION
## Summary
- Verified 5 articles flagged for review on August 4: marketing requirements, technical requirements, create a product, operational requirements, and the order form guide, all in the Vendor Center onboarding guide.
- Fixed audience-language issues ("consumer"/generic "users" corrected to "partners" where describing Marketplace browsers), extensive UI formatting (bold/quoted button, tab, and field names converted to inline code), em dash and mixed-dash cleanup, two prohibited-term removals ("might"), two duplicate H1s, two missing frontmatter descriptions, a future-perfect tense error, and assorted grammar fixes.
- 4 of 5 issues reached **Needs Update** with fixes applied; 1 (technical requirements) reached **Pass**. None required SME review, though a few items are flagged for a manual spot-check (see below).

## Test plan
- [ ] Spot-check rendered pages in `npm run start` for the five changed articles
- [ ] Confirm the `Compare product` tab name in "Create a product" is still current — the description doesn't obviously match the name
- [ ] Confirm "Vendor Success Manager" is still the current role title (Operational Requirements)
- [ ] Confirm whether "Sales order form" is a distinct form type or should read "Order Form and Fulfillment Form" (Order Form Guide)

Closes #868
Closes #869
Closes #870
Closes #871
Closes #872

🤖 Generated with [Claude Code](https://claude.com/claude-code)