### PR TITLE
docs: clean up formatting across AI Workforce articles

### DIFF
--- a/docusaurus/docs/ai/ai-workforce/ai-chat-receptionist/_category_.json
+++ b/docusaurus/docs/ai/ai-workforce/ai-chat-receptionist/_category_.json
@@ -1,5 +1,6 @@
 {
   "label": "AI Chat Receptionist",
+  "position": 2,
   "collapsed": true,
   "link": { "type": "doc", "id": "index" }
 }

--- a/docusaurus/docs/ai/ai-workforce/ai-chat-receptionist/connect-the-ai-receptionist-with-servicetitan.md
+++ b/docusaurus/docs/ai/ai-workforce/ai-chat-receptionist/connect-the-ai-receptionist-with-servicetitan.md
@@ -1,6 +1,7 @@
 ---
 title: "Connect the AI Chat Receptionist with ServiceTitan"
 sidebar_label: Connect with ServiceTitan
+description: Connect the AI Chat Receptionist to ServiceTitan to look up customers, schedule appointments, and provide job status updates.
 ---
 
 import {AISparkleIcon} from '@site/src/components/Icons'
@@ -26,7 +27,7 @@ ServiceTitan is a software platform used by many trades businesses (HVAC, plumbi
 While this guide has been written primarily for your AI Chat Receptionist, you can use the Capabilities created in this guide with your AI Voice Receptionist, or any other AI Employee!
 :::
 
-## Prerequisites & Setup
+## Prerequisites & setup
 
 Before you connect your AI Receptionist to ServiceTitan, you need to gather the following items from your ServiceTitan account and API access. You'll only need to do this once.
 
@@ -38,31 +39,33 @@ Before you connect your AI Receptionist to ServiceTitan, you need to gather the 
 | **App ID & App Key** | Developer Portal → Your App → App Details | Application-specific identifiers |
 | **API Permissions** | `Settings` → `Integrations` → `API Application Access` → Configure Permissions | <ul><li>`jpm:jobs:read`</li><li>`jpm:jobs:write`</li><li>`crm:customers:read`</li><li>`crm:appointments:read`</li><li>`crm:appointments:write`</li><li>`accounting:invoices:read`</li><li>`settings:technicians:read`</li></ul> |
 
-#### ServiceTitan Help Resources
+#### ServiceTitan help resources
 
-> You can get more detailed help on gathering this information from the ServiceTitan resources below:
-> - Setting up API access ([ServiceTitan Developer Portal](https://developer.servicetitan.io/))
-> - Managing integrations ([API Application Access Guide](https://help.servicetitan.com/admin-settings/integrations/api-application-access))
-> - Understanding API permissions ([ServiceTitan API Documentation](https://developer.servicetitan.io/docs))
+:::info
+You can get more detailed help on gathering this information from the ServiceTitan resources below:
+- Setting up API access ([ServiceTitan Developer Portal](https://developer.servicetitan.io/))
+- Managing integrations ([API Application Access Guide](https://help.servicetitan.com/admin-settings/integrations/api-application-access))
+- Understanding API permissions ([ServiceTitan API Documentation](https://developer.servicetitan.io/docs))
+:::
 
 ---
 
-## Capability 1: Customer Lookup and Service History
+## Capability 1: Customer lookup and service history
 
 This capability allows your AI Receptionist to search for customers and retrieve their service history, providing instant access to past jobs, upcoming appointments, and customer preferences.
 
-### Step 1: Add a ServiceTitan Customer Lookup Capability
+### Step 1: Add a ServiceTitan customer lookup capability
 
 1. In your Business App, navigate to <AISparkleIcon /> `AI` → `AI Workforce`
 2. Select your AI Employee and click `Configure`.
 3. Under `Custom Capabilities`, click `Add a capability`.
 4. Fill in the following fields:
-   - **Name**: `ServiceTitan Customer Lookup`
-   - **Description**: Searches ServiceTitan for customer information, service history, and account details to provide personalized support and context for customer inquiries.
+   - `Name`: `ServiceTitan Customer Lookup`
+   - `Description`: Searches ServiceTitan for customer information, service history, and account details to provide personalized support and context for customer inquiries.
 
-### Step 2: Configure ServiceTitan Customer API Tools
+### Step 2: Configure ServiceTitan customer API tools
 
-#### ServiceTitan Tool: searchCustomers
+#### ServiceTitan tool: searchCustomers
 
 `searchCustomers` allows your AI Receptionist to find customers by name, phone number, or email address and retrieve basic customer information.
 
@@ -93,7 +96,7 @@ This capability allows your AI Receptionist to search for customers and retrieve
 | `page` | `Query` | `integer` | Page number for pagination (default: 1) |
 | `pageSize` | `Query` | `integer` | Number of results per page (default: 20, max: 100) |
 
-#### ServiceTitan Tool: getCustomerJobs
+#### ServiceTitan tool: getCustomerJobs
 
 `getCustomerJobs` retrieves the complete job history for a specific customer, including past service calls, upcoming appointments, and job details.
 
@@ -124,7 +127,7 @@ This capability allows your AI Receptionist to search for customers and retrieve
 | `page` | `Query` | `integer` | Page number for pagination |
 | `pageSize` | `Query` | `integer` | Number of results per page (max: 100) |
 
-#### ServiceTitan Tool: createCustomer
+#### ServiceTitan tool: createCustomer
 
 `createCustomer` creates a new customer record in ServiceTitan when they don't already exist in the system.
 
@@ -155,7 +158,7 @@ This capability allows your AI Receptionist to search for customers and retrieve
 | `doNotMail` | `Body` | `boolean` | Opt-out preference for mailing (default: false) |
 | `doNotService` | `Body` | `boolean` | Service restriction flag (default: false) |
 
-### Step 3: Write the Customer Lookup Prompt
+### Step 3: Write the customer lookup prompt
 
 ````
 ## **Customer Information Lookup Instructions**
@@ -225,22 +228,22 @@ Initiate a ServiceTitan customer search **when**:
 
 ---
 
-## Capability 2: Appointment Scheduling and Job Creation
+## Capability 2: Appointment scheduling and job creation
 
 This capability enables your AI Receptionist to schedule new appointments, create service jobs in ServiceTitan, and manage the booking process end-to-end.
 
-### Step 1: Add a ServiceTitan Appointment Scheduling Capability
+### Step 1: Add a ServiceTitan appointment scheduling capability
 
 1. In your Business App, navigate to <AISparkleIcon /> `AI` → `AI Workforce`
 2. Select your AI Employee and click `Configure`.
 3. Under `Custom Capabilities`, click `Add a capability`.
 4. Fill in the following fields:
-   - **Name**: `ServiceTitan Appointment Scheduling`
-   - **Description**: Creates new appointments and service jobs in ServiceTitan, checks technician availability, and manages the complete booking workflow from initial request to job creation.
+   - `Name`: `ServiceTitan Appointment Scheduling`
+   - `Description`: Creates new appointments and service jobs in ServiceTitan, checks technician availability, and manages the complete booking workflow from initial request to job creation.
 
-### Step 2: Configure ServiceTitan Scheduling API Tools
+### Step 2: Configure ServiceTitan scheduling API tools
 
-#### ServiceTitan Tool: getAvailableTimeSlots
+#### ServiceTitan tool: getAvailableTimeSlots
 
 `getAvailableTimeSlots` checks technician availability and capacity to find open appointment slots.
 
@@ -266,7 +269,7 @@ This capability enables your AI Receptionist to schedule new appointments, creat
 | `active` | `Query` | `boolean` | Filter for active technicians only |
 | `hasPermissions` | `Query` | `string` | Filter technicians by specific permissions |
 
-#### ServiceTitan Tool: createAppointment
+#### ServiceTitan tool: createAppointment
 
 `createAppointment` creates a new appointment and job in ServiceTitan with all necessary details.
 
@@ -298,7 +301,7 @@ This capability enables your AI Receptionist to schedule new appointments, creat
 | `appointmentStart` | `Body` | `string` | Appointment start time (ISO 8601 format) |
 | `duration` | `Body` | `integer` | Expected job duration in minutes |
 
-### Step 3: Write the Appointment Scheduling Prompt
+### Step 3: Write the appointment scheduling prompt
 
 ````
 ## **Appointment Scheduling Instructions**
@@ -379,22 +382,22 @@ After successfully creating an appointment:
 
 ---
 
-## Capability 3: Job Status and Updates
+## Capability 3: Job status and updates
 
 This capability allows your AI Receptionist to provide real-time updates on job status, technician location, and estimated arrival times.
 
-### Step 1: Add a ServiceTitan Job Status Capability
+### Step 1: Add a ServiceTitan job status capability
 
 1. In your Business App, navigate to <AISparkleIcon /> `AI` → `AI Workforce`
 2. Select your AI Employee and click `Configure`.
 3. Under `Custom Capabilities`, click `Add a capability`.
 4. Fill in the following fields:
-   - **Name**: `ServiceTitan Job Status Updates`
-   - **Description**: Retrieves real-time job status, technician location, and appointment updates from ServiceTitan to keep customers informed about their service appointments.
+   - `Name`: `ServiceTitan Job Status Updates`
+   - `Description`: Retrieves real-time job status, technician location, and appointment updates from ServiceTitan to keep customers informed about their service appointments.
 
-### Step 2: Configure ServiceTitan Job Status API Tools
+### Step 2: Configure ServiceTitan job status API tools
 
-#### ServiceTitan Tool: getJobStatus
+#### ServiceTitan tool: getJobStatus
 
 `getJobStatus` retrieves current job status and details for specific jobs.
 
@@ -419,7 +422,7 @@ This capability allows your AI Receptionist to provide real-time updates on job 
 |------|----------|------|-------------|
 | `job_id` | `Path` | `integer` | Specific job ID to retrieve status for |
 
-#### ServiceTitan Tool: getTechnicianLocation
+#### ServiceTitan tool: getTechnicianLocation
 
 `getTechnicianLocation` provides technician location and estimated arrival information (requires ServiceTitan Mobile integration).
 
@@ -439,7 +442,7 @@ This capability allows your AI Receptionist to provide real-time updates on job 
 | `Authorization` | `Bearer {{access_token}}` | ✓ |
 | `ST-App-Key` | `{{app_key}}` | ✓ |
 
-### Step 3: Write the Job Status Prompt
+### Step 3: Write the job status prompt
 
 ````
 ## **Job Status and Updates Instructions**
@@ -512,7 +515,7 @@ Retrieve job status information **when**:
 
 ## Example conversations with AI Receptionist connected to ServiceTitan
 
-### Example 1: Existing Customer Scheduling Maintenance
+### Example 1: Existing customer scheduling maintenance
 
 <ChatUserMessage>
 Hi, I'd like to schedule an HVAC maintenance appointment for my home. Can you check what's available next week?
@@ -566,7 +569,7 @@ Mike will call you about 30 minutes before arrival. Please ensure the area aroun
 You'll receive a confirmation email shortly, and we'll send a reminder the day before your appointment. Is there anything specific you'd like our technician to check during the maintenance?
 </ChatAIMessage>
 
-### Example 2: New Customer Requesting Service
+### Example 2: New customer requesting service
 
 <ChatUserMessage>
 Hi, my kitchen sink has been leaking and I need a plumber. Can someone come out this week?
@@ -641,7 +644,7 @@ Dave will call you about 30 minutes before arrival. Please make sure the area un
 You'll receive a confirmation email at sarah.williams@email.com, and we'll send you a reminder the day before. Welcome to our family of customers, Sarah!
 </ChatAIMessage>
 
-## Testing & Troubleshooting
+## Testing & troubleshooting
 
 This section walks you through diagnosing the most common issues with connecting ServiceTitan to the AI Receptionist: from authentication errors and API limits, to empty results and permission issues.
 
@@ -728,9 +731,9 @@ The API returned a `404 Not Found` error, meaning the requested resource doesn't
 
 </Tabs>
 
-## FAQ: Connecting the AI Receptionist with ServiceTitan
+## FAQ: connecting the AI Receptionist with ServiceTitan
 
-### Integration & Setup
+### Integration & setup
 
 <details>
 <summary>Can I use this ServiceTitan integration with other AI Employees besides the Chat Receptionist?</summary>
@@ -760,7 +763,7 @@ While this guide covers core customer service functions, ServiceTitan's API supp
 You can create additional Custom Capabilities for features like inventory lookup, invoice status, equipment history, and maintenance reminders using the same framework described in this guide.
 </details>
 
-### AI & Workflow Questions
+### AI & workflow questions
 
 <details>
 <summary>How does the ServiceTitan integration work with my AI's Knowledge Base?</summary>
@@ -790,7 +793,7 @@ Great question! The ServiceTitan API provides operational and customer data, but
 This ensures your AI can provide complete, helpful answers by combining real-time ServiceTitan data with your business policies and expertise.
 </details>
 
-### Business Process Questions
+### Business process questions
 
 <details>
 <summary>How can I ensure my AI creates jobs with the right priority and routing?</summary>
@@ -857,7 +860,7 @@ Emergency services require special handling to ensure rapid response:
 "I understand you have no heat and it's freezing outside. This is definitely an emergency. I'm creating a high-priority service call right now and will have our emergency dispatch contact you within 10 minutes. In the meantime, if you have a space heater, please use it safely..."
 </details>
 
-### Technical & Advanced Configuration
+### Technical & advanced configuration
 
 <details>
 <summary>How can I track which services customers request most through AI interactions?</summary>

--- a/docusaurus/docs/ai/ai-workforce/ai-chat-receptionist/connect-the-ai-receptionist-with-shopify.md
+++ b/docusaurus/docs/ai/ai-workforce/ai-chat-receptionist/connect-the-ai-receptionist-with-shopify.md
@@ -1,6 +1,7 @@
 ---
 title: "Connect the AI Chat Receptionist with Shopify"
 sidebar_label: Connect with Shopify
+description: Connect the AI Chat Receptionist to Shopify to search products, share details, and check inventory in chat.
 ---
 
 import {AISparkleIcon} from '@site/src/components/Icons'
@@ -29,10 +30,10 @@ Before you connect your AI Receptionist to Shopify, you need to gather the follo
 
 | What you need | Where to find it | Scopes / Notes |
 |---------------|------------------|----------------|
-| **Shopify Store Domain** (`your-store.myshopify.com`) | `Admin` → `Settings` → `General`, copy `Store address` | — |
+| **Shopify Store Domain** (`your-store.myshopify.com`) | `Admin` → `Settings` → `General`, copy `Store address` | N/A |
 | **Admin API Access Token** | <p>1. Click <code>New app</code> → <code>Configure Admin API</code> (select the permissions shown in “Scopes / Notes” and click Save)</p><p>2. Click <code>Install</code> → <code>Reveal token</code></p> | <ul><li>`read_inventory`</li><li>`read_products`</li></ul> |
 | **Storefront API Access Token** | <p>1. Click <code>Enable Storefront API</code> (turn on the permission listed in “Scopes / Notes” and click Save)</p><p>2. Click <code>Install / Update</code> → <code>Reveal token</code></p> | <ul><li>`unauthenticated_read_product_listings`</li></ul> |
-| *(Optional)* **GraphQL Familiarity** | Review [Shopify Admin GraphQL API docs](https://shopify.dev/docs/api/admin-graphql) | — |
+| *(Optional)* **GraphQL Familiarity** | Review [Shopify Admin GraphQL API docs](https://shopify.dev/docs/api/admin-graphql) | N/A |
 
 #### Shopify help resources
 
@@ -54,8 +55,8 @@ This step creates the capability your AI Receptionist will reference when someon
 2. Select your AI Employee and click `Configure`.
 3. Under `Custom Capabilities`, click `Add a capability`.
 4. Fill in the following fields:
-   - **Name**: `Get Shopify Product Info`
-   - **Description**: Searches the Shopify store for products matching a keyword and returns product names, descriptions, prices, and availability using the Storefront API.
+   - `Name`: `Get Shopify Product Info`
+   - `Description`: Searches the Shopify store for products matching a keyword and returns product names, descriptions, prices, and availability using the Storefront API.
   
 :::note
 You will come back to this screen in [Step 3: Write the Prompt](#step-3-write-the-prompt).

--- a/docusaurus/docs/ai/ai-workforce/ai-chat-receptionist/index.md
+++ b/docusaurus/docs/ai/ai-workforce/ai-chat-receptionist/index.md
@@ -1,6 +1,7 @@
 ---
-title: AI Chat Receptionist Overview 
+title: AI Chat Receptionist Overview
 sidebar_position: 2
+description: Set up, train, and monitor the AI Chat Receptionist to capture leads and answer visitor questions across web chat and SMS.
 ---
 
 import { AISparkleIcon } from '@site/src/components/Icons';
@@ -17,7 +18,7 @@ The AI Chat Receptionist helps you capture leads and respond to website visitors
 
 The AI Chat Receptionist ensures that your business never misses an opportunity by engaging website visitors instantly, around the clock. By capturing leads and answering common questions 24/7, it turns casual browsers into qualified prospects, even when your team is offline.
 
-The Chat Receptionist also reduces friction and drop-off by starting conversations with context-driven prompts instead of long forms, and it handles ambiguous or complex questions by understanding free-form requests and adapting in real time—no rigid menus. Natural, empathetic replies and personalized greetings help build trust with visitors.
+The Chat Receptionist also reduces friction and drop-off by starting conversations with context-driven prompts instead of long forms, and it handles ambiguous or complex questions by understanding free-form requests and adapting in real time, with no rigid menus. Natural, empathetic replies and personalized greetings help build trust with visitors.
 
 As your business grows, the AI adapts to new offerings and workflows without needing extensive decision trees. It delivers timely, personalized responses that guide visitors through the sales funnel and can improve both customer satisfaction and conversion rates.
 
@@ -51,7 +52,7 @@ The AI Chat Receptionist can transcribe and respond in 57 languages. A language 
 | | Maltese | Vietnamese |
 | | Marathi | Welsh |
 
-The AI detects the visitor's language automatically from their messages — no configuration is required.
+The AI detects the visitor's language automatically from their messages. No configuration is required.
 
 :::info Languages not on this list
 If a visitor writes in a language not listed above, the AI will still attempt to respond, but results may vary. To get the best results for a specific language, check whether it appears in the table above.
@@ -61,33 +62,33 @@ If a visitor writes in a language not listed above, the AI will still attempt to
 
 Follow these simple steps to configure your AI Chat Receptionist so it effectively engages visitors and captures valuable leads.
 
-### Step 1: Configure Basic Settings for the AI Chat Receptionist
+### Step 1: Configure basic settings for the AI Chat Receptionist
 
-Go to <AISparkleIcon /> `AI > AI workforce` and then click `Configure` on the Chat receptionist.
+Go to <AISparkleIcon /> `AI` → `AI Workforce` and then click `Configure` on the AI Chat Receptionist.
 
-- **Name and Image**  
+- `Name and Image`
 Give your AI a friendly, professional name and photo. The AI Receptionist knows their name and the photo will help you distinguish between other AI Employees in your app.
 
-- **Communication Channels**  
-Your AI Chat Receptionist is assigned to the **Web Chat** channel by default. This channel is always active and cannot be disabled. You can also assign your AI Receptionist to the **SMS** channel to reach customers via text messaging.
+- `Communication Channels`
+Your AI Chat Receptionist is assigned to the `Web Chat` channel by default. This channel is always active and cannot be disabled. You can also assign your AI Receptionist to the `SMS` channel to reach customers via text messaging.
 
-:::note  
-The Web Chat widget isn't automatically added to your website! You'll need to install the widget code or enable it within your site builder before your AI can start engaging visitors. When you are ready to install the widget, refer to [How to install the Conversations Web Chat Widget](https://docs.businessapp.io/business-app/conversations/web-chat)
+:::note
+The `Web Chat` widget isn't automatically added to your website! You'll need to install the widget code or enable it within your site builder before your AI can start engaging visitors. When you are ready to install the widget, refer to [How to install the Conversations Web Chat Widget](https://docs.businessapp.io/business-app/conversations/web-chat)
 :::
 
 :::tip Respond differently on each channel
-Your AI Chat Receptionist knows which channel it's replying on, so it can adapt its tone and reply length per channel. To set this up, add channel-specific instructions to the **Purpose** prompt or to a capability's instructions — for example, "When responding on SMS, keep replies to one or two sentences with no formatting; when responding on web chat, you can use short lists and links." Both places work. See [Adjust responses by channel](../index.mdx#adjust-responses-by-channel) for examples.
+Your AI Chat Receptionist knows which channel it's replying on, so it can adapt its tone and reply length per channel. To set this up, add channel-specific instructions to the `Purpose` prompt or to a capability's instructions. For example, "When responding on SMS, keep replies to one or two sentences with no formatting; when responding on web chat, you can use short lists and links." Both places work. See [Adjust responses by channel](../index.mdx#adjust-responses-by-channel) for examples.
 :::
 
-### Step 2: Configure Your AI Chat Receptionist Capabilities
+### Step 2: Configure your AI Chat Receptionist capabilities
 
 Capabilities are like instructions that guide how your AI Chat Receptionist behaves and what actions it can take. Review these and adjust as needed to make sure your AI performs the way you want.
 
-- **Capture Lead Information**  
+- `Capture Lead Information`
   The AI automatically asks visitors for contact details such as name, phone number, or email and saves captured leads directly to your CRM. This capability is turned on by default.
 
   :::tip Webchat visitors showing as anonymous?
-  If contacts are appearing under the **Anonymous Visitors** tab instead of being saved to your CRM, check that the Lead Capture capability is enabled. Go to **AI Workforce** and then **Configure** on the Chat Receptionist, then open **Capabilities** and make sure **Lead Capture** is toggled on, then save.
+  If contacts are appearing under the `Anonymous Visitors` tab instead of being saved to your CRM, check that the Lead Capture capability is enabled. Go to `AI Workforce` and then `Configure` on the Chat Receptionist, then open `Capabilities` and make sure `Lead Capture` is toggled on, then save.
   :::
 
   **How phone numbers are stored**
@@ -96,18 +97,22 @@ Capabilities are like instructions that guide how your AI Chat Receptionist beha
 
   If your business serves international customers, you can add an instruction to your Q&A or Purpose prompt asking visitors to include their country code when sharing a phone number. For example:
 
-  > Please include your country code when sharing your phone number (for example, +44 for the UK or +61 for Australia).
+  ```text
+  Please include your country code when sharing your phone number (for example, +44 for the UK or +61 for Australia).
+  ```
 
-- **Book Appointments**  
+- `Book Appointments`
   Connect your calendar to let the AI help customers schedule meetings. It will offer available time slots and collect all necessary booking details automatically.
 
   **Setting up a booking link via Q&A instructions**
 
   If you want the AI to share a booking link rather than book directly, add an instruction to your Q&A or Purpose that includes the link text. For example:
 
-  > When a visitor asks to book a meeting or schedule an appointment, share this link: [your booking link here]
+  ```text
+  When a visitor asks to book a meeting or schedule an appointment, share this link: [your booking link here]
+  ```
 
-  The AI will provide the link when booking comes up naturally in conversation. It does not book meetings autonomously — it directs the visitor to the link to complete the process.
+  The AI will provide the link when booking comes up naturally in conversation. It does not book meetings autonomously: it directs the visitor to the link to complete the process.
 
   **Shared booking for a team**
 
@@ -133,14 +138,14 @@ With multi-service booking enabled, the AI can:
 - Collect and deduplicate required contact and intake fields across selected services, including phone validation and confirmation
 - Send one consolidated confirmation flow (email, SMS, or both based on requirements) and create one CRM activity for the multi-service booking
 
- - **Custom Capabilities**  
-   Expand your AI Chat Receptionist's skills by adding custom capabilities tailored to your unique business needs. You can learn more about [Custom Capabilities](../../ai-capabilities/creating-custom-capabilities.md) in depth.
+- `Custom Capabilities`
+  Expand your AI Chat Receptionist's skills by adding custom capabilities tailored to your unique business needs. You can learn more about [Custom Capabilities](../../ai-capabilities/creating-custom-capabilities.md) in depth.
 
-### Step 3: Add Purpose and Business Knowledge to the AI Chat Receptionist
+### Step 3: Add purpose and business knowledge to the AI Chat Receptionist
 
-To respond accurately to general inquiries, your AI Chat Receptionist needs context about your business. 
+To respond accurately to general inquiries, your AI Chat Receptionist needs context about your business.
 
-- **Knowledge**: This includes detailed business information, such as FAQs, service descriptions, and policies, that the AI uses to answer specific questions. Information from your website homepage is included by default.
+- `Knowledge`: This includes detailed business information, such as FAQs, service descriptions, and policies, that the AI uses to answer specific questions. Information from your website homepage is included by default.
 
  For a complete guide on providing your AI Employees with Knowledge, see the [Knowledge Base documentation](../../knowledge-base/).
 
@@ -148,7 +153,7 @@ To respond accurately to general inquiries, your AI Chat Receptionist needs cont
 
 When a visitor chats through the Web Chat widget, the AI Chat Receptionist receives the URL of the page they're currently on with every message they send. The AI can use this URL to answer vague, context-dependent questions ("is this still available?", "what's the price?", "tell me more") without making the visitor re-explain what they're looking at.
 
-This works automatically — no configuration is required for the AI to receive the URL. To get the most out of it, make sure the relevant pages of the SMB's website are in the AI's knowledge base, and consider tuning the Purpose or a capability prompt to tell the AI how to interpret the URL pattern for that business.
+This works automatically. No configuration is required for the AI to receive the URL. To get the most out of it, make sure the relevant pages of the SMB's website are in the AI's knowledge base, and consider tuning the Purpose or a capability prompt to tell the AI how to interpret the URL pattern for that business.
 
 :::info The AI sees the URL, not the page content
 The AI is only given the URL string itself, not a rendered view of the page. To answer detailed questions about what's on a page, the AI needs that page's content in its knowledge base, or a [custom capability](../../ai-capabilities/creating-custom-capabilities.md) that can look up the data (for example, an inventory lookup tool keyed off the URL).
@@ -168,7 +173,7 @@ https://www.example.com/inventory/[year-make-model-slug]/[id]
 The numeric value at the end of the path is the vehicle's id.
 
 When the customer is on a vehicle detail page:
-- If they ask anything vague — "is this still available", "what's the price", "tell me more", "any photos", "what colour is it", "is it certified" — call GetInventory using that id from the URL. Do not ask which vehicle they mean.
+- If they ask anything vague, such as "is this still available", "what's the price", "tell me more", "any photos", "what colour is it", or "is it certified", call GetInventory using that id from the URL. Do not ask which vehicle they mean.
 - Confirm the vehicle naturally in the first line of your reply (e.g. "The 2021 Wrangler Sahara you're looking at...") so they know you understood.
 - If the URL changes between turns, the customer has navigated to a different vehicle. Always use the URL from the most recent message.
 
@@ -181,26 +186,26 @@ When the customer is on a non-inventory page (homepage, /financing, /about, cont
 Customer words always override the URL. If they explicitly reference a different stock number, VIN, or year/make/model than what's on their current page, follow what they said and ignore the URL.
 ```
 
-The same pattern works for any business with structured URLs — e-commerce product pages, service pages, real estate listings, menu items, and so on. Pair this with a [custom capability](../../ai-capabilities/creating-custom-capabilities.md) that looks up live data using the ID parsed from the URL.
+The same pattern works for any business with structured URLs: e-commerce product pages, service pages, real estate listings, menu items, and so on. Pair this with a [custom capability](../../ai-capabilities/creating-custom-capabilities.md) that looks up live data using the ID parsed from the URL.
 
 :::note Web Chat only
 The visitor's current URL is provided on the Web Chat channel. Other channels (SMS, voice, email) don't have a "current page" concept, so this context isn't available there.
 :::
 
-## Test and Monitor Your AI Chat Receptionist
+## Test and monitor your AI Chat Receptionist
 
 Once your AI Chat Receptionist is set up, it's important to test how it handles real conversations and monitor its interactions over time. This helps you ensure the AI is answering questions accurately, capturing leads, and creating a positive experience for your website visitors. Regular testing and review will help you catch issues early and continuously improve your AI's performance as your business evolves.
 
-### Test the AI Chat Receptionist's Responses
+### Test the AI Chat Receptionist's responses
 
-Click the `Try it` button from <AISparkleIcon /> `AI` > `AI Workforce`  to open up a **My Listing** page you can use to test chat responses before installing the website widget. For best results, open the test in an incognito window so it starts with a clean session.
+Click the `Try it` button from <AISparkleIcon /> `AI` → `AI Workforce` to open up a `My Listing` page you can use to test chat responses before installing the website widget. For best results, open the test in an incognito window so it starts with a clean session.
 
 Ask the kinds of questions your real customers might ask, and pay attention to:
 - How the AI responds
 - Whether it gives too much or too little information
 - If it's assuming something you didn't intend
 
-#### Testing with Fresh Conversations
+#### Testing with fresh conversations
 
 For accurate testing results, you'll want each test to start with a fresh conversation that doesn't carry over previous context:
 
@@ -216,13 +221,13 @@ For accurate testing results, you'll want each test to start with a fresh conver
 - Refresh the page to start a new conversation
 - Best for systematic testing when you need multiple fresh conversations in sequence
 
-:::tip Testing Best Practice
+:::tip Testing best practice
 Test the same prompt multiple times to see if you get consistent results. AI responses can vary slightly, so testing helps you identify if your prompts need to be more specific.
 :::
 
-### Monitor and Improve the AI Chat Receptionist
+### Monitor and improve the AI Chat Receptionist
 
-Regularly review the `Conversations` and `Anonymous Visitors` tabs in Conversations to make sure your Chat Receptionist is interacting with visitors like you expected. 
+Regularly review the `Conversations` and `Anonymous Visitors` tabs in Conversations to make sure your Chat Receptionist is interacting with visitors like you expected.
 
 :::note
 Conversations are placed in the `Anonymous Visitors` tab when the AI Chat Receptionist was unable to identify their contact information during the conversation.
@@ -233,7 +238,7 @@ Responses from the AI Chat Receptionist include a clickable `Explanation` that e
 - the source they used for any knowledge
 - any Tools that were used by the AI, as well as the detailed API call and response.
 
-#### Using AI Explanations for Debugging
+#### Using AI explanations for debugging
 
 The Explanation feature is your most valuable debugging tool. Each response explanation shows:
 
@@ -293,7 +298,7 @@ Improving your AI Chat Receptionist is an iterative process. Follow this workflo
 - Track if your fix improved the overall experience
 - Be ready to iterate further if needed
 
-:::tip When to Adjust Purpose vs. Capabilities vs. Knowledge
+:::tip When to adjust Purpose vs. Capabilities vs. Knowledge
 - **Adjust Purpose** when the issue affects all conversations (tone, general behavior, introduction)
 - **Adjust Capabilities** when the issue is about when/how to take specific actions in certain situations
 - **Adjust Knowledge** when the issue is about incorrect facts or missing information
@@ -351,7 +356,7 @@ The AI Chat Receptionist is **non-deterministic**, which means it may provide di
 
 You know your business best! To improve your AI's accuracy, take a moment to write down:
 
-- The services you offer—and those you don't  
+- The services you offer, and those you don't  
 - The most common questions your customers ask  
 - The key information the AI should always collect from visitors
 
@@ -371,7 +376,7 @@ No. The AI is given the URL of the page the visitor is on, but it does not see t
 
 It depends on the outcomes the SMB is after.
 
-- If they only want a smoother experience — the AI naturally picks up that the visitor is on a specific page and references it — no tuning is required.
+- If they only want a smoother experience, the AI naturally picks up that the visitor is on a specific page and references it. No tuning is required.
 - If they want specific behavior tied to specific URL patterns (e.g. always look up inventory when the customer is on a `/inventory/[id]` page), add instructions to the Purpose or a capability prompt that explain the URL pattern and how the AI should react.
 
 </details>
@@ -389,7 +394,7 @@ Two things to check:
 <details>
 <summary>Why did the AI Chat Receptionist stop responding for an hour?</summary>
 
-When a live agent sends a message in a conversation, the AI Chat Receptionist automatically steps back for **1 hour** to avoid conflicting with the human-handled conversation. This is by design — the AI gives the live agent space to take over without interrupting.
+When a live agent sends a message in a conversation, the AI Chat Receptionist automatically steps back for **1 hour** to avoid conflicting with the human-handled conversation. This is by design: the AI gives the live agent space to take over without interrupting.
 
 **What triggers the 1-hour pause:**
 - A live agent sends a message in the conversation
@@ -408,7 +413,7 @@ When the chat receptionist (or any AI Employee) is assigned to a web chat widget
 
 For any other channel that the chat receptionist can respond to, the AI is configured with a 60-minute inactivity timeout. If a human response is not detected in the conversation within this timeframe, the AI will automatically generate a follow-up response. The system strictly bases the timeout countdown on the most recent human message only.
 
-:::info 
+:::info
 This only applies to conversations where messages have been sent from Conversations AI. For example, the chat receptionist would respond instantly to an SMS message from a new contact if it was assigned to monitor the SMS channel.
 :::
 

--- a/docusaurus/docs/ai/ai-workforce/ai-receptionist-features-by-plan.mdx
+++ b/docusaurus/docs/ai/ai-workforce/ai-receptionist-features-by-plan.mdx
@@ -21,7 +21,7 @@ The **Starter** plan includes the **AI Chat Receptionist**, an AI-powered websit
 - Basic lead qualification before forwarding  
 
 :::note
-The Starter plan **does not** include AI Voice Receptionist or social channel integrations (Facebook, Instagram, WhatsApp).
+The **Starter** plan **does not** include AI Voice Receptionist or social channel integrations (Facebook, Instagram, WhatsApp).
 :::
 
 ## Professional plan and above: AI Chat + AI Voice Receptionist
@@ -29,7 +29,7 @@ The Starter plan **does not** include AI Voice Receptionist or social channel in
 Starting from the **Professional** plan, partners get **both** the AI Chat Receptionist and the AI Voice Receptionist.
 
 ### AI Chat Receptionist
-All features included in the Starter plan.
+All features included in the **Starter** plan.
 
 ### AI Voice Receptionist
 An AI-powered phone-answering system ideal for agencies with higher call volumes or after-hours needs.

--- a/docusaurus/docs/ai/ai-workforce/ai-sales-assistant.mdx
+++ b/docusaurus/docs/ai/ai-workforce/ai-sales-assistant.mdx
@@ -1,7 +1,7 @@
 ---
 title: AI Sales Assistant
 sidebar_label: AI Sales Assistant
-sidebar_position: 3
+sidebar_position: 4
 description: Use the AI Sales Assistant to automate CRM updates, explore sales insights through chat, and create activities based on your sales data.
 tags: [ai-sales-assistant, crm-integration, crm-ai, conversation-intelligence]
 keywords: [sales assistant, crm logging, auto crm update, chat with crm, conversation intelligence, ai workforce, activities]
@@ -45,7 +45,7 @@ The AI Sales Assistant uses data from your meeting recordings and CRM records to
 
 The AI Sales Assistant can start working with minimal configuration. Setting up its profile helps ensure it represents your business accurately and is easy to identify within your AI Workforce.
 
-1. Go to `AI` > `AI Workforce`.
+1. Go to `AI` → `AI Workforce`.
 2. Click `Configure` on the AI Sales Assistant.
 3. Name your AI and upload an identifying image.
 
@@ -57,7 +57,7 @@ The AI Sales Assistant includes two core capabilities. Each serves a different p
 
 #### Talk to your CRM data
 
-The **Talk to your CRM data** capability allows you to interact with your CRM through a conversational chat interface. You can ask the AI Sales Assistant natural-language questions to get specific, company-level insights from your CRM data and meeting content.
+The `Talk to your CRM data` capability allows you to interact with your CRM through a conversational chat interface. You can ask the AI Sales Assistant natural-language questions to get specific, company-level insights from your CRM data and meeting content.
 
 For example, you can ask questions like:
 
@@ -77,7 +77,7 @@ You can customize the prompt used by this capability to adjust how the AI Sales 
 
 #### Auto update CRM records
 
-The **Auto update CRM records** capability allows the AI Sales Assistant to automatically update your CRM records after each customer meeting or call, including contacts, companies, opportunities, and custom object fields.
+The `Auto update CRM records` capability allows the AI Sales Assistant to automatically update your CRM records after each customer meeting or call, including contacts, companies, opportunities, and custom object fields.
 
 - Extracts key details from meeting content captured through Conversation Intelligence
 - Updates contact and company records based on meeting participants and conversation outcomes
@@ -91,7 +91,7 @@ The **Auto update CRM records** capability allows the AI Sales Assistant to auto
 - `Always overwrite`: The AI updates the field regardless of whether it already has a value
 - `Overwrite if empty`: The AI only fills in the field if it is currently empty
 
-To configure overwrite preferences, go to `Business App` > `CRM` > `AI Sales Assistant` > `Configure`. In the `Update CRM` capability, set the overwrite preference for each field.
+To configure overwrite preferences, go to `Business App` → `CRM` → `AI Sales Assistant` → `Configure`. In the `Update CRM` capability, set the overwrite preference for each field.
 
 **Automation time trigger:** You can also use an automation time trigger to prompt the AI Sales Assistant to find and act on data updates on a schedule, without waiting for a meeting to trigger it.
 
@@ -161,7 +161,7 @@ CRM AI Pro includes 750 minutes of meeting recording. Overages are billed at app
 <details>
 <summary>Where do I access the AI Sales Assistant?</summary>
 
-You can configure the AI Sales Assistant from `AI` > `AI Workforce`. To use the chat interface, click the `AI icon` in the top right of the CRM screen.
+You can configure the AI Sales Assistant from `AI` → `AI Workforce`. To use the chat interface, click the `AI icon` in the top right of the CRM screen.
 
 </details>
 

--- a/docusaurus/docs/ai/ai-workforce/ai-search-specialist.mdx
+++ b/docusaurus/docs/ai/ai-workforce/ai-search-specialist.mdx
@@ -1,7 +1,7 @@
 ---
 title: AI Search Specialist
 sidebar_label: AI Search Specialist
-sidebar_position: 5
+sidebar_position: 6
 description: Set up the AI Search Specialist, an open beta AI employee for Local SEO Pro that optimizes business profiles and reports on AI search visibility.
 tags: [ai-workforce, ai-search-specialist, local-seo, open-beta]
 keywords: [AI Search Specialist, Local SEO Pro, Brand Visibility Report, AEO Audit, SEO Audit, business profile optimization, AI workforce, open beta]
@@ -28,9 +28,9 @@ The AI Search Specialist is available now as a free, open beta preview for all L
 ## How to access the AI Search Specialist
 
 1. Log in to **Business App**.
-2. In the left-hand navigation, go to **AI** → **AI Workforce**.
-3. Click **Chat** to open the AI Search Specialist.
-4. Type a question directly into chat, or click one of the three report chips: **Brand Visibility**, **AEO Audit**, or **SEO Audit**.
+2. In the left-hand navigation, go to `AI` → `AI Workforce`.
+3. Click `Chat` to open the AI Search Specialist.
+4. Type a question directly into chat, or click one of the three report chips: `Brand Visibility`, `AEO Audit`, or `SEO Audit`.
 
 <img src={require('./img/ai-search-specialist/ai-search-specialist-workforce-nav.png').default} alt="AI Workforce page in Business App showing the AI Search Specialist card alongside other AI employees" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
 

--- a/docusaurus/docs/ai/ai-workforce/ai-voice-receptionist.md
+++ b/docusaurus/docs/ai/ai-workforce/ai-voice-receptionist.md
@@ -1,7 +1,8 @@
 ---
 title: AI Voice Receptionist Overview
 sidebar_label: AI Voice Receptionist
-sidebar_position: 2
+sidebar_position: 3
+description: Learn how to set up, configure, test, and troubleshoot your AI Voice Receptionist, including call routing, capabilities, knowledge sources, and frequently asked questions.
 ---
 
 import { AISparkleIcon, SettingsIcon, CRMIcon } from '@site/src/components/Icons';
@@ -22,7 +23,7 @@ Having an AI Voice Receptionist helps stop customers from moving on to the next 
 
 ## Setting up the AI Voice Receptionist
 
-### AI Voice Receptionist Call Flow & Routing
+### AI Voice Receptionist call flow & routing
 
 There are a number of ways to route calls to and from your Voice Receptionist to ensure that you never miss a lead.
 
@@ -67,20 +68,20 @@ Once a call reaches your AI Voice Receptionist, there are a number of potential 
 While this guide will cover accessing these other options, it will focus on setting up the AI Voice Receptionist to answer calls. For more detail on using the other options, see [Conversations Settings](/administration/platform-settings/conversations-settings/).
 :::
 
-### Prerequisites for AI Voice Receptionist Setup
+### Prerequisites for AI Voice Receptionist setup
 
 Before you begin, make sure you've completed these prerequisites so your AI Voice Receptionist setup goes smoothly.
 
 | What you need                     | Where to find it              | Notes                                                |
 | --------------------------------- | ----------------------------- | ---------------------------------------------------- |
-| AI Voice Receptionist access      | <AISparkleIcon /> `AI` > `AI Workforce`             | See the [AI Workforce Overview](./index.mdx) for edition and region availability.           |
-| Conversations AI phone number        | <SettingsIcon /> `Administration` > `Conversations Settings` | You will need this number for call-forwarding and publishing. This number is assigned after activating an eligible edition of Conversations AI.                |
-| *(Optional)* Calendar connection    | <CRMIcon /> `CRM` > `My Meetings` > <SettingsIcon /> `Settings` > `Defaults` > `Connect Calendar`   | Lets your AI Voice Receptionist book meetings and appointments on the connected calendar.                          |
+| AI Voice Receptionist access      | <AISparkleIcon /> `AI` → `AI Workforce`             | See the [AI Workforce Overview](./index.mdx) for edition and region availability.           |
+| Conversations AI phone number        | <SettingsIcon /> `Administration` → `Conversations Settings` | You will need this number for call-forwarding and publishing. This number is assigned after activating an eligible edition of Conversations AI.                |
+| *(Optional)* Calendar connection    | <CRMIcon /> `CRM` → `My Meetings` → <SettingsIcon /> `Settings` → `Defaults` → `Connect Calendar`   | Lets your AI Voice Receptionist book meetings and appointments on the connected calendar.                          |
 
-### Step 1: Set up your AI Voice Receptionist Persona and Communication Channels
+### Step 1: Set up your AI Voice Receptionist persona and communication channels
 While your AI Voice Receptionist is capable of being a great representative for your business with very little configuration, there are a few things you can do to make them feel more on brand with your business and ensure they are set up correctly.
 
-To get started, go to <AISparkleIcon /> `AI > AI Workforce` and click `Configure` on the Voice Receptionist. 
+To get started, go to <AISparkleIcon /> `AI` → `AI Workforce` and click `Configure` on the Voice Receptionist. 
 
 #### Set your AI Voice Receptionist's name and image
 
@@ -97,7 +98,7 @@ Each voice family and voice have different strengths and weaknesses like respons
 #### Choose your AI Voice Receptionist's communication channels
 Under the `Channels` section, you will see all of the channels the AI Voice Receptionist can be assigned to work with. Your AI Voice Receptionist should be assigned to the Conversations AI phone number by default. 
 
-### Step 2: Configure Your AI Voice Receptionist Capabilities
+### Step 2: Configure your AI Voice Receptionist capabilities
 
 Your AI Voice Receptionist has a number of capabilities available by default that let them take calls like a human receptionist would. 
 
@@ -111,7 +112,7 @@ For more detailed information on Capabilities, see the [AI Workforce Overview](.
 :::
 
 #### Default voice lead capture for AI Voice Receptionist
-The **default voice lead capture** capability guides your AI Employee to offer to help customers by answering questions and then gathering their contact information. This capability is turned on by default. 
+The `Default voice lead capture` capability guides your AI Employee to offer to help customers by answering questions and then gathering their contact information. This capability is turned on by default. 
 
 ::::note
 If this is turned off, the Voice Receptionist will not be able to capture caller information but *will* still answer questions to the best of their ability.
@@ -120,17 +121,17 @@ If this is turned off, the Voice Receptionist will not be able to capture caller
 
 #### Book appointments with your calendar
 
-The **Book appointments with calendar** capability connects to your integrated calendar, enabling the AI Voice Receptionist to offer real-time availability to callers, collect all necessary booking details, and automatically create events on your calendar. 
+The `Book appointments with calendar` capability connects to your integrated calendar, enabling the AI Voice Receptionist to offer real-time availability to callers, collect all necessary booking details, and automatically create events on your calendar. 
 
 On the `Book appointments with calendar` panel, use the `Select event link to book with` dropdown to choose which calendar your receptionist should use to determine availability as well as which kind of appointments they can offer.
 
 :::note
-If an AI Employee's configuration shows a **Book appointments** capability with an **Upgrade available** badge, that is a legacy capability being deprecated. Switch to **Book appointments — Voice** (this capability) for the latest features and multi-service booking.
+If an AI Employee's configuration shows a `Book appointments` capability with an `Upgrade available` badge, that is a legacy capability being deprecated. Switch to `Book appointments: Voice` (this capability) for the latest features and multi-service booking.
 :::
 
 #### Book multiple services in one session
 
-When configuring **Book appointments with calendar**, you can enable **Book Multiple Services** and choose the service menu/group the AI can book from.
+When configuring `Book appointments with calendar`, you can enable `Book Multiple Services` and choose the service menu/group the AI can book from.
 
 With multi-service booking enabled, the AI can:
 
@@ -144,9 +145,9 @@ With multi-service booking enabled, the AI can:
 - Collect and deduplicate mandatory contact and intake fields across selected services, including phone validation and confirmation
 - Send one consolidated confirmation flow (email, SMS, or both based on requirements) and create one CRM activity for the multi-service booking
 
-#### Additional Instructions for AI Voice Receptionist
+#### Additional instructions for AI Voice Receptionist
 
-The **Additional Instructions** capability lets you give your AI Voice Receptionist custom guidance to shape its responses, tone, and logic. It sits at the top of the AI's prompt stack to refine how it interacts with callers. 
+The `Additional Instructions` capability lets you give your AI Voice Receptionist custom guidance to shape its responses, tone, and logic. It sits at the top of the AI's prompt stack to refine how it interacts with callers. 
 
 To add additional instructions, click on the `Additional Instructions` tab in the Capabilities panel. From there you can write plain language instructions to your AI Voice Receptionist. 
 
@@ -168,9 +169,9 @@ For more details on creating custom capabilities, see [Creating Custom Capabilit
 Enable your AI Voice Receptionist to live-transfer callers to one or more phone numbers based on caller intent and conditions you define. For example, route callers asking for "billing" to your billing department, send incoming calls to different teams based on the time of day, or transfer VIP clients directly to their account manager.
 
 How to enable:
-1. Go to `AI > AI Workforce > Voice Receptionist > Configure`
-2. In Capabilities, click "Add new capability"
-3. Select "Transfer call"
+1. Go to `AI` → `AI Workforce` → `Voice Receptionist` → `Configure`
+2. In Capabilities, click `Add new capability`
+3. Select `Transfer call`
 4. Add one or more destination numbers and define criteria (e.g., sales vs. support, business hours)
 
 ![Transfer Call capability](../img/voice-receptionist-transfer.png)
@@ -183,7 +184,7 @@ Best practices:
 Once a call is transferred, recording ends and the system does not record or transcribe the destination leg. If the destination doesn't answer, the transfer is not reverted; the caller would need to call again to speak with the AI.
 :::
 
-### Step 3: Add Knowledge Sources to your AI Voice Receptionist
+### Step 3: Add knowledge sources to your AI Voice Receptionist
 
 The `Knowledge sources` panel lets you choose which information your AI Voice Receptionist can reference when answering calls. When your Voice Receptionist does not immediately have an answer to a caller's question, they will let the caller know they are taking a moment to look up information. If the Receptionist doesn't find the answer, they will let the caller know they don't have the information and offer to take a message and have someone call them back.
 
@@ -200,13 +201,13 @@ For more details on knowledge sources and adding them to the Knowledge Base, see
 :::
 ---
 
-## Test and Monitor Your AI Voice Receptionist
+## Test and monitor your AI Voice Receptionist
 
 Once your AI Voice Receptionist is set up, it's important to test how it handles real calls and monitor its performance over time. This helps you ensure the AI is providing accurate answers, capturing leads, and delivering a professional experience to your callers. Regular testing and review will also help you spot opportunities to improve your AI's responses as your business grows.
 
-### Testing and Reviewing the AI Voice Receptionist's Responses
+### Testing and reviewing the AI Voice Receptionist's responses
 
-Click the `Try it` button on your AI Voice Receptionist's card from <AISparkleIcon /> `AI > AI Workforce` to quickly see the phone number assigned to your AI Voice Receptionist.
+Click the `Try it` button on your AI Voice Receptionist's card from <AISparkleIcon /> `AI` → `AI Workforce` to quickly see the phone number assigned to your AI Voice Receptionist.
 
 Before going live with your AI Voice Receptionist, you should test their responses to make sure they are performing how you would like when:
 - Greeting callers 
@@ -215,7 +216,7 @@ Before going live with your AI Voice Receptionist, you should test their respons
 - Offering to take a message and have someone call the caller back if they don't have an answer
 - Offering to book an appointment with your calendar
 
-### Monitor and Improve the AI Voice Receptionist
+### Monitor and improve the AI Voice Receptionist
 
 You can review call recordings and transcripts of the conversations your AI Voice Receptionist has with callers by going to the `Conversations` tab in your Business App. 
 
@@ -236,11 +237,12 @@ If the AI Voice Receptionist is unable to capture a caller's contact information
 
 Before getting started, make sure you have:
 - **AI Voice Receptionist access** through an eligible edition (see [AI Workforce Overview](./index.mdx) for edition and region availability)
-- **Conversations AI phone number** assigned after activating Pro or Premium (found in Administration > Conversations Settings)
+- **Conversations AI phone number** assigned after activating Pro or Premium (found under `Administration` → `Conversations Settings`)
 - **Basic business information** added to your knowledge base
-- *(Optional)* **Calendar connection** for appointment booking (set up in CRM > My Meetings > Settings)
+- *(Optional)* **Calendar connection** for appointment booking (set up under `CRM` → `My Meetings` → `Settings`)
 
 Your AI Voice Receptionist will work with minimal setup, but having these prerequisites ensures the best experience for your callers.
+
 </details>
 
 <details>
@@ -252,6 +254,7 @@ There are two main ways to route calls to your AI Voice Receptionist:
 2. **Forward calls from your business line** - Set up call forwarding from your existing business number to your Conversations number so customers can keep calling your familiar number
 
 For detailed call forwarding setup instructions, see [Conversations Phone Call Setup](/business-app/conversations/).
+
 </details>
 
 <details>
@@ -260,9 +263,10 @@ For detailed call forwarding setup instructions, see [Conversations Phone Call S
 Yes! You can set up call forwarding from your existing business number to your assigned Conversations phone number. This allows customers to keep calling your familiar business line while having your AI Voice Receptionist handle the calls. 
 
 Most mobile carriers support simple star-codes for call forwarding. Check your [Conversations Settings](/administration/platform-settings/conversations-settings/) for carrier-specific activation codes and step-by-step instructions.
+
 </details>
 
-### Configuration and Customization
+### Configuration and customization
 
 <details>
 <summary>How do I choose the best voice for my business?</summary>
@@ -270,19 +274,21 @@ Most mobile carriers support simple star-codes for call forwarding. Check your [
 Each voice family and voice have different strengths like response speed, expressiveness, and multi-lingual capabilities. To choose the best voice:
 
 1. Go to your AI Voice Receptionist configuration
-2. Under the Profile > Speech tab, browse the available voice families and voices
+2. Under the `Profile` → `Speech` tab, browse the available voice families and voices
 3. Preview different voices by selecting them and clicking the play button
 4. Choose the voice that best matches your brand and provides the clarity your callers need
 
 While you'll see a "Recommended" voice for your business, you can select any voice that fits your preferences.
+
 </details>
 
 <details>
 <summary>Can the AI answer calls in different languages?</summary>
 
-Yes! Your AI Voice Receptionist can detect and respond in multiple languages. To prioritize a specific language, add instructions in the "Additional Instructions" capability section of your configuration.
+Yes! Your AI Voice Receptionist can detect and respond in multiple languages. To prioritize a specific language, add instructions in the `Additional Instructions` capability section of your configuration.
 
 **Important:** Different voices have varying language capabilities. When selecting your voice, pay attention to the suggested language capabilities to ensure optimal performance in your preferred languages.
+
 </details>
 
 <details>
@@ -293,11 +299,12 @@ Your AI Voice Receptionist learns about your business through Knowledge Sources.
 - **Basic business information** you provide (hours, services, contact info)
 
 To add more detailed information:
-1. Go to the Knowledge Sources panel in your AI configuration
-2. Click "Add knowledge" to add text, website pages, or file uploads
+1. Go to the `Knowledge sources` panel in your AI configuration
+2. Click `Add knowledge` to add text, website pages, or file uploads
 3. Organize information by topic for better AI understanding
 
 For more details, see the [Knowledge Base Overview](../knowledge-base/index.md).
+
 </details>
 
 <details>
@@ -306,9 +313,10 @@ For more details, see the [Knowledge Base Overview](../knowledge-base/index.md).
 Absolutely! You can extend your AI Voice Receptionist's capabilities by creating custom tools and integrations specific to your business needs. This allows your AI to perform tasks like checking inventory, scheduling specific services, or connecting with other software you use.
 
 For detailed guidance on creating custom capabilities, see [Creating Custom Capabilities](../ai-capabilities/creating-custom-capabilities).
+
 </details>
 
-### Operations and Performance
+### Operations and performance
 
 <details>
 <summary>What happens if the AI can't answer a caller's question?</summary>
@@ -321,6 +329,7 @@ When your AI Voice Receptionist doesn't have the information needed to answer a 
 5. Capture the caller's contact details for follow-up
 
 This ensures no lead is lost even when the AI reaches its knowledge limits.
+
 </details>
 
 <details>
@@ -328,23 +337,25 @@ This ensures no lead is lost even when the AI reaches its knowledge limits.
 
 You can track your AI Voice Receptionist's performance by:
 
-1. **Reviewing call recordings and transcripts** in your Conversations tab
+1. **Reviewing call recordings and transcripts** in your `Conversations` tab
 2. **Checking lead capture success** in your CRM
-3. **Testing regularly** using the "Try it" button on your AI's configuration card
+3. **Testing regularly** using the `Try it` button on your AI's configuration card
 4. **Updating knowledge sources** based on common questions you notice
 5. **Adjusting capabilities and instructions** as needed
 
 Regular monitoring helps you identify opportunities to improve responses and ensure your AI is representing your business well.
+
 </details>
 
 <details>
 <summary>Where do call recordings and transcripts go?</summary>
 
 All call recordings, transcripts, and summaries are automatically saved to:
-- **Conversations tab** for message history and follow-up
+- `Conversations` tab for message history and follow-up
 - **CRM** for lead tracking and contact management
 
 This allows your team to review interactions, follow up with callers, and maintain a complete record of customer communications. Note that call recordings and transcripts are available with Premium Conversations AI.
+
 </details>
 
 ### Configuration
@@ -352,28 +363,30 @@ This allows your team to review interactions, follow up with callers, and mainta
 <details>
 <summary>Can I change the Interruption Threshold (Voice Activity Detection)?</summary>
 
-The **Interruption Threshold** controls how sensitive the AI is to detecting that a caller has started speaking (voice activity detection). It is set on a scale of **0.6 – 0.75**, with a default of **0.75**.
+The `Interruption Threshold` controls how sensitive the AI is to detecting that a caller has started speaking (voice activity detection). It is set on a scale of **0.6 – 0.75**, with a default of **0.75**.
 
-- **Higher value (0.75)** — the AI waits longer before treating speech as an interruption. Use when callers are in noisy environments or when the AI is cutting off too early.
-- **Lower value (0.6)** — the AI responds more quickly to detected speech. Use when callers feel the AI is not picking up on their words fast enough.
+- **Higher value (0.75):** the AI waits longer before treating speech as an interruption. Use when callers are in noisy environments or when the AI is cutting off too early.
+- **Lower value (0.6):** the AI responds more quickly to detected speech. Use when callers feel the AI is not picking up on their words fast enough.
 
 Adjust this setting in your AI Voice Receptionist configuration if callers report being cut off or if the AI is slow to acknowledge them.
+
 </details>
 
 <details>
 <summary>How do I configure Missed Call Text-Back?</summary>
 
-Missed Call Text-Back sends an SMS to a caller when their call is not answered. To configure it:
+`Missed Call Text-Back` sends an SMS to a caller when their call is not answered. To configure it:
 
-1. Go to **AI > AI Workforce > Voice Receptionist > Configure**
-2. Find the **Missed Call Text-Back** toggle and enable it
+1. Go to `AI` → `AI Workforce` → `Voice Receptionist` → `Configure`
+2. Find the `Missed Call Text-Back` toggle and enable it
 3. Choose the timing option:
-   - **Immediately** — sends the text as soon as the call is not answered by a human
-   - **If the forwarded call is missed** — sends the text only if the forwarded-to number also doesn't answer
+   - `Immediately`: sends the text as soon as the call is not answered by a human
+   - `If the forwarded call is missed`: sends the text only if the forwarded-to number also doesn't answer
 
 :::note
-If the forwarded call rings through to voicemail and the voicemail system picks up, the carrier considers the call "connected" — even if no human answered. In this case, the "If the forwarded call is missed" option will not trigger. Use **Immediately** if you want to ensure the text always goes out.
+If the forwarded call rings through to voicemail and the voicemail system picks up, the carrier considers the call "connected," even if no human answered. In this case, the `If the forwarded call is missed` option will not trigger. Use `Immediately` if you want to ensure the text always goes out.
 :::
+
 </details>
 
 ### Troubleshooting
@@ -384,35 +397,39 @@ If the forwarded call rings through to voicemail and the voicemail system picks 
 If your AI Voice Receptionist isn't answering calls, verify:
 
 1. **Subscription level** - AI Voice Receptionist requires Premium Conversations AI
-2. **Phone number assignment** - Confirm your Conversations number is active (Administration > Conversations Settings)
-3. **AI configuration** - Ensure your Voice Receptionist is configured and the "Phone call: Answer with Voice AI" setting is enabled
+2. **Phone number assignment** - Confirm your Conversations number is active (`Administration` → `Conversations Settings`)
+3. **AI configuration** - Ensure your Voice Receptionist is configured and the `Phone call: Answer with Voice AI` setting is enabled
 4. **Call routing** - Check that calls are being routed to your Conversations number (not another destination)
 
 For additional troubleshooting, see [Conversations Phone Call Setup](/business-app/conversations/).
+
 </details>
 
 <details>
 <summary>Can the AI book meetings on my calendar?</summary>
 
-Yes. Connect your calendar in <CRMIcon /> `CRM` > `My Meetings` > `Settings` > `Defaults` > `Connect Calendar`. Then enable the **Book appointments with calendar** capability in your AI configuration. If your booking link uses Microsoft Teams or Google Meet, meeting links are included automatically. See [My Meetings](/crm/my-meetings) for details.
+Yes. Connect your calendar in <CRMIcon /> `CRM` → `My Meetings` → `Settings` → `Defaults` → `Connect Calendar`. Then enable the `Book appointments with calendar` capability in your AI configuration. If your booking link uses Microsoft Teams or Google Meet, meeting links are included automatically. See [My Meetings](/crm/my-meetings) for details.
+
 </details>
 
 <details>
 <summary>Can I change my AI's knowledge or instructions after setup?</summary>
 
 Yes! You can update your AI Voice Receptionist anytime by:
-- **Adding or removing knowledge sources** in the Knowledge Sources panel
+- **Adding or removing knowledge sources** in the `Knowledge sources` panel
 - **Modifying capabilities** like appointment booking or lead capture settings
 - **Updating additional instructions** to refine tone and behavior
-- **Changing voice settings** in the Profile > Speech section
+- **Changing voice settings** in the `Profile` → `Speech` section
 
 Changes take effect immediately, so you can continuously improve your AI's performance based on real-world interactions.
+
 </details>
 
 <details>
 <summary>Can the AI Voice Receptionist receive SMS verification codes or MFA texts?</summary>
 
 No. The Conversations AI phone number assigned to your AI Voice Receptionist is not able to receive SMS verification codes or multi-factor authentication (MFA) texts. If you need to verify an account or receive a one-time code, use a personal mobile number or a separate business phone number for that purpose.
+
 </details>
 
 <details>
@@ -424,4 +441,5 @@ AI Voice Receptionist is currently available for businesses located in the **Uni
 - Phone number assignment through Conversations
 
 For the most up-to-date region availability, see the [AI Workforce Overview](./index.mdx).
+
 </details>

--- a/docusaurus/docs/ai/ai-workforce/custom-ai-employees.md
+++ b/docusaurus/docs/ai/ai-workforce/custom-ai-employees.md
@@ -1,6 +1,7 @@
 ---
 title: Creating Custom AI Employees
 sidebar_label: Custom AI Employees
+sidebar_position: 7
 description: Learn how to create specialized AI employees tailored to specific business functions like job estimation, project management, sales enablement, and payment coordination.
 tags: [ai-workforce, custom-capabilities, ai-employees]
 keywords: [custom AI employees, AI workforce, capabilities, tools, deployment, web chat]
@@ -27,15 +28,15 @@ Custom AI Employees are AI workers you create from scratch to handle specialized
 To create a Custom AI Employee in Partner Center, your account must be on a Professional plan or higher, as well as equivalent legacy subscriptions.
 :::
 
-## Step-by-Step: Creating a Custom AI Employee
+## Step-by-step: creating a Custom AI Employee
 
-### Step 1: Navigate to AI Workforce
+### Step 1: navigate to AI Workforce
 
-1. Navigate to **AI** > **AI Workforce**
-2. Click **Create**
+1. Navigate to `AI` → `AI Workforce`
+2. Click `Create`
 3. You'll see the configuration interface for your new Custom AI Employee
 
-### Step 2: Configure Profile
+### Step 2: configure profile
 
 Set up the basic identity and behavior of your Custom AI Employee:
 
@@ -72,13 +73,13 @@ Use bullets or numbered lists to make instructions clear. Be specific about what
 
 For more guidance on writing effective instructions, see the [AI Workforce Overview](./index.mdx#profile) section on Profile configuration.
 
-### Step 3: Set Up Channels
+### Step 3: set up channels
 
 Choose where your Custom AI Employee will work:
 
 **Available Channels:**
 
-- **Website chat**: Deploy on one or multiple website chat widgets. Custom AI Employees on Web Chat receive the visitor's current page URL with every message — see [Make responses page-aware with the visitor's URL](./ai-chat-receptionist/index.md#make-responses-page-aware-with-the-visitors-url) for how to tune prompts to use it.
+- **Website chat**: Deploy on one or multiple website chat widgets. Custom AI Employees on Web Chat receive the visitor's current page URL with every message. See [Make responses page-aware with the visitor's URL](./ai-chat-receptionist/index.md#make-responses-page-aware-with-the-visitors-url) for how to tune prompts to use it.
 - **In-platform chat**: Chat directly in Partner Center (automatically available after creation)
 
 
@@ -88,7 +89,7 @@ You do *not* need to assign an AI Employee to in-platform chat; the Chat button 
 
 For detailed information on channels, see the [AI Workforce Overview](./index.mdx#channels) section.
 
-### Step 4: Add Knowledge Sources
+### Step 4: add knowledge sources
 
 Teach your Custom AI Employee about your business:
 
@@ -109,7 +110,7 @@ Teach your Custom AI Employee about your business:
 
 For comprehensive guidance on knowledge sources, see the [Knowledge Base documentation](../knowledge-base/).
 
-### Step 5: Configure Capabilities
+### Step 5: configure capabilities
 
 Define what your Custom AI Employee can do:
 
@@ -127,7 +128,7 @@ Define what your Custom AI Employee can do:
 
 For detailed information on creating custom capabilities, see [Creating Custom Capabilities](../ai-capabilities/creating-custom-capabilities.md).
 
-### Step 6: Deploy Your Custom AI Employee
+### Step 6: deploy your Custom AI Employee
 
 Once tested, deploy your Custom AI Employee:
 
@@ -140,10 +141,10 @@ Once tested, deploy your Custom AI Employee:
 
 Assign your Custom AI Employee to a web chat widget so it handles conversations with website visitors:
 
-1. Go to **Conversations** → **Settings**, then click **Manage widgets** on the **Web Chat** card.
-2. On the **Web Chat configuration** page, click **New Web Chat** (or open an existing widget to edit it).
-3. In the **AI employee** card, click **Select employee**, choose your Custom AI Employee, and click **Ok**.
-4. Click **Next** to save, then install the widget on your site.
+1. Go to `Conversations` → `Settings`, then click `Manage widgets` on the `Web Chat` card.
+2. On the `Web Chat configuration` page, click `New Web Chat` (or open an existing widget to edit it).
+3. In the `AI employee` card, click `Select employee`, choose your Custom AI Employee, and click `Ok`.
+4. Click `Next` to save, then install the widget on your site.
 
 Requires Conversations AI Standard, Pro, or Premium. See [Web Chat Setup](../../conversations/ai-assisted-web-chat-widget.mdx) for details.
 
@@ -153,7 +154,7 @@ Requires Conversations AI Standard, Pro, or Premium. See [Web Chat Setup](../../
 - Use Custom AI Employees for decision-making in automated processes
 - See [Advanced Automation Features](../../automations/my-automations/advanced-automation-features.mdx) for details
 
-## Use Case Examples
+## Use case examples
 
 Explore these examples to see how Custom AI Employees can be tailored for specific business functions:
 
@@ -211,9 +212,9 @@ Keep customers and your team members informed by sending regular updates based o
 </TabItem>
 </Tabs>
 
-## Deployment Options
+## Deployment options
 
-### In-Platform Chat
+### In-platform chat
 
 Your Custom AI Employee is automatically available in the AI Workforce tab after creation. Team members can chat directly with the AI Employee for internal assistance and decision support.
 
@@ -225,7 +226,7 @@ Your Custom AI Employee is automatically available in the AI Workforce tab after
 
 ### Web Chat
 
-Assign your Custom AI Employee to a web chat widget to provide specialized chat experiences for website visitors. Go to **Conversations** → **Settings** → **Manage widgets**, open a widget, then use **Select employee** in the **AI employee** card to assign it. A widget uses one AI employee at a time, but the same employee can be assigned to multiple widgets.
+Assign your Custom AI Employee to a web chat widget to provide specialized chat experiences for website visitors. Go to `Conversations` → `Settings` → `Manage widgets`, open a widget, then use `Select employee` in the `AI employee` card to assign it. A widget uses one AI employee at a time, but the same employee can be assigned to multiple widgets.
 
 **Benefits:**
 
@@ -253,7 +254,7 @@ Add Custom AI Employees to automation workflows using the "Send a prompt to an A
 
 For details on automation integration, see [Advanced Automation Features](../../automations/my-automations/advanced-automation-features.mdx).
 
-## Framework Consistency
+## Framework consistency
 
 Custom AI Employees use the same framework as pre-built AI Employees. All AI Employees share:
 

--- a/docusaurus/docs/ai/ai-workforce/index.mdx
+++ b/docusaurus/docs/ai/ai-workforce/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: AI Workforce Overview
-description: Overview of AI Employees — configure AI Workforce, capabilities, tools, and channels to automate conversations, capture leads, and handle customer interactions.
+description: Overview of AI Employees: configure AI Workforce, capabilities, tools, and channels to automate conversations, capture leads, and handle customer interactions.
 tags: [ai-workforce, ai, ai-employees, capabilities]
 keywords: [AI workforce, AI employees, capabilities, tools, lead capture, web chat, automations]
 ---
@@ -21,17 +21,17 @@ See these guides for step-by-step setup or details on specific AI Employees:
 
 ## Social Media Manager defaults
 
-For newly activated **Social Media Manager** AI employees, **Social Calendar Generation** starts with these defaults:
+For newly activated **Social Media Manager** AI employees, `Social Calendar Generation` starts with these defaults:
 
-- **AI model:** **Gemini Flash Latest** (recommended)
-- **Trigger type:** **On a Schedule**
-- **Schedule defaults:**
-  - **Frequency:** Weekly
-  - **Day:** Monday
-  - **Time:** 9:00 AM
-  - **Timezone:** Uses the business timezone from Business App settings
-  - **Start date:** Current date
-  - **End date:** No end date
+- `AI model`: `Gemini Flash Latest` (recommended)
+- `Trigger type`: `On a Schedule`
+- `Schedule defaults`:
+  - `Frequency`: Weekly
+  - `Day`: Monday
+  - `Time`: 9:00 AM
+  - `Timezone`: Uses the business timezone from Business App settings
+  - `Start date`: Current date
+  - `End date`: No end date
 - Available in web and mobile
 
 For more detail on setup:
@@ -45,17 +45,17 @@ If you're just getting started, review the sections below for an overview of the
 
 ## AI Employee elements
 
-AI Employees all share a similar structure—no matter what role they play in your business. This applies to pre-built AI Employees (eg. Chat Receptionist, Voice Receptionist) and Custom AI Employees you create. Each one comes with common parts you can review and configure, such as their name, purpose, communication channels, capabilities, and what knowledge they use to answer questions. 
+AI Employees all share a similar structure, no matter what role they play in your business. This applies to pre-built AI Employees (eg. Chat Receptionist, Voice Receptionist) and Custom AI Employees you create. Each one comes with common parts you can review and configure, such as their name, purpose, communication channels, capabilities, and what knowledge they use to answer questions. 
 
 ### Profile
 
-The **Profile** section is where you set the basics for your AI Employee—how they appear to your team and how they introduce themselves to customers.
+The `Profile` section is where you set the basics for your AI Employee: how they appear to your team and how they introduce themselves to customers.
 
-- **Name & Avatar:**  
+- `Name & Avatar`:  
   **What this is:** The display name and image used for your AI Employee across your channels.  
   **What to do:** Choose a friendly, memorable name and a profile image (like your logo or a custom avatar) that fits the role or your brand. This helps customers and your team instantly recognize who they're interacting with.
 
-- **Purpose:**  
+- `Purpose`:  
   **What this is:** The job description and behavioral "guidelines" for your AI Employee. This sets the tone, goals, and important instructions for every conversation.  
   **What to do:** Write a clear, short summary of what your AI Employee should do. Be specific about their tone, greeting, and key tasks.
 
@@ -77,9 +77,9 @@ Use bullets or numbered lists to make instructions clear and scannable. Be speci
 
 ### Channels
 
-The **Channels** section lets you choose where your AI Employee will work for you.
+The `Channels` section lets you choose where your AI Employee will work for you.
 
-**What this is:** Channels are the different places or platforms where your AI Employee can interact with your customers—like website chat, SMS, phone calls, or even Google Meet.
+**What this is:** Channels are the different places or platforms where your AI Employee can interact with your customers, like website chat, SMS, phone calls, or even Google Meet.
 
 **What to do:**  
 Review the available channels for your AI Employee's role. Turn on only the channels that make sense for your business right now. For example, you might want your AI to respond on your website's chat widget, via text messages, or answer phone calls.
@@ -101,10 +101,10 @@ Some channels require specific products to unlock. For example, assigning a Cust
 
 ### Capabilities
 
-The **Capabilities** section is where you decide what your AI Employee can actually do for your business.
+The `Capabilities` section is where you decide what your AI Employee can actually do for your business.
 
 **What this is:**  
-Capabilities are like "skills" or "tasks" you can turn on or off, depending on the role of your AI Employee. Each capability tells your AI which actions it should take or what outcomes to prioritize—such as capturing leads, booking appointments, answering FAQs, or performing a role-specific function.
+Capabilities are like "skills" or "tasks" you can turn on or off, depending on the role of your AI Employee. Each capability tells your AI which actions it should take or what outcomes to prioritize, such as capturing leads, booking appointments, answering FAQs, or performing a role-specific function.
 
 **What to do:**  
 Review the available capabilities for your chosen AI Employee.
@@ -133,7 +133,7 @@ You can experiment with different capabilities to see what works best, and updat
 
 ### Tools
 
-The **Tools** section enables your AI Employee to interact with external systems and retrieve real-time information during conversations.
+The `Tools` section enables your AI Employee to interact with external systems and retrieve real-time information during conversations.
 
 **What this is:**  
 Tools are connections to APIs (external software systems) that your AI Employee can use to perform actions or retrieve information that goes beyond their built-in knowledge. For example, tools can check weather forecasts, look up inventory, create records in your CRM, or verify appointment availability in real-time.
@@ -164,10 +164,10 @@ Most standard business needs (like appointment booking or lead capture) are hand
 
 ### Knowledge sources
 
-The **Knowledge Sources** section is where you teach your AI Employee about your business, so it can give accurate, up-to-date answers to customers.
+The `Knowledge Sources` section is where you teach your AI Employee about your business, so it can give accurate, up-to-date answers to customers.
 
 **What this is:**  
-Knowledge sources are collections of business information your AI can refer to during conversations—such as website pages, FAQs, or uploaded documents. The AI uses this info only when it needs to answer a relevant question.
+Knowledge sources are collections of business information your AI can refer to during conversations, such as website pages, FAQs, or uploaded documents. The AI uses this info only when it needs to answer a relevant question.
 
 **What to do:**  
 Add any information that would help your AI answer questions or provide better service:
@@ -201,13 +201,13 @@ There's no separate menu for per-channel behavior. Instead, you write **channel-
 **What to do:**  
 Add channel-specific instructions in either (or both) of these places:
 
-- **The Purpose field** (labeled `Role` on the Chat and Voice Receptionists) — best for behavior that should apply across everything the employee does, such as tone, greeting style, or reply length per channel.
-- **A capability's instructions** — best for shaping a single task, such as how much information to collect for lead capture on SMS versus email.
+- The `Purpose` field (labeled `Role` on the Chat and Voice Receptionists): best for behavior that should apply across everything the employee does, such as tone, greeting style, or reply length per channel.
+- A capability's instructions: best for shaping a single task, such as how much information to collect for lead capture on SMS versus email.
 
 Reference the channel by name in your instructions and describe how you want the AI to behave there. For example, add lines like these to your Purpose field or a capability's instructions:
 
 ```text wrap
-When responding on SMS, keep replies short and conversational. Use plain text only — no bullet points, headings, or markdown, since text messages display them as raw symbols. Aim for one or two sentences.
+When responding on SMS, keep replies short and conversational. Use plain text only (no bullet points, headings, or markdown), since text messages display them as raw symbols. Aim for one or two sentences.
 
 When responding by email, you can write longer, more detailed replies. Open with a professional greeting and sign off with the business name.
 
@@ -219,7 +219,7 @@ Only add channel-specific instructions for the channels where the default behavi
 :::
 
 :::info Instructions shape communication, not actions
-These instructions change *how* your AI Employee communicates on each channel. They don't change *which* actions it can take — those come from its capabilities and tools. See the [AI Capabilities Overview](../ai-capabilities/).
+These instructions change *how* your AI Employee communicates on each channel. They don't change *which* actions it can take: those come from its capabilities and tools. See the [AI Capabilities Overview](../ai-capabilities/).
 :::
 
 ---
@@ -249,7 +249,7 @@ After initial setup, regularly test and optimize your AI Employees to ensure the
 - Identify common customer questions that need better responses
 
 **Use AI Explanations**
-- Click "Explanation" on any AI response to see:
+- Click `Explanation` on any AI response to see:
   - The reasoning behind the AI's decisions
   - Which knowledge sources were used
   - What tools were called and their API responses
@@ -264,10 +264,10 @@ After initial setup, regularly test and optimize your AI Employees to ensure the
 - Tone or behavior that doesn't match expectations
 
 **2. Determine the Root Cause**
-- **Purpose issue**: Adjust if it affects overall behavior across all conversations
-- **Capability issue**: Refine when specific actions aren't working correctly
-- **Knowledge issue**: Update when facts are missing or incorrect
-- **Tool issue**: Fix when API calls fail or return wrong data
+- `Purpose` issue: Adjust if it affects overall behavior across all conversations
+- `Capability` issue: Refine when specific actions aren't working correctly
+- `Knowledge` issue: Update when facts are missing or incorrect
+- `Tool` issue: Fix when API calls fail or return wrong data
 
 **3. Make Focused Changes**
 - Change only one thing at a time
@@ -283,13 +283,13 @@ After initial setup, regularly test and optimize your AI Employees to ensure the
 - Test after every configuration change
 - Monitor live conversations regularly (weekly is a good starting point)
 - Keep notes on what works and what doesn't
-- Be patient—optimizing AI Employees is an iterative process that improves over time
+- Be patient. Optimizing AI Employees is an iterative process that improves over time
 :::
 
 <div style={{display: 'flex', alignItems: 'center', gap: '12px', background: 'rgba(60, 154, 99, 0.08)', border: '1px solid rgba(60, 154, 99, 0.35)', borderRadius: '8px', padding: '14px 18px', margin: '16px 0'}}>
   <span style={{flexShrink: 0}}><GraduationCapIcon size={26} /></span>
   <span style={{fontSize: '14px', color: 'var(--ifm-font-color-base)'}}>
-    New to how AI Employees work? Take the <a href="/learn/ai-foundations" style={{color: '#3C9A63', fontWeight: 600}}>AI foundations</a> course in Vendasta Learn — Beginner, 6 lessons.
+    New to how AI Employees work? Take the <a href="/learn/ai-foundations" style={{color: '#3C9A63', fontWeight: 600}}>AI foundations</a> course in Vendasta Learn (Beginner, 6 lessons).
   </span>
 </div>
 

--- a/docusaurus/docs/ai/ai-workforce/social-media-manager.mdx
+++ b/docusaurus/docs/ai/ai-workforce/social-media-manager.mdx
@@ -1,7 +1,7 @@
 ---
 title: Social Media Manager
 sidebar_label: Social Media Manager
-sidebar_position: 4
+sidebar_position: 5
 description: Configure the Social Media Manager AI employee to generate social calendars with recommended model and weekly schedule defaults.
 tags: [ai-workforce, social-media-manager, social-calendar-generation]
 keywords: [Social Media Manager, Social Calendar Generation, AI workforce, weekly schedule, Gemini Flash Latest]
@@ -13,27 +13,27 @@ The **Social Media Manager** is an AI employee that helps you generate a social 
 
 ## Default configuration
 
-When you activate the Social Media Manager, **Social Calendar Generation** is preconfigured with these defaults:
+When you activate the Social Media Manager, `Social Calendar Generation` is preconfigured with these defaults:
 
-- **AI model:** **Gemini Flash Latest** (recommended)
-- **Schedule type:** **On a Schedule**
-- **Frequency:** **Weekly**
-- **Day of the week:** **Monday**
-- **Time:** **9:00 AM**
-- **Timezone:** Uses the SMB timezone configured in Business App
-- **Start date:** Current date
-- **End date:** **No end date**
+- `AI model`: `Gemini Flash Latest` (recommended)
+- `Schedule type`: `On a Schedule`
+- `Frequency`: `Weekly`
+- `Day of the week`: `Monday`
+- `Time`: `9:00 AM`
+- `Timezone`: Uses the SMB timezone configured in Business App
+- `Start date`: Current date
+- `End date`: `No end date`
 
 ## Where to configure it
 
-1. Go to **AI** and open **AI Workforce**.
-2. Select **Social Media Manager**.
-3. Open **Social Calendar Generation** to review or adjust the default model and schedule settings.
+1. Go to `AI` and open `AI Workforce`.
+2. Select `Social Media Manager`.
+3. Open `Social Calendar Generation` to review or adjust the default model and schedule settings.
 
 ## Web and mobile behavior
 
 The same Social Calendar Generation defaults are used in web and mobile.
 
-## Tip
-
+:::tip
 Review these settings before activating automations to confirm the model and schedule align with your publishing workflow.
+:::

--- a/docusaurus/docs/ai/ai-workforce/upgrading-ai-employees.mdx
+++ b/docusaurus/docs/ai/ai-workforce/upgrading-ai-employees.mdx
@@ -1,50 +1,48 @@
 ---
 id: upgrading-ai-employees
 title: Upgrading AI Employees
-sidebar_position: 2
+sidebar_position: 8
 description: How locked AI Employee cards in Business App let customers upgrade themselves, how marketplace gating decides which cards appear, and how to configure the upgrade experience in Partner Center.
 tags: [ai, ai-workforce, ai-employees, upgrade, editions, marketplace]
 keywords: [AI workforce upgrade, self-serve upgrade, edition change, upgrade CTA, marketplace gating, AI employees]
 ---
-
-# Upgrading AI Employees
 
 The **AI Workforce** page in Business App shows your customer every AI Employee available to them. Some of those employees are already active; others are locked because the product or edition that powers them isn't part of the customer's current plan.
 
 Locked AI Employees offer a **self-serve upgrade** path: a locked card can open an in-app upgrade window that takes the customer straight to checkout for the product that unlocks the employee. This page explains what your customers see, how the platform decides which locked cards to show, and how you control the experience from Partner Center.
 
 :::info Where this appears
-This experience lives on the **AI Workforce** page in **Business App** (the page your customers use), not in Partner Center. You configure the behavior from Partner Center — see [Configure the upgrade experience](#configure-the-upgrade-experience-in-partner-center) below.
+This experience lives on the **AI Workforce** page in **Business App** (the page your customers use), not in Partner Center. You configure the behavior from Partner Center. See [Configure the upgrade experience](#configure-the-upgrade-experience-in-partner-center) below.
 :::
 
 ## What your customer sees
 
 On the AI Workforce page, each AI Employee is shown as a card. A card falls into one of these states:
 
-- **Active** — the employee is set up and running. Always shown.
-- **Locked with self-serve upgrade** — the customer doesn't own the product yet, but you sell it in their market. The card shows a clickable **Upgrade to gain access** chip that opens the upgrade window.
-- **Locked, no self-serve** — the same locked card, but the upgrade window is turned off (for example, the product is sold through your sales team). The card keeps a non-clickable **Upgrade to gain access** badge so the employee still reads as unavailable.
-- **Coming soon** — the employee shows a **Coming soon** badge and can't be enabled yet.
+- **Active**: the employee is set up and running. Always shown.
+- **Locked with self-serve upgrade**: the customer doesn't own the product yet, but you sell it in their market. The card shows a clickable `Upgrade to gain access` chip that opens the upgrade window.
+- **Locked, no self-serve**: the same locked card, but the upgrade window is turned off (for example, the product is sold through your sales team). The card keeps a non-clickable `Upgrade to gain access` badge so the employee still reads as unavailable.
+- **Coming soon**: the employee shows a `Coming soon` badge and can't be enabled yet.
 
-The label text is the same whether the chip is clickable or not — the difference is what happens on click.
+The label text is the same whether the chip is clickable or not. The difference is what happens on click.
 
 <img src={require('./img/ai-workforce-locked-cards.png').default} alt="The AI Workforce page in Business App with an active Chat Receptionist card and several locked cards showing Upgrade to gain access" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
 
 ## How the self-serve upgrade flow works
 
-When a customer clicks **Upgrade to gain access** on a locked card:
+When a customer clicks `Upgrade to gain access` on a locked card:
 
 1. An upgrade window opens for the product that powers that employee.
 2. The window shows the product's sellable editions (or packages), each with its name, price and billing frequency, and key selling points.
 3. The customer's current edition, if they already own a lower one, is labeled rather than offered for purchase.
-4. The customer selects an edition and clicks **Upgrade**.
+4. The customer selects an edition and clicks `Upgrade`.
 5. The platform creates an order and follows the flow you've configured for that product: if you have Vendasta Payments enabled, payment is collected during the upgrade; if you don't, an order is submitted for you to process.
 
 Because the whole flow runs inside Business App, upgrades follow the same order, billing, and pricing rules as any other product purchase.
 
 <img src={require('./img/upgrade-modal-local-seo.png').default} alt="The in-app upgrade window for Local SEO, showing an edition with its price, selling points, and an Upgrade button" style={{width: '100%', maxWidth: '520px', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
 
-## Which AI Employees have an upgrade path
+## Which AI employees have an upgrade path
 
 Each locked AI Employee is powered by a specific product. If a customer clicks upgrade, this is the product they're steered toward:
 
@@ -57,7 +55,7 @@ Each locked AI Employee is powered by a specific product. If a customer clicks u
 | AI Sales Assistant | CRM AI |
 | AI Search Specialist | Local SEO / Listing Builder |
 
-The exact edition a customer is offered is the one you've set to unlock that employee — its name and price reflect your own product catalog (for example, the Local SEO window above offers the **Pro** edition).
+The exact edition a customer is offered is the one you've set to unlock that employee: its name and price reflect your own product catalog (for example, the Local SEO window above offers the **Pro** edition).
 
 A few employees have no upgrade path and behave differently when locked:
 
@@ -80,25 +78,25 @@ This means your **stop-selling** and market-availability decisions in the Market
 
 ## Configure the upgrade experience in Partner Center
 
-You control the upgrade behavior per product from its settings in the Marketplace. Go to **Partner Center → Marketplace → Products**, open a product, and find the **Upgrade** section on its settings page.
+You control the upgrade behavior per product from its settings in the Marketplace. Go to **Partner Center → Marketplace → Products**, open a product, and find the `Upgrade` section on its settings page.
 
 <img src={require('./img/partner-center-upgrade-settings.png').default} alt="The Upgrade section of a product's settings in Partner Center, showing the On toggle and the three upgrade options" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
 
 ### Turn the upgrade experience on or off
 
-The **Upgrade** toggle controls whether locked cards for this product are clickable. Leave it **On** (recommended) to give customers the self-serve upgrade chip. Turn it **Off** and the locked card keeps a non-clickable **Upgrade to gain access** badge instead — the employee still reads as unavailable, but customers can't upgrade themselves.
+The `Upgrade` toggle controls whether locked cards for this product are clickable. Leave it `On` (recommended) to give customers the self-serve upgrade chip. Turn it `Off` and the locked card keeps a non-clickable `Upgrade to gain access` badge instead: the employee still reads as unavailable, but customers can't upgrade themselves.
 
 ### Choose what happens when a customer clicks upgrade
 
-Under **What should happen when a user selects Upgrade?**, pick one:
+Under `What should happen when a user selects Upgrade?`, pick one:
 
-- **Self-serve upgrade** — creates an order and follows your configured checkout. If you have Vendasta Payments enabled, payment is collected during the upgrade; otherwise an order is submitted for you to process.
-- **Contact a salesperson** — opens a contact-sales window instead of a purchase flow, for products you don't sell self-serve.
-- **Upgrade with a custom package** — offers your custom upgrade package instead of the standard editions.
+- `Self-serve upgrade`: creates an order and follows your configured checkout. If you have Vendasta Payments enabled, payment is collected during the upgrade; otherwise an order is submitted for you to process.
+- `Contact a salesperson`: opens a contact-sales window instead of a purchase flow, for products you don't sell self-serve.
+- `Upgrade with a custom package`: offers your custom upgrade package instead of the standard editions.
 
 ### Customize the modal content
 
-Click **Customize modal content** to control how the upgrade window looks. You can set its title, image, selling points, and button text, and the window shows your **retail** price and billing frequency. Match the content to the upgrade option you chose above.
+Click `Customize modal content` to control how the upgrade window looks. You can set its title, image, selling points, and button text, and the window shows your **retail** price and billing frequency. Match the content to the upgrade option you chose above.
 
 {/* TODO: add screenshot of Partner Center → Marketplace → Manage products → [product] → Settings → Customize dialog. Anonymize partner/pricing data. */}
 


### PR DESCRIPTION
## Summary
- Reorders the AI Workforce sidebar so all AI employee pages are grouped together, followed by Custom AI Employees, then Upgrading AI Employees at the bottom.
- Converts real blockquotes (`>`) to Docusaurus callouts (`:::info`/`:::note`), replaces stray `>` used as UI nav-path separators with `→`, and removes em dashes throughout the folder.
- Sentence-cases Title Case headings (wording untouched, so no anchor links break).
- Converts bolded UI element names (buttons, tabs, field/capability names) to inline code, reserving bold for genuine emphasis.
- Adds missing frontmatter `description` fields and removes a stray duplicate H1 in `upgrading-ai-employees.mdx`.

## Flagged for review
- `ai-voice-receptionist.md`: "Book appointments — Voice" was rendered as `` `Book appointments: Voice` `` — please confirm this is the correct literal capability name before merging.
- `index.mdx` calls a Social Media Manager field `` `Trigger type` `` while `social-media-manager.mdx` calls it `` `Schedule type` `` — pre-existing content inconsistency, not introduced by this PR, flagging for a possible follow-up.

## Test plan
- [ ] Run `npm run start` in `docusaurus/` and spot-check the AI Workforce sidebar order and a few edited pages render correctly
- [ ] Confirm no broken anchors on pages that link into `index.mdx` or `ai-voice-receptionist.md` sections