### PR TITLE
docs: expand timezone, goal, and notification settings

### DIFF
--- a/docusaurus/docs/automations/my-automations/creating-and-configuring-automations.mdx
+++ b/docusaurus/docs/automations/my-automations/creating-and-configuring-automations.mdx
@@ -44,11 +44,29 @@ To transfer permissions to your own profile, click **Transfer Permissions** and 
 
 ### Timezone configuration
 
-Set your preferred timezone for time-based automation steps and scheduling.
+Set your preferred timezone for time-based automation steps and scheduling. This affects:
+
+- When **On a schedule** triggers fire
+- When **Delay** steps calculate their wait periods
+- How timestamps appear in the Activity tab
+
+To set the timezone, go to the automation's **Settings** tab and select **Timezone**.
+
+### Goal
+
+Goals let you define a success condition for the automation. When the goal is met, the run ends early with a **Completed from goal** status instead of running through all remaining steps.
+
+To set a goal, go to the automation's **Settings** tab and select **Goal**.
 
 ### Notification settings
 
-Subscribe to error notifications to be alerted when automations encounter issues.
+Subscribe to notifications so you're alerted when automations encounter issues:
+
+1. Go to the automation's **Settings** tab and select **Notifications**.
+2. Choose which events to be notified about (e.g., errors, completion).
+3. Select who receives the notifications.
+
+Notifications are sent via email and in-app alerts.
 
 ## Duplicating automations
 


### PR DESCRIPTION
Expand the stub sections for timezone configuration, goal setting, and notification settings with actual descriptions of what each does and how to access them in the Settings tab.

Story 3.1 of the automation docs restructure plan.