### PR TITLE
docs: write system automations overview page

### DIFF
--- a/docusaurus/docs/automations/system-automations/index.mdx
+++ b/docusaurus/docs/automations/system-automations/index.mdx
@@ -7,21 +7,45 @@ sidebar_label: System automations
 
 # System automations
 
-System automations are pre-built workflows provided by Vendasta. They run common tasks automatically so you don't have to build them from scratch.
+System automations are pre-built workflows provided by Vendasta. They handle common platform tasks automatically — no setup required. You can enable or disable them, but you cannot edit them directly.
 
-:::info
-Detailed documentation for system automations is coming soon. In the meantime, navigate to **Automations** in Partner Center and select the **System automations** tab to view and manage available system automations.
-:::
+## How system automations work
 
-## What are system automations?
+- **Enabled by default** — new partner accounts have all system automations turned on. You only need to take action if you want to disable one.
+- **Read-only workflows** — click a system automation's name to view its trigger and steps, but you cannot modify them.
+- **Duplicate to customize** — if you need a version you can edit, duplicate the system automation. The copy becomes a regular automation in **My automations** that you fully control.
+- **Scoped to your account** — enabling or disabling a system automation only affects your partner account or the specific account group you're managing.
 
-- Pre-configured workflows built and maintained by Vendasta
-- Automatically available in your account — no setup required
-- Can be enabled or disabled per account
-- Cannot be edited — they run as designed
-
-## How to manage system automations
+## Manage system automations
 
 1. In Partner Center, go to **Automations**.
 2. Select the **System automations** tab.
-3. Use the toggle to enable or disable individual system automations.
+3. Each system automation is displayed as a card showing its name and description.
+4. Use the **toggle** on each card to enable or disable it.
+
+### Enable a system automation
+
+Flip the toggle to **on**. The automation starts processing trigger events immediately.
+
+### Disable a system automation
+
+1. Flip the toggle to **off**.
+2. A confirmation dialog appears: **"Turn off [automation name]?"**
+3. Click **Turn off** to confirm, or **Cancel** to keep it enabled.
+
+Once disabled, the automation stops processing new trigger events. Any runs already in progress will complete.
+
+## Duplicating a system automation
+
+If a system automation does most of what you need but requires changes, duplicate it:
+
+1. Click the system automation's name to open its workflow view.
+2. From the **More actions** menu, select **Duplicate**.
+3. The copy appears in **My automations** as a regular automation you can edit, rename, and configure.
+4. Optionally disable the original system automation if you only want your customized version running.
+
+## Related resources
+
+- [My automations](../my-automations/index.mdx) — create and configure your own workflows
+- [Automation templates](../templates/index.mdx) — pre-built templates you can customize
+- [Managing your automations](../automation-history/managing-your-automations.mdx) — monitor activity and retry failed runs


### PR DESCRIPTION
Replace placeholder with full documentation covering how system automations work (enabled by default, read-only, duplicate to customize), how to enable/disable with confirmation dialog, and how to duplicate for customization.

Story 2.1 of the automation docs restructure plan.