### PR TITLE
fix: remove unquoted colon in AI Workforce index frontmatter

### DIFF
--- a/docusaurus/docs/ai/ai-workforce/index.mdx
+++ b/docusaurus/docs/ai/ai-workforce/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: AI Workforce Overview
-description: Overview of AI Employees: configure AI Workforce, capabilities, tools, and channels to automate conversations, capture leads, and handle customer interactions.
+description: Overview of AI Employees. Configure AI Workforce, capabilities, tools, and channels to automate conversations, capture leads, and handle customer interactions.
 tags: [ai-workforce, ai, ai-employees, capabilities]
 keywords: [AI workforce, AI employees, capabilities, tools, lead capture, web chat, automations]
 ---


### PR DESCRIPTION
## Summary
- Fixes the master build break introduced by #925: `docs/ai/ai-workforce/index.mdx`'s frontmatter `description` had an unquoted colon (`Overview of AI Employees: configure...`), which YAML front matter parsing chokes on ("incomplete explicit mapping pair").
- Reworded to avoid the colon entirely (`Overview of AI Employees. Configure...`) rather than just quoting the string.

## Verification
- Confirmed the frontmatter now parses via `gray-matter` (the same library Docusaurus uses).
- Ran `npm run build` locally: build now succeeds. Remaining broken-link/anchor warnings in the output are pre-existing and unrelated to this change or to #925.

Closes the Cloud Build failure from build `22033dd0-228e-45a4-b030-c4c271368efd`.