### PR TITLE
docs(fulfillment): add Subtasks section to Task Manager Tasks overview

### DIFF
--- a/docusaurus/docs/fulfillment/task-manager/tasks/index.mdx
+++ b/docusaurus/docs/fulfillment/task-manager/tasks/index.mdx
@@ -32,6 +32,14 @@ Tasks streamline your fulfillment workflow by:
 - **Task tags** – Organize and filter tasks
 - **Approval workflows** – Request client approval for review responses from tasks
 
+## Subtasks
+
+The system supports creating subtasks within tasks for better organization of complex work:
+
+- Create subtasks within any task to break down work into smaller steps
+- Multi-level task hierarchies allow you to structure work at different levels of detail
+- Parent-child task relationships help track dependencies and progress through related work items
+
 ## Articles in this section
 
 - **[Creating and managing tasks](./creating-managing-tasks.mdx)** – Create tasks manually, set up auto-generation, task types, account settings


### PR DESCRIPTION
## Summary
- Adds a Subtasks section to the Task Manager Tasks overview page, capturing content originally proposed in #242 (closed — predated the Task Manager docs restructure into its current multi-page layout)
- Conversations and Attachments from the original PR were not duplicated here since they're already documented in more detail in `task-communication-collaboration.mdx`

## Test plan
- [x] Verified heading structure renders correctly (`##` level, consistent with surrounding sections)
- [ ] Visual check on preview/staging build