### PR TITLE
Docs: Reminder Flexibility for My Meetings event types (VS-1402)

### DIFF
--- a/docusaurus/docs/crm/my-meetings/index.mdx
+++ b/docusaurus/docs/crm/my-meetings/index.mdx
@@ -96,7 +96,20 @@ Click **Create event type** to set up a new type of meeting. Fill in the event t
 You can also configure additional options for each event type. Settings configured here override your user-level defaults for this event type only:
 
 - **General availability** - Override your default availability for this specific event type.
-- **Questions for invitee** - Add custom questions that invitees answer when booking.
+- **Questions for invitee** - Add custom questions that invitees answer when booking. Making **Phone Number** and/or **Email** required fields controls which channels are available for confirmations and reminders.
+
+  Choose a **confirmation channel** - **Email**, **SMS**, or **Both** - for the confirmation guests receive when they book. Choose a **reminder channel** the same way; it defaults to your confirmation channel until you change it, after which the two work independently - for example, an Email confirmation with an SMS reminder.
+
+  - Turning off **Phone Number** required disables **SMS** and **Both** in both channel controls, and any current SMS/Both selection falls back to Email.
+  - Turning off **Email** required disables **Email** and **Both** in both channel controls, and any current Email/Both selection falls back to SMS.
+  - If both **Phone Number** and **Email** are off, all channel options are disabled and an inline warning appears - the event type can't be saved until at least one channel is selected.
+
+  Set the **reminder lead time** - an integer plus a unit (minutes, hours, or days) - to control how far ahead of the meeting the reminder sends. The default is 24 hours, and the maximum is 10 days; values entered above the maximum are clamped, and switching units re-clamps the value. Only one reminder can be configured per event type.
+
+  :::note
+  SMS confirmations and reminders require an active subscription to Conversations AI Pro or Premium (Reputation AI Premium and Campaigns Pro also unlock this), and the business's phone number must be registered first. Configure at **Administration** → **SMS Configuration**.
+  :::
+
 - **Customize invitation email** - Customize the email subject and body sent when you request a meeting via the CRM Contacts page.
 - **Availability increment** - Override the default time slot increment (5, 10, 15, 30, or 60 minutes).
 - **Meeting buffer before/after** - Override the default buffer times.

--- a/docusaurus/docs/crm/my-meetings/team-booking-links.mdx
+++ b/docusaurus/docs/crm/my-meetings/team-booking-links.mdx
@@ -222,6 +222,16 @@ Personalize the team booking page with custom colors and booking questions.
 
 You can add custom questions that visitors must complete when booking a meeting. This information will be available to the team member who receives the booking.
 
+### Confirmation and reminder channels
+
+Making **Phone Number** and/or **Email** required fields (in the booking questions) controls which channels are available for confirmations and reminders.
+
+- Choose a **confirmation channel** - **Email**, **SMS**, or **Both** - for the confirmation guests receive when they book.
+- Choose a **reminder channel** the same way. It defaults to your confirmation channel until you change it, after which the two channels work independently - for example, an Email confirmation with an SMS reminder.
+- Turning off **Phone Number** required disables **SMS** and **Both** in both channel controls, and any current SMS/Both selection falls back to Email. Turning off **Email** required disables **Email** and **Both**, and falls back to SMS.
+- If both **Phone Number** and **Email** are off, all channel options are disabled and an inline warning appears - the event type can't be saved until at least one channel is selected.
+- Set the **reminder lead time** - an integer plus a unit (minutes, hours, or days) - to control how far ahead of the meeting the reminder sends. The default is 24 hours, and the maximum is 10 days; values above the maximum are clamped, and switching units re-clamps the value. Only one reminder can be configured per event type.
+
 ## Viewing and sharing your team booking link
 
 After creating a team booking link, you can view and share it with prospects and clients.


### PR DESCRIPTION
## JIRA

[VS-1402: Reminder Flexibility: multi-channel confirmation/reminder + configurable reminder lead time (Book Me Now)](https://vendasta.jira.com/browse/VS-1402) — Status: **Done**

## Classification

- **Type:** Feature behavior change / UI change
- **Product impacted:** Partner-facing My Meetings (CRM → My Meetings → event type settings). Per a related sibling ticket (VS-1438), the meeting-scheduler settings UI is a shared component used by both Business App and Partner Center, so this change applies to both surfaces.
- **Repo targeted by this PR:** Partner Center

## Summary of documentation updates

Event type settings previously exposed no documented notification-channel control in the Partner Center docs at all (this repo had a gap relative to the Business App docs, which already described the old single-channel toggle). This story adds independent **confirmation channel** and **reminder channel** controls (Email / SMS / Both), field-dependency logic driven by the Email/Phone "Required" toggles, and a configurable **reminder lead time** (default 24h, max 10 days, clamped). Updated two existing articles:

- `docusaurus/docs/crm/my-meetings/index.mdx` — "Questions for invitee" bullet (personal/general event type flow).
- `docusaurus/docs/crm/my-meetings/team-booking-links.mdx` — new "Confirmation and reminder channels" subsection under "Customizing your booking page" (team event type flow).

## Existing docs updated vs. new docs created

**Updated existing docs only** — no new pages created. `index.mdx` got new content inside its existing "Questions for invitee" bullet. `team-booking-links.mdx` needed a new subsection since it previously only covered custom booking questions, not notification channels — adding a heading there (rather than a new page) keeps it beside the directly related "Customizing your booking page" content.

## Placement reasoning

Both edits live in the same event-type settings section documented for the analogous Business App flow, since that's the settings panel functions AC-6 through AC-13 modify. No new top-level page, folder, or sidebar entry needed.

## Acceptance criteria coverage

| AC | Covered |
|----|---------|
| AC-6 Confirmation channel (Email/SMS/Both) | ✅ |
| AC-7 Reminder channel (defaults to confirmation, then independent) | ✅ |
| AC-8 Reminder lead time (integer + unit, default 24h, max 10d, clamped) | ✅ |
| AC-9 Single reminder per event type (v1) | ✅ |
| AC-10 Phone required off → disables SMS/Both, falls back to Email | ✅ |
| AC-11 Email required off → disables Email/Both, falls back to SMS | ✅ |
| AC-12 Both off → all disabled, inline warning, can't save | ✅ |
| AC-13 Copy says "guests" not "customers" | ✅ (applied to the new UI-control language added here) |

## Figma / images

None were provided with this ticket. No new screenshot was available, so these sections are text-only for now — flagging as a follow-up once UI screenshots are available.

## Skills used

None of this repo's `.claude/skills` cover a docs-lint/validation workflow analogous to businessapp-docs' `pre-push-validation`; changes were checked manually for frontmatter, balanced `:::` callouts, and the repo's "no `>` character" markdown rule.

## Assumptions & limitations

- **Rollout check:** Parent epic VS-1418 ("Product Improvements in Booking system") is a general catch-all epic in "To Do" status, not a feature-specific gating epic. Its other open children (VS-1437, VS-1438, VS-1393) are unrelated features (a UI badge fix, a button removal, and partner-user access scoping) with no feature-flag, eligibility, or region-gating language tied to Reminder Flexibility specifically. VS-1402 and its sibling VS-1401 (Reminder Visibility) are both **Done**. Treating the feature as shipped, but noting the epic's incomplete status per the automation runbook's rollout-verification step.
- Added the SMS subscription-requirement note (Conversations AI Pro/Premium, registered phone number) to `index.mdx` to match the parallel, already-published Business App article — this pre-existing gating requirement isn't new in VS-1402, it was simply undocumented on the Partner Center side before this change.
- Could not identify a specific code-author reviewer: the linked GitHub PRs for VS-1402 live in `vendastaapis`, `meetings`, and `galaxy`, which are outside this session's repo access scope (limited to `businessapp-docs` and `partnercenter-docs`). The JIRA assignee/reporter is Amalnath P (apanchabikesan@vendasta.com); no matching GitHub account was found via user search, so no reviewer was requested — please add the right reviewer manually.

@ahnikakuse @haleyserrano @maryam6samadi

---
_Generated by [Claude Code](https://claude.ai/code/session_012d2UkqtnhQxRJcxeBNiLCU)_