### PR TITLE
docs: article verifications for August 5

### DIFF
--- a/docusaurus/docs/conversations/conversations-in-partner-center.mdx
+++ b/docusaurus/docs/conversations/conversations-in-partner-center.mdx
@@ -5,15 +5,13 @@ description: Complete guide to using Conversations in Partner Center for messagi
 sidebar_position: 2
 ---
 
-# How to Use Conversations in Partner Center
+Conversations in Partner Center provides shared messaging channels for your entire team to communicate with clients, vendors, and Vendasta representatives. Unlike email threads that become unwieldy and lose context, Conversations ensures team collaboration where any member can respond to client messages.
 
-Conversations in Partner Center provides shared messaging channels for your entire team to communicate with clients, vendors, and Vendasta representatives. Unlike email threads that become unwieldy and lose context, Conversations ensures seamless team collaboration where any member can respond to client messages.
-
-## **Starting Conversations with Clients**
+## Starting conversations with clients
 
 1. **Start a conversation** by clicking the message icon next to any account in Partner Center.
 2. **Choose the recipient** from the pop-up menu showing available accounts.
-3. **Send your message** — clients receive it in **Business App → Conversations** along with email notifications.
+3. **Send your message**. Clients receive it in `Business App` → `Conversations` along with email notifications.
 
 <img src={require('./img/partner-center-conversations/conversations-side-panel.png').default} alt="Conversations side panel interface" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
 
@@ -21,42 +19,42 @@ Your clients will see the message in their Business App interface:
 
 <img src={require('./img/partner-center-inbox/business-app-inbox.png').default} alt="Business App Conversations interface" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
 
-### **Receiving Messages from Clients**
+### Receiving messages from clients
 
-Clients can reach you through the 'Contact Us' button in Business App. Enable notifications in Partner Center to stay on top of all incoming messages.
+Clients can reach you through the `Contact Us` button in Business App. Enable notifications in Partner Center to stay on top of all incoming messages.
 
 <img src={require('./img/partner-center-inbox/contact-us-button.jpg').default} alt="Contact us button in Business App" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
 
-## **Communicating with Vendors**
+## Communicating with vendors
 
 Connect directly with marketplace vendors for product support and sales assistance:
 
 1. **Navigate to any product** in the marketplace.
-2. **Click "Contact Us"** on the vendor's Product Details page (when chat support is enabled).
+2. **Click** `Contact Us` on the vendor's `Product Details` page (when chat support is enabled).
 3. **Start your conversation** for immediate vendor assistance.
 
 <img src={require('./img/partner-center-inbox/vendor-contact-us.jpg').default} alt="Contact Us option on Product Vendor Details page" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
 
-## **Contacting Vendasta Support**
+## Contacting Vendasta support
 
 Reach Vendasta representatives directly through Conversations:
 
 1. **Click the contact card** in the bottom left of Partner Center navigation.
-2. **Select "Send Message"** to start a conversation with Vendasta support.
+2. **Select** `Send Message` to start a conversation with Vendasta support.
 
-## **Setting Up Notifications**
+## Setting up notifications
 
 Stay on top of all communications by configuring notifications properly:
 
 1. Click the **bell icon** (<img src={require('./img/partner-center-inbox/bell-icon.png').default} alt="bell icon" style={{width: '16px', verticalAlign: 'middle'}} />) in the top right corner of Partner Center.
 2. Click the **gear icon** (<img src={require('./img/partner-center-inbox/gear-icon.png').default} alt="gear icon" style={{width: '16px', verticalAlign: 'middle'}} />) at the top of the dropdown.
-3. Enable **All events** to receive notifications for all conversations.
-4. Enable **Only my events** to get alerts only for conversations you're following.
+3. Enable `All events` to receive notifications for all conversations.
+4. Enable `Only my events` to get alerts only for conversations you're following.
 5. Configure your preferred notification method (email, browser alerts, etc.).
 
 <img src={require('./img/partner-center-inbox/enable-notifications.jpg').default} alt="Enabling notifications in Partner Center" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
 
-## **Using Conversation Automations**
+## Using conversation automations
 
 Streamline your communication workflow with automated responses and triggers:
 
@@ -67,7 +65,7 @@ Streamline your communication workflow with automated responses and triggers:
 
 [Learn more about setting up automation workflows here.](./automations-available-for-conversations.mdx)
 
-## **Key Features Available**
+## Key features available
 
 - **Unlimited in-platform messaging** with all ecosystem participants
 - **Side-panel view** that stays accessible across all Partner Center pages
@@ -75,31 +73,31 @@ Streamline your communication workflow with automated responses and triggers:
 - **Following view** for managing priority conversations
 - **Team collaboration** with shared channel access
 
-## **Managing Priority Conversations with Following**
+## Managing priority conversations with following
 
 Use the ★ Following feature to focus on your most important conversations:
 
-### **How to Follow Conversations**
+### How to follow conversations
 
 1. Look for the **star button (★)** in any conversation header.
 2. Click the **star** to start following that conversation.
-3. Access your **Following view** to see only conversations you're actively tracking.
-4. Enable **Only My Events** in notification settings to get alerts only for followed conversations.
+3. Access your `Following` view to see only conversations you're actively tracking.
+4. Enable `Only My Events` in notification settings to get alerts only for followed conversations.
 
 <img src={require('./img/partner-center-inbox/following-view.jpg').default} alt="Following view in Conversations" style={{width: '50%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
 
-### **Automatic Following**
+### Automatic following
 
 You'll automatically follow conversations when:
 - **Sending a message** in any conversation (can be unfollowed anytime)
 - **Assigned as Salesperson** to an account (follows all past and future conversations)
 
-### **Notification Routing**
+### Notification routing
 
 Message notifications direct you to the appropriate center based on your permission level:
 1. **Partner Center Admin/Vendor Center users** → Partner Center
 2. **Digital Agent** → Task Manager
 
-## **Client Access Through Business App**
+## Client access through Business App
 
 Your clients communicate with you through Business App at no additional cost. To customize or disable this feature, [configure these settings](/administration/platform-settings/customize-business-app) in Partner Center administration.

--- a/docusaurus/docs/crm/my-meetings/visibility-settings.mdx
+++ b/docusaurus/docs/crm/my-meetings/visibility-settings.mdx
@@ -6,8 +6,6 @@ tags: [visibility-settings, meeting-recordings, sales-coaching, notetaker]
 keywords: [private meetings, meeting visibility, recording settings]
 ---
 
-##
-
 Visibility Settings enable you to manage access to and control the privacy of sensitive content, including recordings, transcripts, summaries, and sales coaching. These settings help safeguard sensitive discussions by applying privacy rules based on whether meetings are internal or external.
 
 This feature lets you categorize meetings as private or publicly accessible within the CRM. This flexibility accommodates various meeting recording needs, including one-on-ones, confidential discussions, product meetings, HR meetings, and training sessions that require privacy.
@@ -20,7 +18,7 @@ It supports trust and enables use cases beyond sales, such as HR, product, and t
 - Protect confidential discussions while preserving CRM automation for non-private discussions.  
 - Empower you to configure, override, and reverse privacy decisions at any time.
 
-### Key Concepts & Definitions
+### Key concepts & definitions
 
 | Term | Definition |
 |------|------------|
@@ -47,13 +45,13 @@ It supports trust and enables use cases beyond sales, such as HR, product, and t
 
 ### The 3 Visibility Settings
 
-**Private**  
+`Private`  
 Only meeting invitees to the Calendar event in the same namespace/Partner ID can view the Meeting Recording or Meeting Summary Page.
 
-**All**  
+`All`  
 Anyone in the same namespace/Partner ID can view the Meeting Recording or Meeting Summary Page. A CRM activity is logged.
 
-**Anyone with the link**  
+`Anyone with the link`  
 Anyone in the same namespace/Partner ID with access to the Meeting Summary Page link can view it. The meeting will not appear in the CRM.
 
 ### Configure default Visibility Settings for recorded meetings
@@ -67,12 +65,12 @@ Visibility Settings for any specific meeting can be adjusted at any time.
 
 You can configure defaults under:
 
-**My Meetings → Meeting Settings → Recording Settings**
+`My Meetings` → `Meeting Settings` → `Recording Settings`
 
 This is a user-level setting and does not affect others in the same namespace/Partner ID.
 
 :::note
-Meetings marked *Private* on Google Calendar are still recorded. Future updates may allow preventing Notetaker scheduling for these calls.
+Meetings marked *Private* on Google Calendar are still recorded.
 :::
 
 ### Default logic
@@ -83,16 +81,16 @@ Meetings marked *Private* on Google Calendar are still recorded. Future updates 
 | Internal meeting | Private | Not Logged |
 | Ad-hoc meeting | Private | Not Logged |
 
-You can override these defaults anytime—from either the Meeting Summary Page or the My Meetings Page.
+You can override these defaults anytime, from either the Meeting Summary Page or the My Meetings Page.
 
-## Overriding Default Visibility settings
+## Overriding default Visibility Settings
 
 You can update Visibility Settings before or after a meeting.
 
 ### Before the meeting
 
-1. Navigate to **My Meetings → Recordings → Upcoming**.  
-2. Select the meeting and choose the preferred Visibility Setting: **Use default** or **Override defaults**.  
+1. Navigate to `My Meetings` → `Recordings` → `Upcoming`.  
+2. Select the meeting and choose the preferred Visibility Setting: `Use default` or `Override defaults`.  
 3. The platform indicates whether the meeting will be recorded and logged.
 
 **Demo:**
@@ -110,7 +108,7 @@ You can update Visibility Settings before or after a meeting.
 
 ### After the meeting
 
-- In the **Recorded Meetings** tab, switch between grid and table views to adjust settings.  
+- In the `Recorded Meetings` tab, switch between grid and table views to adjust settings.  
 - On the **Meeting Summary Page**, change Visibility Settings as needed.
 
 **Demo:**
@@ -151,9 +149,11 @@ Includes indicators for:
 
 Shows all meeting recordings where you are an organizer or invitee. This is the default view for reviewing your recorded meetings.
 
-**Please use the CRM Activity Feed for team-related activities.**
+Please use the CRM Activity Feed for team-related activities.
 
-> **Note:** For meetings created by someone outside your namespace/Partner ID, you must manually add the Notetaker.
+:::note
+For meetings created by someone outside your namespace/Partner ID, you must manually add the Notetaker.
+:::
 
 Includes indicators for:
 
@@ -178,7 +178,7 @@ Includes indicators for:
 <details>
   <summary>Do private meetings still generate AI summaries?</summary>
   
-  Yes—only visible to the meeting participants or invitees with that Partner ID.
+  Yes, only visible to the meeting participants or invitees with that Partner ID.
 </details>
 
 <details>

--- a/docusaurus/docs/legacy/customer-voice/index.mdx
+++ b/docusaurus/docs/legacy/customer-voice/index.mdx
@@ -5,8 +5,6 @@ description: "Legacy Customer Voice: review requests via email and SMS, template
 sidebar_position: 1
 ---
 
-# Customer Voice (Legacy)
-
 :::warning Deprecated
 As of February 21st, 2025, Customer Voice is legacy. Use [Reputation AI Premium](https://partners.vendasta.com/marketplace/products/RM) for reviews and NPS via email and SMS.
 :::
@@ -49,11 +47,11 @@ With Customer Voice, your clients could gather customer experiences to boost onl
 
 ## Overview page and performance metrics
 
-Business owners could visualize the effectiveness of review requests on the **Customer Voice** → **Overview** page: how many were sent, open rate, and click-through rate. A performance funnel helped pinpoint areas for improvement (e.g. changing the subject line). Metrics included requests sent by email and SMS.
+Business owners could visualize the effectiveness of review requests on the `Customer Voice` → `Overview` page: how many were sent, open rate, and click-through rate. A performance funnel helped pinpoint areas for improvement (e.g. changing the subject line). Metrics included requests sent by email and SMS.
 
 The Overview page also showed **SMS usage stats** and a **recent requests** log so business owners could see credits left, when they expire, and request to purchase more.
 
-Go to **Customer Voice** → **Overview**. You could expect:
+Go to `Customer Voice` → `Overview`. You could expect:
 
 - A review request performance funnel
 - Metrics for email performance over time
@@ -69,7 +67,7 @@ The performance funnel included SMS metrics for accounts with an SMS add-on.
 
 ![SMS Performance Metrics](./overview/img/legacy-customer-voice/sms-performance-metrics.jpg)
 
-SMS reporting included the number of messages sent and click-through rate. Open rate is not available for SMS. Go to **Customer Voice Pro** (with SMS add-on) → **Overview** to toggle between Email only, SMS only, or both, filter by date range, and see new reviews from connected accounts.
+SMS reporting included the number of messages sent and click-through rate. Open rate is not available for SMS. Go to `Customer Voice Pro` (with SMS add-on) → `Overview` to toggle between Email only, SMS only, or both, filter by date range, and see new reviews from connected accounts.
 
 ## A2P 10DLC registration
 
@@ -77,10 +75,10 @@ To prevent spam and SMS abuse, US phone carriers require businesses to register 
 
 **What is A2P 10DLC?** – A system that allows businesses to send Application-to-Person messaging via standard 10-digit long code numbers. Registration is required for clients using Inbox (Business App) or Customer Voice to send notifications, marketing messages, and review requests. This affects US businesses only.
 
-**What to do** – US-based SMBs must register to keep sending SMS after Aug 31, 2023. In Customer Voice, go to **Settings** → **SMS Configuration** to submit the business for registration. Registration can take up to 28 days. For step-by-step instructions, see [Register for SMS text messaging](./settings/register-for-sms-text-messaging.mdx).
+**What to do** – US-based SMBs must register to keep sending SMS after Aug 31, 2023. In Customer Voice, go to `Settings` → `SMS Configuration` to submit the business for registration. Registration can take up to 28 days. For step-by-step instructions, see [Register for SMS text messaging](./settings/register-for-sms-text-messaging.mdx).
 
 :::info New businesses with a recently issued EIN
-SMBs that receive a new EIN may need to wait **30–90 days** before that information appears in the databases used by Twilio and its ecosystem partners for verification. During this period, the brand registration process may **reject** the submission — even if the EIN and legal business name provided are correct — because the automated checks cannot yet find a matching record in the expected sources.
+SMBs that receive a new EIN may need to wait **30–90 days** before that information appears in the databases used by Twilio and its ecosystem partners for verification. During this period, the brand registration process may **reject** the submission, even if the EIN and legal business name provided are correct, because the automated checks cannot yet find a matching record in the expected sources.
 
 This is part of Twilio's digitized approval process and is not something Vendasta can influence or override.
 
@@ -110,8 +108,8 @@ Customer Voice works with other products for best results:
 
 SMS add-ons are only available with **Customer Voice Pro**.
 
-1. Go to **Partner Center** → **Accounts** → **Manage Accounts**.
-2. Open the account and select **Order Products**.
+1. Go to `Partner Center` → `Accounts` → `Manage Accounts`.
+2. Open the account and select `Order Products`.
 3. Choose the SMS add-on by location and message volume, then complete the order.
 </details>
 
@@ -121,8 +119,8 @@ SMS add-ons are only available with **Customer Voice Pro**.
 Yes.
 
 1. Open a template and right-click the button.
-2. Select **Insert/Edit Link**.
-3. Update **URL** for the destination and **Text to Display** for the button label.
+2. Select `Insert/Edit Link`.
+3. Update `URL` for the destination and `Text to Display` for the button label.
 </details>
 
 <details>
@@ -136,8 +134,8 @@ No. The business address is required for **CAN-SPAM** compliance. Unsolicited co
 
 Yes.
 
-1. Go to **Customer Voice** → **Templates** → **SMS Template**.
-2. Set the template type to **custom site** and insert your custom link (e.g. a Google Form).
+1. Go to `Customer Voice` → `Templates` → `SMS Template`.
+2. Set the template type to `custom site` and insert your custom link (e.g. a Google Form).
 
 :::info
 Custom links are shortened for SMS. Clicks on custom links are not tracked.
@@ -165,8 +163,8 @@ Example: 100 credits activated April 16th reset to 0/100 on May 1st.
 <details>
 <summary>How do I edit the review request email template?</summary>
 
-1. Open the **Email template** tab for a customer.
-2. Click the three-dot menu on the template preview and select **Edit template**.
+1. Open the `Email template` tab for a customer.
+2. Click the three-dot menu on the template preview and select `Edit template`.
 
 You can then add a custom message, choose review sources, set layout and colors, profile picture, business address visibility, opt-out, and unsubscribe link. Changes apply to all future emails sent to that customer.
 </details>
@@ -174,8 +172,8 @@ You can then add a custom message, choose review sources, set layout and colors,
 <details>
 <summary>How do I create a custom email review request template?</summary>
 
-1. Go to **Customer Voice** → **Templates** → **Add New Template** and name it.
-2. Choose one of: **New Preferred Review Sites Template**, **New My Listing template**, or **New Blank Template**.
+1. Go to `Customer Voice` → `Templates` → `Add New Template` and name it.
+2. Choose one of: `New Preferred Review Sites Template`, `New My Listing template`, or `New Blank Template`.
 3. Edit the pre-populated template or use a blank one and add variables, images, and text.
 </details>
 
@@ -184,8 +182,8 @@ You can then add a custom message, choose review sources, set layout and colors,
 
 **Customer Voice Pro** users can set a custom "send from" domain.
 
-1. In **Partner Center** → **Accounts**, open the Business App → **Settings** → **Email Configuration**.
-2. Edit **Email 'Send From' Information** and enter the address and display name.
+1. In `Partner Center` → `Accounts`, open the Business App → `Settings` → `Email Configuration`.
+2. Edit `Email 'Send From' Information` and enter the address and display name.
 3. Verify **SPF**, **DKIM**, and **DMARC** in your DNS. Update any invalid records.
 
 This helps deliverability; content and subject lines also affect spam filtering.
@@ -196,8 +194,8 @@ This helps deliverability; content and subject lines also affect spam filtering.
 
 SMS add-ons are required.
 
-- **Single new contact:** On the Customer Voice overview tab click **Send request**, fill the form (include phone number), choose an SMS template, then **Send**.
-- **Existing contacts:** Go to **Overview** → **Customers**, select one or more customers with phone numbers, click **Send request**, choose a template, then **Send to [#] Customers**.
+- **Single new contact:** On the Customer Voice overview tab click `Send request`, fill the form (include phone number), choose an SMS template, then `Send`.
+- **Existing contacts:** Go to `Overview` → `Customers`, select one or more customers with phone numbers, click `Send request`, choose a template, then `Send to [#] Customers`.
 </details>
 
 <details>
@@ -205,15 +203,15 @@ SMS add-ons are required.
 
 Available in **Customer Voice Pro**.
 
-1. Go to **Customer Voice** → **Customers**.
+1. Go to `Customer Voice` → `Customers`.
 2. Select multiple customers.
-3. Click **Send Request** (bottom right), choose a template, then **Send**.
+3. Click `Send Request` (bottom right), choose a template, then `Send`.
 </details>
 
 <details>
 <summary>How do I upload multiple customers at once?</summary>
 
-1. Go to **Customer Voice** → **Customers** → **Import Customers**.
+1. Go to `Customer Voice` → `Customers` → `Import Customers`.
 2. Upload a .csv with the correct column headers in the first row (e.g. first name, last name, email).
 3. Attach the file, map fields, then upload.
 
@@ -227,8 +225,8 @@ Available in **Customer Voice Pro**.
 
 It depends on the template:
 
-- **My Preferred Sites** – Reviews go to the sites you directed users to. Status in **Customer Voice** → **Customers** updates to Bounced, Sent, Clicked, or Opened.
-- **My Listing** – Reviews go to the My Listing page (Local SEO). Status shows as Review Completed.
+- `My Preferred Sites`: Reviews go to the sites you directed users to. Status in `Customer Voice` → `Customers` updates to Bounced, Sent, Clicked, or Opened.
+- `My Listing`: Reviews go to the My Listing page (Local SEO). Status shows as Review Completed.
 </details>
 
 <details>
@@ -236,16 +234,16 @@ It depends on the template:
 
 Two template types:
 
-- **My Preferred Sites** – Third-party sites like Google and Facebook. You can choose up to three from **Customer Voice** → **Settings** → **My Preferred Sites** (driven by **Partner Center** → **Administration** → **Customize** → **Listing Sources**).
-- **My Listing** – The client's My Listing page.
+- `My Preferred Sites`: Third-party sites like Google and Facebook. You can choose up to three from `Customer Voice` → `Settings` → `My Preferred Sites` (driven by `Partner Center` → `Administration` → `Customize` → `Listing Sources`).
+- `My Listing`: The client's My Listing page.
 
-Create templates under **Customer Voice** → **Templates** → **Add New Template**.
+Create templates under `Customer Voice` → `Templates` → `Add New Template`.
 </details>
 
 <details>
 <summary>How do I change the three suggested review sites (Preferred Sources)?</summary>
 
-1. Go to **Customer Voice** → **Settings** → **Preferred Review Sites**.
+1. Go to `Customer Voice` → `Settings` → `Preferred Review Sites`.
 2. Select or clear the sites you want, or enter review URLs manually.
 
 - With **Reputation AI**, listing URLs can be pulled from the Primary Listings tab. **Reputation AI Pro** adds more options.
@@ -262,11 +260,11 @@ Create templates under **Customer Voice** → **Templates** → **Add New Templa
 <details>
 <summary>How do I embed the Review Generation Widget on my website?</summary>
 
-1. Go to **Customer Voice** → **Tools** → **Widgets**.
-2. Customize the widget and select **Copy Widget Code**.
+1. Go to `Customer Voice` → `Tools` → `Widgets`.
+2. Customize the widget and select `Copy Widget Code`.
 3. Paste the code into your site's HTML.
 
-For **WordPress**: use the editor in **Text** mode (not Visual), paste the code, and adjust width/height if needed.
+For **WordPress**: use the editor in `Text` mode (not Visual), paste the code, and adjust width/height if needed.
 </details>
 
 <details>

--- a/docusaurus/docs/vendor-center/vendor-center-general/create-projects.mdx
+++ b/docusaurus/docs/vendor-center/vendor-center-general/create-projects.mdx
@@ -5,21 +5,19 @@ sidebar_position: 4
 description: Learn how to create and manage projects in Vendor Center to track work across your resellers with Vendasta.
 ---
 
-# Create projects in Vendor Center
-
 Projects allow you to track the work you're doing across your resellers with Vendasta. Through them, you gain access to Task Manager, letting you add tasks, notes, and share activities with your clients directly.
 
 ### Create a project
 
 1. Log in to [Vendor Center](https://vendors.vendasta.com/)
-2. Go to **Orders**
+2. Go to `Orders`
 3. Find the order you wish to create a project for
-4. Click the kebab, then click **Create Project** ![Create Project link](./img/vendor-center-general/create-project-link.png)
-5. Fill in the **Create project** form
-6. Click **Create project**
+4. Click the kebab, then click `Create Project` ![Create Project link](./img/vendor-center-general/create-project-link.png)
+5. Fill in the `Create project` form
+6. Click `Create project`
 
 :::note
-Note that each product included in a Sales order is separated into its own row. You may see the same **Order ID** listed twice if two of your products were purchased in the same order.
+Note that each product included in a Sales order is separated into its own row. You may see the same `Order ID` listed twice if two of your products were purchased in the same order.
 :::
 
-Once created, you'll see it linked in the **Orders** table.
+Once created, you'll see it linked in the `Orders` table.

--- a/docusaurus/docs/vendor-center/vendor-onboarding-guide/service-vendor-requirements.mdx
+++ b/docusaurus/docs/vendor-center/vendor-onboarding-guide/service-vendor-requirements.mdx
@@ -5,14 +5,14 @@ description: Requirements for service vendors in the Vendasta Marketplace, inclu
 ---
 
 :::note
-This article was created to support the integration phase for Marketplace Vendors. If you're ready to get started as a vendor, we'd love to hear from you. [Apply to join the Marketplace](https://www.vendasta.com/marketplace/vendors/).
+This article supports the integration phase for Marketplace Vendors. If you're ready to get started as a vendor, we'd love to hear from you. [Apply to join the Marketplace](https://www.vendasta.com/marketplace/vendors/).
 :::
 
-### Reliance on another marketplace product
+### Reliance on another Marketplace product
 
 1. If your service leverages a Marketplace Product and requires that product to be active before you can start your work, ensure that the required product has been selected.
 
-[Vendor Center](https://vendors.vendasta.com/) → **Select Product** → **Product Info** → **Product activation** → **Required products**:
+[Vendor Center](https://vendors.vendasta.com/) → `Select Product` → `Product Info` → `Product activation` → `Required products`:
 
 ![Required products selection interface](./img/partner-center/vendor-center/vendor-onboarding-guide/service-vendor-requirements/required-products.png)
 
@@ -24,7 +24,7 @@ If your service is not this type of service, ignore this checkbox.
 
 ### Reporting
 
-If you currently provide a service completion report or any ongoing reporting to your clients, then this will now need to be provided via the Vendasta Platform.
+Provide any service completion report or ongoing reporting to your clients via the Vendasta Platform.
 
 ### Requirements
 
@@ -44,7 +44,7 @@ If you have a hosted reporting dashboard that is accessed via a login, or shared
 
 **The Executive Report (API Integration):**
 
-Pull highlights from, or recreate your reporting in Vendasta's dynamic report that lives within the end user dashboard Business App. See supported card types [here](https://developers.vendasta.com/vendor/ZG9jOjE2NTY5Mzk0-executive-report).
+Pull highlights from, or recreate your reporting in Vendasta's dynamic report that lives within the Business App end-user dashboard. See supported card types [here](https://developers.vendasta.com/vendor/ZG9jOjE2NTY5Mzk0-executive-report).
 
 :::info
 Suggested maximum of 9 cards.
@@ -54,18 +54,18 @@ Suggested maximum of 9 cards.
 
 File groups can be generated in two ways:
 
-1. The Account Details page in Vendor Center. In this case, Vendasta hosts the file.
+1. The `Account Details` page in Vendor Center. In this case, Vendasta hosts the file.
 
 ![File upload interface](./img/partner-center/vendor-center/vendor-onboarding-guide/service-vendor-requirements/file-upload-interface.png)
 
 2. Automated upload via the Account [File Group API](https://developers.vendasta.com/vendor/e8e7370a6bbc0-create-a-file-group). In this case, the vendor hosts the file and provides a link.
 
-**For either method, file uploads will automatically send a message to the Activity Stream providing an alert that a new file is now available.**
+For either method, file uploads will automatically send a message to the Activity Stream providing an alert that a new file is now available.
 
 
 ### Final walkthrough (Vendasta testing your integration)
 
-Once you have finished each task, submit it for review and approval in your project tracker by clicking **Approve**.
+Once you have finished each task, submit it for review and approval in your project tracker by clicking `Approve`.
 
 ![Approve button](./img/partner-center/vendor-center/vendor-onboarding-guide/service-vendor-requirements/approve-button.png)
 
@@ -79,8 +79,8 @@ Enable fulfillment forms on your product in Vendor Center. After you configure t
 
 **Work order statuses:**
 
-- **Details needed** — Required information is missing. View these orders under the **In Review** tab and complete the fulfillment form to proceed.
-- **Complete** — The fulfillment form is completed. You can view contact details, order forms, and fulfillment responses for each order.
+- `Details needed`: Required information is missing. View these orders under the `In Review` tab and complete the fulfillment form to proceed.
+- `Complete`: The fulfillment form is completed. You can view contact details, order forms, and fulfillment responses for each order.
 
 <iframe 
   src="https://drive.google.com/file/d/1k8YNG1r2_ORiaxGf8LqKQMFh91RrJVD1/preview" 


### PR DESCRIPTION
## Summary
- Verified 5 articles flagged for review on August 5: service vendor requirements, meeting visibility settings, create projects (Vendor Center), Conversations in Partner Center, and the legacy Customer Voice doc.
- Fixed extensive UI formatting (bolded/quoted nav paths, buttons, tabs, and fields converted to inline code), em dash removal, a broken empty heading, a `>` blockquote converted to a `:::note` callout, two evergreen violations (implied recency, unreleased-capability reference), one prohibited term ("seamless"), an awkward word-order fix, and three duplicate H1s.
- The legacy Customer Voice article is explicitly deprecated (points to Reputation AI Premium), so its past-tense content was left as-is — that's accurate for a retired product, not a violation.
- All 5 issues reached **Needs Update** with fixes applied. None required SME review, though a few items are flagged for a manual spot-check (see below).

## Test plan
- [ ] Spot-check rendered pages in `npm run start` for the five changed articles
- [ ] Confirm whether "your clients" in "Create projects in Vendor Center" means the vendor's resellers or the resellers' own end customers
- [ ] Confirm correct capitalization of "Only my events"/"Only My Events" in Conversations (inconsistent between two sections), and whether "Digital Agent" is a genuine permission level
- [ ] Confirm whether the Customer Voice Overview page was genuinely client-facing ("Business owners could visualize...") or should read "you" like the rest of the doc

Closes #876
Closes #877
Closes #878
Closes #879
Closes #880

🤖 Generated with [Claude Code](https://claude.com/claude-code)