### PR TITLE
chore: require a source citation on new training claims

### DIFF
--- a/.cursor/rules/source-citation-required
+++ b/.cursor/rules/source-citation-required
@@ -1,0 +1,92 @@
+---
+description: "Requires an inline source citation on every new factual claim in Learn tab training content — numbers, limits, entitlements, defaults, and UI paths."
+globs: ["docusaurus/training/**/*.mdx"]
+---
+
+CRITICAL: In `docusaurus/training/**`, a new factual claim ships with its source or it does not ship.
+
+Partners act on this content without re-checking it, and a wrong number in a course is repeated by
+reps to clients. Someone has to be able to audit every claim later without guessing where it came
+from. That is the whole point of the rule.
+
+## What must carry a citation
+
+Add a citation when you introduce or change any of these:
+
+- **Any number tied to the product or the market** — counts, caps, limits, percentages, multipliers,
+  prices, word counts, page counts, language counts, turnaround times, SLAs, trial durations.
+- **Entitlement and availability claims** — a feature requiring, being gated behind, included in,
+  free on, or limited to a named SKU or tier.
+- **Product, SKU and tier names** when the claim is about what that product is or does, not just a
+  passing mention. "Reputation AI Standard limits review sources to Google and Facebook" needs a
+  source. "Open Reputation AI" does not.
+- **Defaults and settings values** — "defaults to Level 3: Autonomous", "the default sending domain
+  is smblogin.com".
+- **UI navigation paths** — "Administration → SMS configuration".
+- **Third-party and market statistics** — anything attributed to a research publisher, and anything
+  a reader would read as research even if unattributed.
+
+## What does not need one
+
+Skip general marketing copy, opinion and framing, In Practice narratives and sales anecdotes,
+learning objectives, and anything the reader will obviously take as illustrative rather than factual.
+Do not add placeholder comments like "SOURCE NEEDED" — either cite it, waive it explicitly, or cut
+the claim.
+
+## The two forms
+
+Use `Source:` when the source confirms the claim:
+
+```jsx
+{/* Source: https://docs.vendasta.com/crm/ — verified 2026-08-05 */}
+```
+
+Use `Audit:` when the source contradicts the claim, only partly supports it, or the claim is on hold
+pending a product team's answer. Say what the finding was, then give the source:
+
+```jsx
+{/* Audit 2026-08-05: the 25-widget cap appears nowhere outside the docs corpus — flagged to the MS team to confirm or remove. Source: https://vendasta.jira.com/wiki/spaces/MS/pages/3356491826/Change+Vendasta+Services+Website+Naming */}
+```
+
+Keeping the two distinct is what lets the next auditor tell a confirmation from a contradiction
+without re-reading the source.
+
+If a claim genuinely cannot be sourced and you are keeping it anyway, mark it so the reason survives:
+
+```jsx
+{/* no-source-needed: partner-reported field result, presented as an anecdote */}
+```
+
+## Where to put it
+
+- **List items and table rows:** append the comment inline at the end of the same line. A JSX
+  expression on its own line between bullets or table rows splits the list or table.
+- **Paragraphs:** put the comment on its own line directly after the paragraph.
+- Comments render as nothing on the site. They are for the next person reading the source.
+
+## Sourcing discipline
+
+- **Never compose a URL from memory.** Fetch the page and confirm it contains the claim before citing
+  it. A citation that does not support its claim is worse than no citation, because the next auditor
+  trusts it and moves on.
+- Prefer, highest to lowest: `docs.vendasta.com`, Confluence at `vendasta.jira.com/wiki`,
+  `support.vendasta.com`, `vendasta.com` and `servicesdocs.io`, then a named external publisher with
+  a date. Cite the best available source rather than skipping the claim.
+- Include the verification date. A source that was right in 2026 is evidence about 2026, not forever.
+- When two sources conflict, cite both in an `Audit:` comment and name the team who decides. Do not
+  silently pick one.
+
+## Keep every copy of the claim in sync
+
+Training pages repeat the same fact in body copy, FlipCards and Knowledge Check answers. When you
+change or cite a number, grep the file for it and update every instance. A corrected body paragraph
+sitting above a quiz that still teaches the old number is worse than either alone, because the
+learner is tested on the wrong answer.
+
+## Related
+
+- The [Learn tab content audit sheet](https://docs.google.com/spreadsheets/d/1p8mzuaFeZxkFPxKZR72ynybf5gShepfJGSRL0T7-CGU/edit) tracks which claims have been
+  verified, which are on hold, and who owns each open question. Add a row there when you leave
+  something unresolved.
+- `scripts/check_source_citations.py` flags uncited claims on pull requests. It is advisory, not a
+  gate, and it will miss things. It is not a substitute for citing as you write.

--- a/.github/workflows/source-citation-check.yml
+++ b/.github/workflows/source-citation-check.yml
@@ -1,0 +1,107 @@
+# .github/workflows/source-citation-check.yml
+#
+# Flags factual claims added to Learn tab training content that ship without a source
+# citation, and reports them as a single PR comment.
+#
+# This check is deliberately ADVISORY. It never fails the build and never blocks a merge.
+# It is a reviewer aid, not a gate — the detection is heuristic and will both miss real
+# gaps and occasionally flag prose that needs no source. The actual rule lives in
+# .cursor/rules/source-citation-required and CLAUDE.md; authors are expected to cite as
+# they write rather than wait for this.
+
+name: Source Citation Check
+
+on:
+  pull_request:
+    paths:
+      - "docusaurus/training/**/*.mdx"
+      - "scripts/check_source_citations.py"
+  workflow_dispatch:
+    inputs:
+      scan_all:
+        description: "Scan every training file instead of just this PR's changes"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+
+jobs:
+  check-citations:
+    name: Flag uncited claims
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          # Full history so the base commit is present for the diff
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Run the citation check
+        id: check
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.scan_all }}" = "true" ]; then
+            python3 scripts/check_source_citations.py --all --output report.md
+          else
+            python3 scripts/check_source_citations.py \
+              --base "${{ github.event.pull_request.base.sha }}" \
+              --output report.md
+          fi
+
+          # Expose whether anything was flagged, so the comment step can stay quiet
+          # on clean PRs that never had a comment.
+          if grep -q "^| [0-9]" report.md; then
+            echo "findings=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "findings=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Comment on the pull request
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- source-citation-check -->';
+            const body = marker + '\n\n' + fs.readFileSync('report.md', 'utf8');
+            const findings = ${{ steps.check.outputs.findings }};
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number, per_page: 100 }
+            );
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+
+            if (existing) {
+              // Keep one comment and edit it in place, so the thread does not fill up
+              // with a new report on every push.
+              await github.rest.issues.updateComment({
+                owner, repo, comment_id: existing.id, body,
+              });
+              core.info(`Updated comment ${existing.id}`);
+            } else if (findings) {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number, body,
+              });
+              core.info('Posted a new comment');
+            } else {
+              core.info('Nothing flagged and no existing comment — staying quiet');
+            }
+
+      - name: Write the report to the run summary
+        if: always()
+        run: cat report.md >> "$GITHUB_STEP_SUMMARY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,18 @@ URL redirects are managed in `docusaurus.config.ts` via `@docusaurus/plugin-clie
 - Sentence case headings: `## Set up a domain`
 - **Bold** for UI elements, `code` for commands and filenames
 
+### Source citations in training content
+
+Applies to `docusaurus/training/**`. Full rule: `.cursor/rules/source-citation-required`.
+
+- **Every new factual claim ships with its source.** Numbers, caps, limits, percentages, prices, turnaround times, SLAs, trial durations, entitlement and tier gating, defaults, and UI navigation paths.
+- Two forms. `{/* Source: URL — verified YYYY-MM-DD */}` when the source confirms the claim. `{/* Audit YYYY-MM-DD: finding. Source: URL */}` when it contradicts, only partly supports, or the claim is on hold pending a product team's answer.
+- **Append inline on list items and table rows.** A JSX expression on its own line between bullets or table rows splits the list or table. Paragraphs get the comment on the next line.
+- **Never compose a URL from memory.** Fetch the page and confirm it contains the claim first. A citation that does not support its claim is worse than none.
+- **Sync every copy of the claim.** Training pages repeat facts in body copy, FlipCards and Knowledge Check answers. Grep the file and update all of them, or the quiz will test the old number.
+- Skip marketing copy, learning objectives and In Practice anecdotes. If a claim genuinely needs no source, mark it `{/* no-source-needed: reason */}` rather than leaving it bare.
+- `scripts/check_source_citations.py` flags gaps on pull requests. Advisory only, and it misses things. Cite as you write.
+
 ### Frontmatter
 
 ```yaml

--- a/scripts/check_source_citations.py
+++ b/scripts/check_source_citations.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""
+Flag factual claims in Learn tab training content that ship without a source citation.
+
+Advisory only. This script never decides whether a claim is true — it decides whether a
+future auditor would be able to check it. Exit code is 0 unless --strict is passed.
+
+The rule this enforces is documented in .cursor/rules/source-citation-required and in
+CLAUDE.md. The running audit trail lives in SOURCE-COMMENT-HANDOFF.md.
+
+Usage
+-----
+  # what a PR added, compared against the base branch (this is what CI runs)
+  python3 scripts/check_source_citations.py --base origin/master
+
+  # sweep whole files instead of just added lines
+  python3 scripts/check_source_citations.py --all
+
+  # sweep specific files
+  python3 scripts/check_source_citations.py --all --paths docusaurus/training/vibe/meet-vibe.mdx
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+TRAINING_ROOT = "docusaurus/training/"
+
+# A comment that satisfies the rule. Accepts the two documented forms, the explicit
+# waiver, and the older "<something> source:" phrasing already in the tree.
+CITATION_RE = re.compile(
+    r"\{/\*\s*(?:audit\b|no-source-needed\s*:|[a-z ]{0,24}source\s*:)",
+    re.IGNORECASE,
+)
+
+# An inline markdown link to a real URL also counts — the claim is sourced in the prose.
+INLINE_LINK_RE = re.compile(r"\]\(https?://")
+
+# Product, SKU and tier names. Used only to qualify entitlement claims, never on their
+# own — a bare product mention is not a claim. Extend this list as the lineup changes.
+PRODUCT_NAMES = [
+    "Reputation AI", "Reputation Management", "Conversations AI", "Social AI",
+    "Social Marketing", "Business App", "Snapshot Report", "Executive Report",
+    "Local SEO", "Advertising Intelligence", "MatchCraft", "Clickable.bio",
+    "CalendarHero", "Kixie", "WooCommerce", "Duda", "Accelerated Templated Website",
+    "Vendasta Payments", "AI Chat Receptionist", "AI Voice Receptionist",
+    "Voice Receptionist", "Sales Assistant", "Task Manager", "Marketplace",
+    "Partner Center", "WordPress Hosting", "Alpha SEO", "Campaigns Pro",
+    "Google Business Profile", "Vibe", "AI Workforce", "Autopilot",
+]
+PRODUCT_RE = re.compile("|".join(re.escape(p) for p in PRODUCT_NAMES))
+
+UNITS = (
+    r"products?|widgets?|pages?|languages?|words?|sources?|data\s+points?|"
+    r"days?|minutes?|hours?|weeks?|months?|years?|countries|country|reviews?|"
+    r"contacts?|users?|seats?|options?|templates?|integrations?|platforms?|"
+    r"networks?|stars?|KPIs?|leads?|calls?|posts?|keywords?"
+)
+
+CLAIM_RULES: list[tuple[str, re.Pattern[str]]] = [
+    ("percentage", re.compile(r"\d+(?:\.\d+)?\s?%")),
+    ("multiplier", re.compile(r"\b\d+(?:\.\d+)?x\b", re.IGNORECASE)),
+    ("price", re.compile(r"\$\s?\d")),
+    (
+        "qualified number",
+        re.compile(
+            r"\b(?:over|under|up\s+to|more\s+than|less\s+than|fewer\s+than|"
+            r"at\s+least|at\s+most|as\s+many\s+as)\s+\$?\d",
+            re.IGNORECASE,
+        ),
+    ),
+    ("counted noun", re.compile(rf"\b\d[\d,]*\+?\s+(?:business\s+)?(?:{UNITS})\b", re.IGNORECASE)),
+    ("default value", re.compile(r"\b(?:defaults?\s+to|by\s+default)\b", re.IGNORECASE)),
+    ("UI navigation path", re.compile(r"[A-Za-z]\s*(?:→|➜)\s*[A-Z]")),
+    (
+        "research attribution",
+        re.compile(r"\b(?:according\s+to|study|survey|research\s+(?:shows|found))\b", re.IGNORECASE),
+    ),
+]
+
+ENTITLEMENT_RE = re.compile(
+    r"\b(?:only\s+works\s+when|only\s+available|only\s+with|must\s+be\s+active|"
+    r"gated\s+behind|requires?|required\s+(?:for|to)|included\s+(?:in|with)|"
+    r"free\s+(?:on|with)|limited\s+to|available\s+(?:on|with)|part\s+of|"
+    r"add-on|entitle|prerequisite|upgrade\s+to)\b",
+    re.IGNORECASE,
+)
+
+# Lines that are structure, chrome or learning objectives rather than claims.
+SKIP_SUBSTRINGS = (
+    "<CourseProgressBar", "<SectionFeedback", "courseId=", "sidebar_position",
+    "Estimated time", "&#10003;", "import ", "className=\"principle-area\"",
+    "<PageActions", "<Cards",
+)
+SKIP_LINE_RE = re.compile(r"^\s*#{1,6}\s+Step\s+\d", re.IGNORECASE)
+
+# In Practice blocks are illustrative narratives, not claims the reader should act on.
+# Both markup styles appear in the tree.
+IN_PRACTICE_OPEN_RE = re.compile(r"className=\"in-practice\"|:::tip\s+In Practice", re.IGNORECASE)
+IN_PRACTICE_CLOSE_RE = re.compile(r"^\s*(?:</div>|:::)\s*$")
+
+# Keep a PR comment readable even when someone lands a whole new course.
+MAX_ROWS = 40
+
+# Lines that mirror a claim made elsewhere on the page. Reported separately as a
+# sync reminder, because the body copy is where the citation belongs.
+MIRROR_RE = re.compile(
+    r"<FlipCard|<KnowledgeCheck|correctIndex"
+    r"|type:\s*\"(?:mcq|truefalse|match|sort|whicharea|fillblank|ordering|sequence)\""
+)
+
+
+def is_training_mdx(path: str) -> bool:
+    return path.startswith(TRAINING_ROOT) and path.endswith(".mdx")
+
+
+def git(*args: str) -> str:
+    return subprocess.run(
+        ["git", *args], check=True, capture_output=True, text=True
+    ).stdout
+
+
+def changed_training_files(base: str) -> list[str]:
+    out = git("diff", "--name-only", "--diff-filter=d", f"{base}...HEAD")
+    return [p for p in out.splitlines() if is_training_mdx(p)]
+
+
+def added_line_numbers(base: str, path: str) -> set[int]:
+    """Line numbers in the new file that this diff added."""
+    out = git("diff", "--unified=0", f"{base}...HEAD", "--", path)
+    added: set[int] = set()
+    for line in out.splitlines():
+        m = re.match(r"^@@ -\S+ \+(\d+)(?:,(\d+))? @@", line)
+        if m:
+            start, count = int(m.group(1)), int(m.group(2) or 1)
+            added.update(range(start, start + count))
+    return added
+
+
+def scan(path: str, only_lines: set[int] | None) -> tuple[list[dict], list[dict]]:
+    """Return (findings, mirrors) for one file."""
+    with open(path, encoding="utf-8", newline="") as fh:
+        lines = fh.read().splitlines()
+
+    # Section index, so a nav path can be judged against its whole procedure rather
+    # than the line it sits on. A step-by-step page has a nav path on every line;
+    # citing the procedure once is the reasonable bar, not once per step.
+    section_of: dict[int, int] = {}
+    section_cited: dict[int, bool] = {}
+    current = 0
+    for i, raw in enumerate(lines, start=1):
+        if re.match(r"^\s*#{2,3}\s+\S", raw):
+            current = i
+        section_of[i] = current
+        if CITATION_RE.search(raw):
+            section_cited[current] = True
+
+    findings: list[dict] = []
+    mirrors: list[dict] = []
+    nav_sections_reported: set[int] = set()
+
+    in_fence = False
+    in_practice = False
+    frontmatter_bounds = 0
+
+    for idx, raw in enumerate(lines, start=1):
+        line = raw.rstrip("\r")
+        stripped = line.strip()
+
+        if stripped == "---" and frontmatter_bounds < 2 and idx <= 20:
+            frontmatter_bounds += 1
+            continue
+        if frontmatter_bounds == 1:
+            continue
+        if stripped.startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence or not stripped:
+            continue
+
+        if in_practice:
+            if IN_PRACTICE_CLOSE_RE.match(line):
+                in_practice = False
+            continue
+        if IN_PRACTICE_OPEN_RE.search(line):
+            in_practice = True
+            continue
+        if only_lines is not None and idx not in only_lines:
+            continue
+        if SKIP_LINE_RE.match(line) or any(s in line for s in SKIP_SUBSTRINGS):
+            continue
+
+        triggers = [name for name, rx in CLAIM_RULES if rx.search(line)]
+        if ENTITLEMENT_RE.search(line) and PRODUCT_RE.search(line):
+            triggers.append("entitlement claim")
+        if not triggers:
+            continue
+
+        # A claim counts as cited if the citation sits on the same line, or on the
+        # nearest non-blank line either side of it.
+        neighbourhood = [line]
+        for step in (-1, 1):
+            j = idx - 1 + step
+            while 0 <= j < len(lines) and not lines[j].strip():
+                j += step
+            if 0 <= j < len(lines):
+                neighbourhood.append(lines[j])
+
+        # A citation for a table row is conventionally placed after the whole table,
+        # so widen the neighbourhood to the contiguous table block and what follows it.
+        if stripped.startswith("|"):
+            start = end = idx - 1
+            while start > 0 and lines[start - 1].strip().startswith("|"):
+                start -= 1
+            while end + 1 < len(lines) and lines[end + 1].strip().startswith("|"):
+                end += 1
+            neighbourhood.extend(lines[start : min(end + 4, len(lines))])
+
+        cited = any(CITATION_RE.search(n) for n in neighbourhood) or INLINE_LINK_RE.search(line)
+
+        if cited:
+            continue
+
+        triggers = sorted(set(triggers))
+
+        if triggers == ["UI navigation path"]:
+            section = section_of[idx]
+            if section_cited.get(section) or section in nav_sections_reported:
+                continue
+            nav_sections_reported.add(section)
+
+        record = {"line": idx, "triggers": triggers, "text": stripped}
+        (mirrors if MIRROR_RE.search(line) else findings).append(record)
+
+    return findings, mirrors
+
+
+def truncate(s: str, n: int = 150) -> str:
+    s = s.replace("|", r"\|")
+    return s if len(s) <= n else s[: n - 1] + "…"
+
+
+def render(results: dict[str, tuple[list[dict], list[dict]]]) -> str:
+    total = sum(len(f) for f, _ in results.values())
+    mirror_total = sum(len(m) for _, m in results.values())
+
+    if not total and not mirror_total:
+        return (
+            "### Source citation check\n\n"
+            "No uncited claims found in the training content this PR touches.\n"
+        )
+
+    out = ["### Source citation check", ""]
+    if total:
+        out.append(
+            f"Found **{total}** claim{'s' if total != 1 else ''} without a nearby source "
+            "citation. This check is advisory and does not block the merge, but each one "
+            "is a fact a future auditor will not be able to trace."
+        )
+        out.append("")
+        shown = 0
+        for path, (findings, _) in sorted(results.items()):
+            if not findings or shown >= MAX_ROWS:
+                continue
+            out.append(f"**`{path}`**")
+            out.append("")
+            out.append("| Line | Looks like | Content |")
+            out.append("|------|------------|---------|")
+            for f in findings:
+                if shown >= MAX_ROWS:
+                    break
+                out.append(f"| {f['line']} | {', '.join(f['triggers'])} | {truncate(f['text'])} |")
+                shown += 1
+            out.append("")
+        if total > shown:
+            out.append(
+                f"Showing the first {shown}. {total - shown} more not listed — run "
+                "`python3 scripts/check_source_citations.py --base origin/master` locally "
+                "for the full list."
+            )
+            out.append("")
+
+    if mirror_total:
+        plural = "s" if mirror_total != 1 else ""
+        out.append(
+            f"<details><summary>Plus {mirror_total} FlipCard or Knowledge Check line{plural} "
+            "repeating a figure — cite the body copy, then make sure these match it</summary>"
+        )
+        out.append("")
+        for path, (_, ms) in sorted(results.items()):
+            for m in ms:
+                out.append(f"- `{path}` line {m['line']} — {truncate(m['text'], 110)}")
+        out.append("")
+        out.append("</details>")
+        out.append("")
+
+    out.append(
+        "Fix by adding `{/* Source: URL — verified YYYY-MM-DD */}` next to the claim, or "
+        "`{/* Audit YYYY-MM-DD: finding. Source: URL */}` if the source disagrees with it. "
+        "See `.cursor/rules/source-citation-required` for placement and sourcing rules. "
+        "If a claim genuinely needs no source, mark it `{/* no-source-needed: reason */}`."
+    )
+    return "\n".join(out) + "\n"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--base", default="origin/master", help="base ref to diff against")
+    ap.add_argument("--all", action="store_true", help="scan whole files, not just added lines")
+    ap.add_argument("--paths", nargs="*", help="explicit files to scan (implies --all)")
+    ap.add_argument("--output", help="write the markdown report here as well as stdout")
+    ap.add_argument("--strict", action="store_true", help="exit 1 when findings exist")
+    args = ap.parse_args()
+
+    if args.paths:
+        files = [p for p in args.paths if is_training_mdx(p)]
+        scan_all = True
+    elif args.all:
+        files = sorted(str(p) for p in Path(TRAINING_ROOT).rglob("*.mdx"))
+        scan_all = True
+    else:
+        try:
+            files = changed_training_files(args.base)
+        except subprocess.CalledProcessError as exc:
+            print(f"git diff against {args.base} failed: {exc.stderr.strip()}", file=sys.stderr)
+            return 0
+        scan_all = False
+
+    results: dict[str, tuple[list[dict], list[dict]]] = {}
+    for path in files:
+        if not Path(path).exists():
+            continue
+        only = None if scan_all else added_line_numbers(args.base, path)
+        if only is not None and not only:
+            continue
+        findings, mirrors = scan(path, only)
+        if findings or mirrors:
+            results[path] = (findings, mirrors)
+
+    report = render(results)
+    print(report)
+    if args.output:
+        Path(args.output).write_text(report, encoding="utf-8")
+
+    findings_total = sum(len(f) for f, _ in results.values())
+    return 1 if (args.strict and findings_total) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Hey Shiva, a few concerns with this one.

Right idea. You found a real problem and I am glad you chased it. But the execution here would be really heavy for what we get. Every time anyone adds a number to a training page they would owe a source note, and a bot would comment on the pull request when they miss one. That is a tax on every change, forever, to catch something we could sweep for once a month instead.

The bigger thing is that I do not want to edit `CLAUDE.md` or the rules files for this. Those files get loaded every time anyone works in this repo, and almost all of that work is product documentation, not training. Keeping them tight is the priority, so they need to stay focused on how to write here. Anything to do with checking and auditing content should live in a separate tool or a scheduled routine we run, not in the writing instructions everyone carries around.

So: let's keep the audit findings from the other PR, drop the rule and the bot, and build the checking as its own thing on a monthly cadence.

Detail is in my review above if you want the specifics. Happy to grab 30 minutes and work out the replacement together, I do not want you guessing at what I am asking for.

---

# chore: require a source citation on new training claims

Turns the source-citation convention into an enforced rule rather than tribal knowledge. Any new factual claim added to Learn tab training content has to ship with its source.

Scoped to `docusaurus/training/**` only. Help centre articles stay under the existing `article-review` workflow.

---

## Why now

The companion PR (`docs/learn-audit-sources`) cites 73 existing claims. Without a rule, the tree drifts straight back: a new course lands next month with a fresh set of uncited numbers, and in two years someone runs the audit again from scratch.

The audit that prompted this found claims that were probably true when written and unverifiable by the time anyone checked. That is not a diligence problem, it is a process gap. Nothing in the repo asked authors to record a source, so most did not.

## What lands

| File | Lines | Purpose |
|---|---|---|
| `.cursor/rules/source-citation-required` | 91 | The full rule, for agents and humans |
| `CLAUDE.md` | +12 | Short form, under Content Guidelines |
| `scripts/check_source_citations.py` | 354 | Heuristic detector |
| `.github/workflows/source-citation-check.yml` | 107 | Runs the detector on PRs |

## The rule

### What needs a citation

- **Any number tied to the product or the market**: counts, caps, limits, percentages, multipliers, prices, word counts, page counts, language counts, turnaround times, SLAs, trial durations.
- **Entitlement and availability claims**: a feature requiring, gated behind, included in, free on, or limited to a named SKU or tier.
- **Product, SKU and tier names** when the claim is about what that product does. "Reputation AI Standard limits review sources to Google and Facebook" needs a source; "Open Reputation AI" does not.
- **Defaults and settings values**: "defaults to Level 3: Autonomous", "the default sending domain is smblogin.com".
- **UI navigation paths**: "Administration → SMS configuration".
- **Third-party and market statistics**, and anything a reader would take as research even if unattributed.

### What does not

General marketing copy, opinion and framing, In Practice narratives and sales anecdotes, and learning objectives. Citing those dilutes the signal until reviewers stop reading the comments at all.

### Two clauses that matter most in practice

**Never compose a URL from memory.** Fetch the page and confirm it contains the claim before citing it. A citation that does not support its claim is worse than no citation, because the next auditor trusts it and stops looking.

**Keep every restatement of a figure in sync.** Training pages repeat the same fact in body copy, FlipCards and Knowledge Check answers. A corrected paragraph above a stale quiz answer is worse than either alone, because the learner is graded on the wrong number. This has already happened: the language count was fixed in the body and the FlipCard but not the quiz, and sat that way until the companion PR caught it.

### Source precedence

Cite the best source available rather than skipping the claim.

| Rank | Source | Notes |
|---|---|---|
| 1 | `docs.vendasta.com` | Published product documentation |
| 2 | `vendasta.jira.com/wiki` | PRDs, vision docs, release notes, learner journeys |
| 3 | `support.vendasta.com` | Help centre articles |
| 4 | `vendasta.com`, `servicesdocs.io` | Real, but written to sell |
| 5 | Named external publisher, with a date | Market statistics only |

Two rules on top of the ranking. A number appearing **only** inside our own docs corpus is not sourced, it is circular, and the comment has to say so and name who can confirm it. And when two sources conflict, cite both in an `Audit:` comment rather than silently picking one.

### The waiver

A claim that genuinely needs no source gets marked, not left bare:

```jsx
{/* no-source-needed: partner-reported field result, presented as an anecdote */}
```

Placeholders like "SOURCE NEEDED" are explicitly banned. Cite it, waive it with a reason, or cut the claim.

## The check

**Advisory by design.** On a pull request the workflow inspects only added lines, posts one comment and edits it in place on every push, and **always exits zero**. It never blocks a merge. On a clean PR that never had a comment, it stays silent entirely.

That is deliberate, because the detection is heuristic. It makes three simplifications a reviewer should know about:

| Simplification | Why |
|---|---|
| UI navigation paths are judged once per section, not per line | A step-by-step page has a nav path on every line. Citing the procedure once is the reasonable bar; per-line would produce 16 findings on `payments-and-invoices.mdx` alone |
| A citation placed after a table counts for all rows in it | The convention puts one comment below a feature table rather than one per row |
| FlipCard and Knowledge Check lines are reported separately, as a sync reminder | The body copy is where the citation belongs. These are mirrors, and flagging them as gaps would double-count every figure |

It also skips frontmatter, fenced code, step headings, estimated-time lines, and In Practice blocks in both markup styles.

**It will miss real gaps.** It is a reviewer aid, not a gate, and not a substitute for citing as you write.

### Running it locally

```bash
python3 scripts/check_source_citations.py --all                    # sweep the whole tree
python3 scripts/check_source_citations.py --base origin/master     # just this branch
python3 scripts/check_source_citations.py --all --paths <file>      # one file
```

`--strict` makes it exit 1 when findings exist, for anyone who wants it as a local pre-push gate. The workflow does not use it.

## Baseline

A full sweep currently reports **134 uncited claims**, every one in the four sections that have never had a citation pass (Getting Started plus Growth Engine, AI Foundations plus Advertising, Builder plus Build Lab plus Vibe, and the untouched parts of Vendasta Services and CRM).

That is the existing backlog, not a regression. **This PR stops it growing; it does not clean it up.** Working through it is separate, section by section.

### Tuning evidence

- All 31 files in `docs/learn-audit-sources` come back **clean**, which confirms citation detection recognises both comment forms in all their placements.
- Planted test claims are caught: a percentage plus counted noun ("Express Ads reach 92% of the open web and launch in 3 business days") and an entitlement claim ("Shopping campaigns are included with Advertising Intelligence Pro").
- False-positive sources found and removed during tuning: In Practice narratives, step headings, estimated-time lines, per-line nav paths, and table rows whose citation sits after the table.
- The workflow YAML parses, and the script compiles under Python 3.11.

## Not in here

The team-brain SOP for this convention (`enablement-docs` sop-015, under `subfunctions/knowledge-management/sops/`) is drafted and being **held back deliberately**.

## How to review this

The rule text and the workflow are mechanical. Every judgment call is in `scripts/check_source_citations.py`:

1. **`CLAIM_RULES`** — the regexes that decide what counts as a claim. Too broad and reviewers ignore the comment; too narrow and it misses things.
2. **`ENTITLEMENT_RE` plus `PRODUCT_NAMES`** — an entitlement phrase only fires alongside a known product name, so a bare product mention is not treated as a claim. `PRODUCT_NAMES` needs extending as the lineup changes.
3. **The three simplifications above**, implemented in `scan()`.
4. **`MAX_ROWS = 40`** — caps the PR comment length. Anything beyond that is counted but not listed, with a pointer to run it locally.

If the signal-to-noise looks wrong on your next PR, that file is where to tune it, and the check failing to block anything means tuning it is low risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QjPiySz7LPbUiizSweKH7a

