### PR TITLE
docs(ai): fix dead link to migrated Web Chat widget guide

### DIFF
--- a/docusaurus/docs/ai/ai-workforce/ai-chat-receptionist/index.md
+++ b/docusaurus/docs/ai/ai-workforce/ai-chat-receptionist/index.md
@@ -72,7 +72,7 @@ Give your AI a friendly, professional name and photo. The AI Receptionist knows 
 Your AI Chat Receptionist is assigned to the **Web Chat** channel by default. This channel is always active and cannot be disabled. You can also assign your AI Receptionist to the **SMS** channel to reach customers via text messaging.
 
 :::note  
-The Web Chat widget isn't automatically added to your website! You'll need to install the widget code or enable it within your site builder before your AI can start engaging visitors. When you are ready to install the widget, refer to [How to install the Conversations Web Chat Widget](/business-app/conversations/web-chat/)
+The Web Chat widget isn't automatically added to your website! You'll need to install the widget code or enable it within your site builder before your AI can start engaging visitors. When you are ready to install the widget, refer to [How to install the Conversations Web Chat Widget](https://docs.businessapp.io/business-app/conversations/web-chat)
 :::
 
 :::tip Respond differently on each channel


### PR DESCRIPTION
## Summary
- Fixes a dead link in the AI Chat Receptionist page pointing to `/business-app/conversations/web-chat/`, which no longer exists in this repo — the content moved to `docs.businessapp.io`
- Same broken-link pattern PR #286 was fixing on the Conversations Settings page, but that page's "Related setup guides" section has since been removed in a docs restructure, so #286 itself is being closed as superseded rather than merged

## Test plan
- [x] Confirmed the new URL (`https://docs.businessapp.io/business-app/conversations/web-chat`) resolves with a 200
- [ ] Run `npm run build` to confirm no broken link errors