### PR TITLE
Add the partner Sales path ("How to sell") — 9 lessons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,6 @@ build/
 # Raw SME/partner call transcripts (see learn-revamp/transcripts/README.md)
 learn-revamp/transcripts/*
 !learn-revamp/transcripts/README.md
+
+# Internal lesson review drafts (working artifacts, not site content)
+docusaurus/training/*/_review/

--- a/docusaurus/training/sales/_category_.json
+++ b/docusaurus/training/sales/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "How to sell",
-  "position": 5,
+  "position": 10,
   "collapsed": true,
   "className": "hide-from-sidebar",
   "link": {

--- a/docusaurus/training/sales/_category_.json
+++ b/docusaurus/training/sales/_category_.json
@@ -1,0 +1,10 @@
+{
+  "label": "How to sell",
+  "position": 5,
+  "collapsed": true,
+  "className": "hide-from-sidebar",
+  "link": {
+    "type": "doc",
+    "id": "sales/index"
+  }
+}

--- a/docusaurus/training/sales/build-your-brand-and-your-day.mdx
+++ b/docusaurus/training/sales/build-your-brand-and-your-day.mdx
@@ -1,0 +1,272 @@
+---
+title: "Build your brand and run your sales day like a pro"
+sidebar_position: 9
+description: "The habits and positioning that make the other eight steps repeatable."
+sidebar_class_name: hide-from-sidebar
+---
+
+import KnowledgeCheck from "@site/src/components/KnowledgeCheck";
+import CourseProgressBar from "@site/src/components/CourseProgressBar";
+import SectionFeedback from "@site/src/components/SectionFeedback";
+import InlineHighlighter from "@site/src/components/InlineHighlighter";
+import MarkComplete from "@site/src/components/MarkComplete";
+import LessonHeader from "@site/src/components/LessonHeader";
+import LessonFooter from "@site/src/components/LessonFooter";
+import FlipCard, { FlipCardGrid } from "@site/src/components/FlipCard";
+
+<InlineHighlighter courseId="build-your-brand-and-your-day" site="vendasta_learn">
+
+<CourseProgressBar courseId="build-your-brand-and-your-day" site="vendasta_learn" />
+
+{/* VIDEO SLOT: "The Perfect Sales Day" (Master Sales Training Series, Wistia, keep-as-is verdict
+    — talking-head, no product UI). No embed ID recorded: proj-009 catalogued the Wistia library
+    by title and this clip is not in the 360Learning export that carries IDs. Look it up by title
+    in the vendasta-1 account. A near-duplicate cut exists as "Ep. 1: The Perfect Sales Day" —
+    the standalone cut is the one this lesson was drafted from.
+
+    The brand-building half (part 1) has no associated Wistia clip. It is sourced from the two
+    audited 360Learning courses, which may carry their own video inside the original course. */}
+
+<LessonHeader
+  difficulty="Intermediate"
+  time="about 18 minutes"
+  required={["Lessons 1–8 — this one closes the arc"]}
+  video={true}
+  pathName="How to sell"
+  step={9}
+  totalSteps={9}
+  outcomes={[
+    "Decide whether to niche down or stay broad, based on local versus global reach",
+    "Build an ideal-client profile that shapes your positioning, not just your pitch",
+    "Write copy that makes the client the hero, not your agency",
+    "Structure a day so avoided tasks and unmanaged accounts stop quietly costing you deals",
+    "Apply the 60/30/10 rule and the line-by-line test to your own book of business",
+  ]}
+/>
+
+Everything so far has been about one deal at a time. This lesson is about the two things that decide whether you can do it again next month and the month after: how you position yourself, and how you run your day.
+
+## Part 1 — Build your brand
+
+### Decide: local variety, or global niche
+
+Before you write a word of positioning, answer one question: are you building this locally or globally?
+
+**Local — keep variety.** Work one or two verticals with enough range that no two clients are direct competitors. A roofer and an HVAC company, not two roofers three blocks apart. You are building relationships with local business and community leaders, and that only works if nobody in the room feels like you are also selling to the person trying to take their customers.
+
+**Global — niche down.** If you are building funnels and selling online, a tight vertical (just dentists, just funeral homes, just med spas) lets you build specific messaging, hold yourself out as the expert for that one type of business, and offer real exclusivity by territory — because your clients are scattered nationally and never actually compete with each other.
+
+Same skill set either way. If you are a good marketer, you can market pretty much anything. The variable is reach, not talent.
+
+### Four steps to know who you are actually building for
+
+1. **List the qualities of your best clients** — not your average client, your best one. What makes them a joy to work with? They pay on time. They take your advice. They treat you like a partner, not a vendor.
+2. **Figure out what makes them tick.** Where do they spend their time and money, and what do they actually care about?
+3. **Decide what you want them to expect from you** — not what you assume they want, but what you are actually going to deliver. If you want a monthly standing call, say so and build toward it.
+4. **Name what has to change in your own operation** to deliver that. If you promised online booking and you do not have online booking yet, that is the gap to close before the promise is real.
+
+### Make the client the hero, not your agency
+
+The single most common brand mistake is writing your website as though your agency is the hero. "We've been in business 10 years. Our team of experts." Nobody's problem gets solved by your tenure.
+
+Flip it, using the structure behind every story you have ever found compelling:
+
+1. **The hero** — your client
+2. **The problem** — the thing keeping them up at night
+3. **The guide** — you
+4. **The plan** — what you are going to do about it
+5. **The action** — the specific next step you are asking them to take
+6. **The solution** — the problem, solved
+7. **The conclusion** — what their business looks like after
+
+> **Before:** "We've been in business 10 years. Our team of experts handles your digital marketing."
+>
+> **After:** "Local businesses struggle to get found online. You have a plan — we help you execute it. Here's what it looks like when your phone rings with qualified leads."
+
+The prospect should see themselves in the first sentence, not your company history.
+
+### Prove you are a real guide, not just a good storyteller
+
+A compelling story earns you a first conversation. What keeps the account is whether your operation actually delivers what the story promised — repeatable systems, reliable follow-through, and the kind of professionalism a client notices even when nothing has gone wrong. If you are going to guide someone through fixing their business, you have to be willing to run the same audit on your own.
+
+## Part 2 — Run your sales day
+
+### Attack the thing you are avoiding, first
+
+Every rep has a list of tasks they would rather not do — the cancellation call, the customer who owes money, the twenty-page proposal. Left alone, those tasks do not go away. They sit in the back of your mind all day and show up in your voice on every call you make in the meantime, because customers can tell when you are carrying something heavy.
+
+Clear the unpleasant task first, before you touch anything else. Everything after it gets easier because you are not dragging it around.
+
+### The minutes add up
+
+You can get more budget, more headcount, more product to sell. You cannot get more time.
+
+Track where a normal day actually goes — most reps are startled by how much of it disappears into their phone, into meetings, and into waiting for a customer who does not show. Protect your schedule the way a dentist's office protects theirs: they call you nine times before an appointment because every empty chair costs them money. Treat your calendar the same way.
+
+### Become a chemist about your own numbers
+
+Revenue at the end of the month is a *lag* measure. You either feel good or you do not, but by the time you see it, it is too late to change it.
+
+What you can act on are the *leading* measures: how many calls you made, how many proposals are out, what your closing ratio actually is. If you know your close rate is 20% and you need $100,000 this month, you can work backward to exactly how many live opportunities you need in the pipeline — aim for about 120% of that number as a buffer.
+
+Measuring the leading numbers is what keeps you out of the whirlwind: the daily grind of urgent-but-not-important tasks that eats a day nobody actually planned.
+
+### Split your book into A / B / C
+
+<FlipCardGrid>
+  <FlipCard front="A accounts" back="Paying you real money right now. When an A account raises a hand, you drop what you are doing." subtext="Protect" />
+  <FlipCard front="B accounts" back="Your biggest opportunities, or A accounts in the making. This is where extra selling effort goes." subtext="Invest" />
+  <FlipCard front="C accounts" back="Flat or going nowhere. Find the one thing that would grow them, or manage them out." subtext="Limit" />
+</FlipCardGrid>
+
+C accounts include "fallen angels" — former A accounts where something changed. Spend very little time here. Either find the specific thing that would grow one back into a B, or manage it out of your book. Do not let them quietly eat your week.
+
+Aim to spend roughly 80% of your time on A accounts and the B accounts that are becoming A accounts.
+
+### The 60/30/10 rule
+
+A well-run selling day breaks down roughly like this:
+
+- **60%** actually talking to customers
+- **30%** getting better at your craft — the product, the competition, your own numbers
+- **10%** on administration
+
+Most reps who feel busy but are not hitting budget have this ratio flipped: heavy on admin and craft, light on actual customer conversations.
+
+### Master the line-by-line
+
+Here is a test a good sales manager will run on you, and one you should be able to run on yourself: without opening a spreadsheet or a notebook, can you talk through your top ten accounts — what is happening with each one, why it matters to the business, when you last talked to them, and when you will talk to them next?
+
+If you cannot do it from memory, you do not know your book of business as well as you think you do. The spreadsheet is where you organize it. The line-by-line is where you prove you actually know it.
+
+### Always be looking for the next opportunity
+
+The rate of change in this business is fast enough that "the way we have always done it" is a genuine liability, not just a cliché. Keep your mind open to the next product shift, the next customer need, the next idea. A rep who is certain they have already found the ceiling is the rep who gets outworked by someone hungrier.
+
+### Proof from the field
+
+Two of Vendasta's top-performing partner agencies were asked what actually separates them. Neither credited a clever tactic.
+
+One runs a standing monthly performance review with every client so the client never has to wonder whether it is working — *"if you're not proving value, they're going to start shaking when they write that check."* The other's answer was blunter: *"no lotion, potion, no magic. Just not afraid to work. First one in the building, last one to leave."*
+
+The operating system in this lesson is what that discipline looks like applied to a calendar, instead of left as a slogan.
+
+:::tip Try it now
+Two parts. First, write the "before and after" of your own website's opening line — who is the hero in each version? Second, do a line-by-line, out loud, no spreadsheet, on your own top five accounts. Wherever you go blank on either one is this week's work.
+:::
+
+## What you now have
+
+- A clear call on local-variety versus global-niche positioning for your own agency
+- A four-step process for defining your ideal client beyond a demographic guess
+- The hero's-journey structure for copy that puts the client first
+- A rule for clearing the task you are avoiding before it costs you the whole day
+- The A/B/C framework for where your time should actually go
+- The 60/30/10 split to check your week against
+- The line-by-line test for how well you really know your book
+
+<SectionFeedback courseId="build-your-brand-and-your-day" site="vendasta_learn" section="content" />
+
+<KnowledgeCheck courseId="build-your-brand-and-your-day" site="vendasta_learn"
+  sessionSize={5}
+  intro="Five questions on positioning, and on where your hours actually go."
+  questions={[
+    {
+      type: 'mcq',
+      question: 'An agency wants to build digital marketing funnels and sell nationwide. What positioning does this lesson recommend?',
+      options: [
+        'Stay as broad as possible across every vertical',
+        'Pick one niche and go deep, since clients will not compete with each other nationally',
+        'Only take clients within a 10-mile radius',
+        'Avoid any specific vertical language'
+      ],
+      correctIndex: 1,
+      explanation: 'Global reach removes the local competition problem, so niching down for expert positioning works — the opposite of the local approach.'
+    },
+    {
+      type: 'mcq',
+      question: 'Why should local agencies serve one or two verticals with variety, rather than one narrow niche in town?',
+      options: [
+        'Local clients do not respond well to specialists',
+        'Serving multiple direct competitors in the same small market creates conflict',
+        'It is required by most licensing agreements',
+        'Local marketing budgets are too small for a niche focus'
+      ],
+      correctIndex: 1,
+      explanation: 'Marketing every dentist in one town means competing clients are all paying you, which is a disservice to all of them.'
+    },
+    {
+      type: 'mcq',
+      question: 'In the hero\'s-journey framing for website copy, who is the hero?',
+      options: ['The agency', 'The client', 'The product being sold', 'The founder'],
+      correctIndex: 1,
+      explanation: 'The client has the problem and needs a guide. The agency is the guide. Copy that reverses this makes the prospect work to see themselves in it.'
+    },
+    {
+      type: 'mcq',
+      question: 'Roughly how should a selling day break down under the 60/30/10 rule?',
+      options: [
+        '60% admin, 30% customer calls, 10% learning',
+        '60% talking to customers, 30% improving your craft, 10% admin',
+        '60% prospecting, 30% closing, 10% onboarding',
+        '60% learning, 30% admin, 10% customer calls'
+      ],
+      correctIndex: 1,
+      explanation: 'The rule exists because most reps who feel busy have this backwards — too much admin and craft-building, not enough actual customer time.'
+    },
+    {
+      type: 'truefalse',
+      statement: 'C accounts deserve roughly equal time to A accounts, since today\'s C account could become tomorrow\'s A account.',
+      correct: false,
+      explanation: 'C accounts get deliberately little time. You are either finding the one thing that could grow a specific account back into a B, or managing it out — not investing broadly across the whole C list.'
+    },
+    {
+      type: 'mcq',
+      question: 'Why does this lesson push you to attack the task you are avoiding first thing in the day?',
+      options: [
+        'It is usually the highest-paying task of the day',
+        'Left alone it weighs on you and quietly affects every other call you make',
+        'Managers check on it first',
+        'It takes the least amount of time'
+      ],
+      correctIndex: 1,
+      explanation: 'An unresolved unpleasant task does not disappear. It follows you into every other conversation you have that day.'
+    },
+    {
+      type: 'sort',
+      instruction: 'Sort each metric into lag measures and leading measures.',
+      items: [
+        { label: 'Revenue booked this month', correctBucket: 'lag' },
+        { label: 'Number of calls made', correctBucket: 'leading' },
+        { label: 'Proposals currently out', correctBucket: 'leading' },
+        { label: 'Whether you hit budget', correctBucket: 'lag' }
+      ],
+      buckets: [
+        { id: 'lag', label: 'Lag measure' },
+        { id: 'leading', label: 'Leading measure' }
+      ],
+      explanation: 'Lag measures tell you how it went. Leading measures are the only ones you can still act on while the month is running.'
+    },
+    {
+      type: 'fillblank',
+      principle: 'If you know your close rate and your revenue target, work backward to the opportunities you need — then aim for about ___% of that number as a buffer.',
+      before: '',
+      answer: '120',
+      after: '',
+      hint: 'a number above 100',
+      explanation: 'Building in a buffer above the mathematically required pipeline absorbs the deals that slip, stall, or die.'
+    }
+  ]}
+/>
+
+<LessonFooter
+  to="/learn/growth-engine"
+  pathName="How to sell"
+  step={9}
+  totalSteps={9}
+  nextPathName="Your growth engine"
+  description="Run the full loop for one prospect: Snapshot, package, propose, deliver, and prove the result."
+/>
+
+</InlineHighlighter>
+<MarkComplete courseId="build-your-brand-and-your-day" site="vendasta_learn" />

--- a/docusaurus/training/sales/close-and-open-the-relationship.mdx
+++ b/docusaurus/training/sales/close-and-open-the-relationship.mdx
@@ -1,0 +1,227 @@
+---
+title: "Close, then open the relationship"
+sidebar_position: 6
+description: "The close is the beginning of the account, not the end of the sale."
+sidebar_class_name: hide-from-sidebar
+---
+
+import KnowledgeCheck from "@site/src/components/KnowledgeCheck";
+import CourseProgressBar from "@site/src/components/CourseProgressBar";
+import SectionFeedback from "@site/src/components/SectionFeedback";
+import InlineHighlighter from "@site/src/components/InlineHighlighter";
+import MarkComplete from "@site/src/components/MarkComplete";
+import LessonHeader from "@site/src/components/LessonHeader";
+import LessonFooter from "@site/src/components/LessonFooter";
+import FlipCard, { FlipCardGrid } from "@site/src/components/FlipCard";
+
+<InlineHighlighter courseId="close-and-open-the-relationship" site="vendasta_learn">
+
+<CourseProgressBar courseId="close-and-open-the-relationship" site="vendasta_learn" />
+
+{/* VIDEO SLOT: source is "Close Prospects, Open Relationships" (Wistia, keep-as-is
+    verdict — talking-head, no product UI, no accuracy pass pending). Ready to embed as-is. */}
+
+<LessonHeader
+  difficulty="Intermediate"
+  time="about 10 minutes"
+  required={["The order is sent and accepted (Lesson 5's endpoint)"]}
+  video={true}
+  pathName="How to sell"
+  step={6}
+  totalSteps={9}
+  outcomes={[
+    "Explain why the moment you close is the start of the real work, not the finish line",
+    "Run a 30/60/90-day check-in cadence that proves value before the client has to ask",
+    "Reuse the same moves that won the deal — research, contrast, stories, questions — to keep growing the account",
+    "Catch a relationship drifting off course early, before a small gap becomes a lost client",
+  ]}
+/>
+
+## "Close" is the wrong word
+
+You just sent Riverside Landscaping's order and they accepted it. Every instinct says the sale is over. It isn't. The word "close" is doing you a disservice: most of the work starts the moment a deal closes, not before it. Think of the sales conversation as earning the right to a relationship, not winning a transaction. The account you just opened is worth more over three years than the deal you just signed is worth today, and what happens in your first 90 days determines which one you get.
+
+Here's why that isn't just a feel-good idea: if every new client you sign is just filling the seat of someone who churned last month, you're not growing — you're running in place to stay even. Growth only shows up when a new seat is a net-new seat: you keep the clients you already have while you add new ones. That's the entire economic case for everything in this lesson. A renewal is worth more to your growth number than a new logo, because it doesn't cost you anything to win it twice.
+
+## Prove what changed, on a schedule
+
+Don't wait for the client to wonder whether this was worth it. Check in at 30, 60, and 90 days after the sale, on a schedule you set, not one they have to ask for. Spend that window proving the specific thing you promised is actually happening: pull the before-and-after, not just an opinion.
+
+> "Here's your Snapshot from the day we started next to today's. Your review count is up, and here's the one listing that was dragging your score before we fixed it."
+
+A client who sees the receipt trusts the next thing you propose. A client who has to ask for it starts wondering what else you're not telling them.
+
+## Keep asking, now that you don't have to
+
+The questions that won the deal don't stop mattering once it's signed. Ask them anyway:
+
+> "Is this working the way you expected? What would make it better?"
+
+You already know your product. The client is the only one who knows what their day actually looks like now, and asking is the only way you find out before it becomes a complaint instead of a conversation.
+
+## Turn their win into their story
+
+Once Riverside Landscaping has a real result, ask if you can tell it:
+
+> "Would you be open to being a case study? I'd love to show other landscaping companies what happened with your listings."
+
+A specific client's story, with their industry and their numbers, is what a similar prospect trusts most — more than anything you could say about yourself. It's also worth more to you than a generic testimonial: name the industry, name the number, and the next Riverside Landscaping you pitch will see themselves in it.
+
+## Use before-and-after to make the value visible
+
+Lead with what changed for them, not with what you did. "We configured three automations" is a feature. "You used to lose half your quote requests overnight; now every one gets a same-day response" is a result they can feel. When you check in, don't explain your work — narrate their outcome:
+
+> "Three months ago you were manually following up on every quote request after hours. Now that's automatic, and your close rate on quotes moved from one in five to one in three. That's the difference."
+
+That contrast is also what keeps you different from whoever they almost hired instead. Anyone can list features; showing the exact gap you closed for this specific client is something a competitor can't copy after the fact.
+
+<FlipCardGrid>
+  <FlipCard front="30 days" back="First proof point. Show the before-and-after on the specific thing you promised." subtext="Check-in 1" />
+  <FlipCard front="60 days" back="Ask the standing question: is this working the way you expected?" subtext="Check-in 2" />
+  <FlipCard front="90 days" back="Real result in hand. This is when you ask for the case study." subtext="Check-in 3" />
+</FlipCardGrid>
+
+## Course-correct before it's a crisis
+
+A plane one degree off course is nothing for the first few minutes. Left uncorrected for the whole flight, it lands hundreds of miles from where it meant to. A client relationship works the same way: a small unmet expectation is easy to fix in week two and expensive to fix in month five. Your 30/60/90 check-ins exist to catch the one-degree drift while it's still one degree — say the quiet part out loud ("here's what hasn't happened yet, here's the plan to get there") instead of hoping they don't notice.
+
+## Give your check-ins a script, not a guess
+
+Each of your 30/60/90 check-ins is a key inflection point — a moment where your next move either builds the client's loyalty or quietly chips away at it. The mistake reps make is winging each one, which means quality depends on whatever mood you're in that day. Instead, write yourself a one-page playbook for each check-in before you need it: what to pull (the before-and-after numbers), what to ask (the two standing questions above), and what to do with a "no, actually, this part isn't working" answer. You're not scripting a robotic call — you're making sure the 30-day check-in is as good on your worst week as it is on your best one. The same logic applies the moment something predictable goes wrong, like your main contact at the account leaving — decide now what you'll do then, so you're not improvising while the relationship is already at risk.
+
+## At-risk isn't the same as lost
+
+Worth separating two things that get used interchangeably. A client is *at risk* when something has gone wrong enough that the relationship could end. A client has *churned* when the revenue is actually gone. Those aren't the same event, and treating them as the same is how reps give up early. An at-risk client is still a client — often one who'll tell you exactly what's wrong if you ask directly. That's the entire window your 30/60/90 check-ins exist to find.
+
+Also worth knowing: the reason usually isn't your work. It's more often financial pressure on their side, a change in their business, or something human that has nothing to do with you. Which is exactly why asking beats assuming — the fix for "their budget got cut" is a different conversation than the fix for "we dropped the ball in month two," and you can't tell which one you're in without asking.
+
+## When you do lose one, lose it well
+
+Sometimes you don't catch the drift in time, or the reason was never yours to fix. You can't save them all. What you can control is how the relationship ends.
+
+When a client is genuinely leaving, the instinct is to either fight it or go quiet. Both cost you. Instead: be efficient about the wind-down, respect their time, don't make them chase you for the last steps, and say plainly that the door is open if things change.
+
+> "I'm sorry this didn't work out the way we planned. I'll get everything wrapped up cleanly on our end this week. If your situation changes down the road, I'd genuinely like to work together again — call me directly."
+
+Businesses change. Budgets come back, owners move to new companies, and the person who left you on good terms is the one who recommends you to someone else — or comes back themselves in eighteen months. A client you lost gracefully is a lead. A client you lost badly is a review you can't undo.
+
+:::tip Try it now
+Pick a client you closed in the last 90 days. Write down what you promised them in the pitch, one sentence. Then write down whether you have already shown them, in numbers, that it happened. If you haven't, that's this week's check-in.
+:::
+
+## What you now have
+
+- A 30/60/90-day check-in habit that proves value before the client asks for it
+- A before-and-after script you can adapt to any client's numbers
+- A standing question ("is this working the way you expected?") that surfaces small problems before they become churn
+- The habit of asking for the case study the moment you have a real result
+- A one-page playbook for each check-in, so the habit survives a bad week and a change in who's on the account
+- A clear line between at-risk and lost, so you keep working a relationship that's still winnable
+- A way to end a relationship that's genuinely over without burning the referral or the return
+
+{/* No "do it, delegate it, or buy it" block here, same as lesson 4: this is a relationship-management
+    habit, not a task Vendasta Services could take off a partner's hands. */}
+
+<SectionFeedback courseId="close-and-open-the-relationship" site="vendasta_learn" section="content" />
+
+<KnowledgeCheck courseId="close-and-open-the-relationship" site="vendasta_learn"
+  sessionSize={6}
+  intro="Six quick questions on why the close isn't the finish line, and how to keep proving value after it."
+  questions={[
+    {
+      type: 'mcq',
+      question: 'Why does the lesson push back on the word "close"?',
+      options: [
+        '"Close" undersells how hard the pitch itself was',
+        'Most of the real work starts after the deal is signed, not before',
+        'Clients dislike sales language',
+        '"Close" implies the price was too low'
+      ],
+      correctIndex: 1,
+      explanation: 'The deal signing isn\'t the finish line — it\'s the start of the relationship that determines whether the account grows or churns.'
+    },
+    {
+      type: 'mcq',
+      question: 'What is the point of the 30/60/90-day check-in cadence?',
+      options: [
+        'It is a contractual requirement in most service agreements',
+        'It gives you a fixed schedule to prove value before the client has to ask',
+        'It is how often invoices go out',
+        'It replaces the need for an onboarding call'
+      ],
+      correctIndex: 1,
+      explanation: 'Checking in on a schedule you set, with a real before-and-after, builds trust proactively instead of reactively.'
+    },
+    {
+      type: 'mcq',
+      question: 'A client relationship has a small unmet expectation in week two that nobody addresses. What does the plane analogy say happens if it\'s ignored?',
+      options: [
+        'It resolves itself once the client sees other results',
+        'It stays a minor issue indefinitely',
+        'A small drift compounds into something far more costly the longer it goes unaddressed',
+        'It only matters if the client brings it up first'
+      ],
+      correctIndex: 2,
+      explanation: 'One degree off course is nothing for a few minutes and everything over a whole flight. Small gaps are cheap to fix early and expensive to fix late.'
+    },
+    {
+      type: 'truefalse',
+      statement: 'The best time to ask a client to be a case study is right when you close the deal, before any results exist yet.',
+      correct: false,
+      explanation: 'A case study is the client\'s real result told with their numbers and industry — ask once you\'ve actually proven the before-and-after, not before there\'s a "before and after" to show.'
+    },
+    {
+      type: 'mcq',
+      question: 'Why does the lesson recommend writing a one-page playbook for your check-ins instead of improvising each one?',
+      options: [
+        'Playbooks are required by most CRM tools',
+        'It makes the check-in sound more formal to the client',
+        'It keeps the quality of the check-in consistent even on a bad week or a change in who owns the account',
+        'It lets you skip check-ins you don\'t have time for'
+      ],
+      correctIndex: 2,
+      explanation: 'A check-in that only works when you\'re at your best isn\'t a habit yet — a playbook is what makes it survive a bad week, a busy quarter, or a change in who\'s running the account.'
+    },
+    {
+      type: 'mcq',
+      question: 'A client tells you they are ending the engagement and nothing you offer will change their mind. What does the lesson say to do?',
+      options: [
+        'Keep pitching until they stop replying',
+        'Stop responding, since the revenue is gone either way',
+        'Wrap up cleanly and quickly, respect their time, and say plainly that the door is open if their situation changes',
+        'Ask them to reconsider in writing before you close the account'
+      ],
+      correctIndex: 2,
+      explanation: 'You can\'t save every client, but you control how it ends. A client who leaves on good terms can refer you or come back later; one who leaves badly can\'t.'
+    },
+    {
+      type: 'sort',
+      instruction: 'Sort each signal into whether the account is at risk or has already churned.',
+      items: [
+        { label: 'Client stopped replying but is still paying', correctBucket: 'atrisk' },
+        { label: 'The revenue has stopped', correctBucket: 'churned' },
+        { label: 'An unmet expectation nobody has addressed', correctBucket: 'atrisk' },
+        { label: 'Contract formally ended', correctBucket: 'churned' }
+      ],
+      buckets: [
+        { id: 'atrisk', label: 'At risk — still winnable' },
+        { id: 'churned', label: 'Churned — revenue gone' }
+      ],
+      explanation: 'At risk is not the same as lost. Treating the two as one event is how reps give up on relationships that were still recoverable.'
+    },
+    {
+      type: 'fillblank',
+      principle: 'Check in at 30, 60, and ___ days after the sale, on a schedule you set.',
+      before: '',
+      answer: '90',
+      after: '',
+      hint: 'a number',
+      explanation: 'The 30/60/90 cadence exists so you prove value before the client has to ask for it.'
+    }
+  ]}
+/>
+
+<LessonFooter to="/learn/sales/sell-socially" pathName="How to sell" step={6} totalSteps={9} />
+
+</InlineHighlighter>
+<MarkComplete courseId="close-and-open-the-relationship" site="vendasta_learn" />

--- a/docusaurus/training/sales/consult-dont-just-pitch.mdx
+++ b/docusaurus/training/sales/consult-dont-just-pitch.mdx
@@ -1,0 +1,183 @@
+---
+title: "Consult, don't just pitch"
+sidebar_position: 8
+description: "The questions that make a prospect trust your recommendation."
+sidebar_class_name: hide-from-sidebar
+---
+
+import KnowledgeCheck from "@site/src/components/KnowledgeCheck";
+import CourseProgressBar from "@site/src/components/CourseProgressBar";
+import SectionFeedback from "@site/src/components/SectionFeedback";
+import InlineHighlighter from "@site/src/components/InlineHighlighter";
+import MarkComplete from "@site/src/components/MarkComplete";
+import LessonHeader from "@site/src/components/LessonHeader";
+import LessonFooter from "@site/src/components/LessonFooter";
+import FlipCard, { FlipCardGrid } from "@site/src/components/FlipCard";
+
+<InlineHighlighter courseId="consult-dont-just-pitch" site="vendasta_learn">
+
+<CourseProgressBar courseId="consult-dont-just-pitch" site="vendasta_learn" />
+
+{/* VIDEO SLOT: two candidates, both talking-head/panel footage with no product UI.
+    1. "Using dynamic and personalized content to fuel growth" — Conquer Local Connect customer
+       panel, Wistia embed ID `u24r2lp4vp`. The stronger of the two: contains the "never automate
+       the sales conversation" exchange that this lesson is built around.
+    2. "Stacking Success: Your Competitive Advantage" — Conquer Local conference talk, Wistia
+       embed ID `4in417wbuj`. Source of the trust-beats-features statistics.
+
+    Provenance caveat: both IDs are listed in the 360Learning export against unrelated course
+    titles ("Host a Powerful Consultation that Converts" and "Engage and Keep your Clients with
+    Expert Consulting"). Shiva confirmed the IDs resolve to the two clips named above, not to
+    those course titles. Verify in Wistia before embedding. */}
+
+<LessonHeader
+  difficulty="Intermediate"
+  time="about 9 minutes"
+  required={["A discovery call run (Lesson 3) and at least one deal closed (Lesson 6)"]}
+  video={true}
+  pathName="How to sell"
+  step={8}
+  totalSteps={9}
+  outcomes={[
+    "Explain why the sales conversation itself is where you find out what a client actually needs",
+    "Ask the questions that let you recommend with confidence instead of guessing",
+    "Name the one thing in your sales process you should never automate, and why",
+    "Report results in a way that builds trust instead of triggering skepticism",
+  ]}
+/>
+
+## The pitch you did not earn
+
+A pitch is something you can write before you have met the prospect. A recommendation is something you can only write after. The difference matters because a prospect can tell which one they are getting.
+
+Three different agency owners, on a panel about what they automate in their sales process, all landed on the same rule without prompting each other: **they will never automate the actual sales conversation.** Not because it is sentimental — because that conversation is the one place they find out what the client actually needs, and a recommendation built on a guess is just a pitch wearing a nicer outfit.
+
+> "This is your chance to understand what the client needs. And after you know what the client needs, this allows you to then map the problem and how you can best solve that."
+
+That is the whole job in one sentence: understand, then map, then recommend. Skip the first step and you are not consulting, you are guessing out loud.
+
+## Do your homework before you recommend anything
+
+One agency owner on that panel runs a qualifying questionnaire before a prospect ever gets on a call — a short form asking about pain points, how the prospect found them, and their financial situation. By the time they are on the call, they already know "what their hand in poker is" instead of guessing.
+
+You do not need a website form to do the same thing. Before your next consultation, get answers to three questions however you can — a quick email, a form, or the first two minutes of the call:
+
+- What is the actual goal you are trying to hit this quarter?
+- What have you already tried, and why did it not stick?
+- What would make this a clear win for you, in your own words?
+
+Walking in with those answers is what separates a consultation from a cold pitch with a prospect's name swapped in.
+
+## The two questions that turn a pitch into a recommendation
+
+Once you know what they are chasing, two follow-up questions do most of the remaining work:
+
+> "What does 'better' actually look like for you here?"
+>
+> "What's stopped this from getting fixed already?"
+
+The first stops you from recommending the wrong *size* of solution — you are aiming at their definition of success, not yours. The second surfaces the real obstacle, which is often not the one they led with.
+
+A client who says they need "more reviews" but whose real obstacle is that nobody on staff has time to ask for them needs a different recommendation than the one you would have made from the first sentence alone.
+
+<FlipCardGrid>
+  <FlipCard front="Understand" back="The sales conversation is the only place you learn the real need. Never automate it." subtext="Step 1" />
+  <FlipCard front="Map" back="Two questions: what does better look like, and what has stopped this from being fixed?" subtext="Step 2" />
+  <FlipCard front="Recommend" back="Only now. A recommendation made before understanding is just a pitch." subtext="Step 3" />
+</FlipCardGrid>
+
+## Why trust beats features
+
+Here is the payoff for working this way instead of pitching: roughly three out of every four dollars small businesses spend on software and services flow through an expert they already trust, not the vendor with the longest feature list. Research cited in this material also finds B2B buyers are *more* emotionally attached to the vendors and service providers they rely on than typical consumers are to the brands they buy from.
+
+That is not a reason to be less rigorous about your product. It is the reason the questions above matter more than your pitch deck. A prospect is not deciding whether your product is good — they are deciding whether you are the person whose recommendation they can trust without independently verifying it. Understanding their problem before you name a solution is how you earn that.
+
+## Keep consulting after the sale
+
+The same "do not automate the conversation" rule those agency owners apply to selling, they also apply to reporting results.
+
+It is fine to have an automated monthly report go out. But the thing that actually keeps a client is walking them through their real numbers yourself, in a short screen recording or a call, rather than letting a canned report speak for you. Skip the vanity metrics — impressions, clicks — and narrate the ones that show where the business actually improved.
+
+Clients who get that personal walkthrough trust the relationship more, because they can tell you are not hiding behind a dashboard when the numbers are anything less than perfect.
+
+:::tip Try it now
+Before your next consultation, write down the three homework questions above and actually get answers before the call, even if it is just a two-line email. Then, in the call itself, ask the two follow-up questions before you say a single word about what you would recommend.
+:::
+
+## What you now have
+
+- A three-question homework habit that replaces guessing with actual knowledge of the client's goal
+- Two follow-up questions that keep your recommendation sized to their definition of success
+- A clear line on what never gets automated: diagnosing the problem, and reporting the real results
+- The trust-over-features argument for why this is worth the extra ten minutes
+
+<SectionFeedback courseId="consult-dont-just-pitch" site="vendasta_learn" section="content" />
+
+<KnowledgeCheck courseId="consult-dont-just-pitch" site="vendasta_learn"
+  sessionSize={4}
+  intro="Four questions on the difference between recommending and pitching."
+  questions={[
+    {
+      type: 'mcq',
+      question: 'What is the difference between a pitch and a recommendation?',
+      options: [
+        'A recommendation is shorter',
+        'A pitch can be written before meeting the prospect; a recommendation can only be written after you understand their actual need',
+        'A recommendation always costs more',
+        'There is no real difference, just different words'
+      ],
+      correctIndex: 1,
+      explanation: 'A recommendation is built on understanding this specific client. A pitch is the same thing you would say to anyone.'
+    },
+    {
+      type: 'mcq',
+      question: 'Why do the agency owners in this lesson refuse to automate the sales conversation itself?',
+      options: [
+        'Automation software for sales calls does not exist yet',
+        'It is the one place they find out what the client actually needs before recommending anything',
+        'Clients complain when a call feels automated',
+        'Their CRM contracts require it'
+      ],
+      correctIndex: 1,
+      explanation: 'The conversation is where the diagnosis happens. Automate it away and you lose the one input your recommendation depends on.'
+    },
+    {
+      type: 'mcq',
+      question: 'A prospect says they need "more reviews." Your follow-up reveals the real obstacle is that nobody on staff has time to ask for them. What does this show?',
+      options: [
+        'The prospect was lying about needing reviews',
+        'The follow-up question surfaced a more accurate problem than the one first stated',
+        'You should ignore what a prospect says they need',
+        'More reviews was never a valid goal'
+      ],
+      correctIndex: 1,
+      explanation: 'The stated want and the real obstacle are often not the same thing. The follow-up question is what surfaces the gap.'
+    },
+    {
+      type: 'truefalse',
+      statement: 'B2B buyers mostly choose vendors based on which one has the longest feature list.',
+      correct: false,
+      explanation: 'Roughly three-quarters of SMB software spending flows through an expert the buyer already trusts. Trust in the recommender, not a feature comparison, is doing the deciding.'
+    },
+    {
+      type: 'fillblank',
+      principle: 'The consulting sequence in this lesson is: understand, ___, then recommend.',
+      before: '',
+      answer: 'map',
+      after: '',
+      hint: 'what you do with the problem once you understand it',
+      explanation: 'Understand the need, map the problem to how you can solve it, then recommend. Skipping the first two makes it a pitch.'
+    },
+    {
+      type: 'truefalse',
+      statement: 'An automated monthly report is enough to keep a client confident in your work.',
+      correct: false,
+      explanation: 'Automated reports are fine as a baseline, but walking the client through the real numbers yourself is what builds trust — especially when the numbers are less than perfect.'
+    }
+  ]}
+/>
+
+<LessonFooter to="/learn/sales/build-your-brand-and-your-day" pathName="How to sell" step={8} totalSteps={9} />
+
+</InlineHighlighter>
+<MarkComplete courseId="consult-dont-just-pitch" site="vendasta_learn" />

--- a/docusaurus/training/sales/find-your-next-prospect.mdx
+++ b/docusaurus/training/sales/find-your-next-prospect.mdx
@@ -1,0 +1,178 @@
+---
+title: "Find your next prospect"
+sidebar_position: 1
+description: "Build a pipeline instead of waiting for one to show up."
+sidebar_class_name: hide-from-sidebar
+---
+
+import KnowledgeCheck from "@site/src/components/KnowledgeCheck";
+import CourseProgressBar from "@site/src/components/CourseProgressBar";
+import SectionFeedback from "@site/src/components/SectionFeedback";
+import InlineHighlighter from "@site/src/components/InlineHighlighter";
+import MarkComplete from "@site/src/components/MarkComplete";
+import LessonHeader from "@site/src/components/LessonHeader";
+import LessonFooter from "@site/src/components/LessonFooter";
+import FlipCard, { FlipCardGrid } from "@site/src/components/FlipCard";
+
+<InlineHighlighter courseId="find-your-next-prospect" site="vendasta_learn">
+
+<CourseProgressBar courseId="find-your-next-prospect" site="vendasta_learn" />
+
+{/* VIDEO SLOT: "Better Prospecting" — Wistia, embed ID `lpdxav2w39`, keep-as-is verdict
+    (talking-head, no product UI, no accuracy pass pending). Transcript filed in
+    wistia-transcripts/ under the "Better Prospecting" title. Note: this ID is listed in the
+    360Learning export against course 603 ("Perfecting the Discovery Call"), but Shiva confirmed
+    it actually resolves to "Better Prospecting" — one of several known mismatched IDs in that
+    export. Verify in Wistia before embedding. */}
+
+<LessonHeader
+  difficulty="Beginner"
+  time="about 12 minutes"
+  required={["None"]}
+  video={true}
+  pathName="How to sell"
+  step={1}
+  totalSteps={9}
+  outcomes={[
+    "Explain why keeping the funnel full matters more than any single deal",
+    "Deliver a concise, headline-first pitch instead of a rambling one",
+    "Respond to a prospect at the moment they are most engaged, not hours later",
+    "Use a sales engagement tool to automate the outreach grind instead of doing it by hand",
+  ]}
+/>
+
+## Why the top rep last month is at the bottom this month
+
+You have seen it happen: someone crushes every record one month and is scraping the bottom of the leaderboard the next. It is almost never that they got worse at selling. It is that they stopped prospecting while they were busy servicing the deals they just won — and the funnel behind them went empty.
+
+Prospecting is not the thing you do when you have spare time. It is the thing that determines whether you have a next month at all.
+
+## Keep the funnel full: six habits
+
+**1. Deliver the concise version first.** Human attention is measured in seconds, not minutes. Say the headline up front, then go deeper only if they ask. An eight-paragraph email gets skimmed for ten seconds and deleted; a two-line one gets read.
+
+**2. Ask questions you can predict the shape of, not the content of.** You often already know roughly what a prospect will say — you are asking because *how* they say it tells you what they actually care about. That is different from an interrogation. Nobody wants to feel like they are filling out a form out loud.
+
+**3. Never stop delivering value, even to your own customers.** Your customer is someone else's prospect, and your prospect is someone else's customer. It is a constant contest over who delivers more value more often, and the rep who stops adding value between deals loses the account eventually.
+
+**4. Respond at the moment they are engaged, not on your schedule.** Studies put a prospect roughly 60 times more likely to convert if you reach them within 60 seconds of them opening your message. If you can see when an email was opened or a message was read, that is your signal to call — right then, not at the end of the day.
+
+**5. Use the channel your prospect actually prefers.** Some people want a phone call. A growing number would rather text or message than ever get on one. Do not fight this: figure out which channel a given prospect responds to and meet them there.
+
+**6. Become the trusted expert, so referrals do your prospecting for you.** Bragging is just marketing with worse branding — if customers say good things about you, amplify it. The endpoint of doing this well is referrals: prospects who arrive pre-sold because someone already vouched for you.
+
+<FlipCardGrid>
+  <FlipCard front="Concise first" back="Lead with the headline. Depth only if they ask for it." subtext="Habit 1" />
+  <FlipCard front="60 seconds" back="Reach a prospect within 60 seconds of an open and they are ~60x more likely to convert." subtext="Habit 4" />
+  <FlipCard front="Referrals" back="The endpoint of being the trusted expert: prospecting you no longer have to do yourself." subtext="Habit 6" />
+</FlipCardGrid>
+
+## The five-before-nine, nine-after-five rule
+
+If you work a standard nine-to-five, make five prospecting calls before 9am and nine after 5pm. The logic: your buyer is doing their actual job during business hours. You want to reach them when they are doing their own admin and planning, when they are more likely to pick up.
+
+Even on days this feels arbitrary, the discipline of doing it keeps prospecting as something you think about every day, not something you get to eventually.
+
+## Automate the part that should not take you hours by hand
+
+Everything above is a discipline. The next part is a tool. A sales engagement platform like Yesware plugs into Gmail or Outlook and takes over the mechanical side of outreach, so you spend your time on conversations instead of the busywork around them:
+
+- **Track** — get a real-time notification when a prospect opens your email or clicks a link, so you know exactly when to follow up. This is habit 4, automated.
+- **Search** — pull verified contact data (phone, email, social) for new leads in a couple of clicks instead of hours of manual research.
+- **Standardize** — build reusable, personalizable email templates once, instead of rewriting the same email every time.
+- **Automate** — schedule multi-touch outreach across several days. It takes an average of five follow-ups after first contact before a prospect says yes, so a tool that remembers to send touch number four is doing real work.
+- **Analyze** — see which campaigns, cadences, and follow-up counts actually produce replies, so you stop guessing.
+
+None of this replaces the habits above. It removes the manual grind around them so more of your day goes to actually talking to people — which is where the 60/30/10 rule (you will meet it properly in Lesson 9) says most of your time belongs anyway.
+
+:::tip Try it now
+Pick one prospect you have not followed up with this week. Write the headline version of your outreach — one sentence of value, one question — before you write anything longer.
+:::
+
+## Do it, delegate it, or buy it
+
+- **Do it** — build your own outreach cadence and templates by hand. Free, but the most time.
+- **Delegate it** — have an SDR or junior rep own the prospecting-volume side of the funnel while you focus on live conversations.
+- **Buy it** — a sales engagement tool to automate tracking, sequencing, and reporting. The fastest path to more outreach without more hours.
+
+## What you now have
+
+- Six habits for keeping your pipeline full instead of running dry between big deals
+- The five-before-nine, nine-after-five discipline that makes prospecting daily rather than occasional
+- A model for building toward referral-based prospecting instead of permanent cold outreach
+- A concrete picture of what a sales engagement tool automates, and what it cannot
+
+<SectionFeedback courseId="find-your-next-prospect" site="vendasta_learn" section="content" />
+
+<KnowledgeCheck courseId="find-your-next-prospect" site="vendasta_learn"
+  sessionSize={4}
+  intro="Four questions on why funnels run dry, and the habits that stop it."
+  questions={[
+    {
+      type: 'mcq',
+      question: 'Why does a top performer sometimes fall to the bottom of the leaderboard the very next month?',
+      options: [
+        'Their product knowledge got worse',
+        'They stopped prospecting while servicing the deals they just closed',
+        'Their manager changed their territory',
+        'Leads got reassigned to someone else'
+      ],
+      correctIndex: 1,
+      explanation: 'A big month of closing consumes the time that would otherwise go into prospecting. The funnel runs dry right after a great month, not a bad one.'
+    },
+    {
+      type: 'mcq',
+      question: 'Roughly how much more likely is a prospect to convert if you reach them within 60 seconds of them opening your message?',
+      options: ['About 2 times', 'About 10 times', 'About 60 times', 'It makes no measurable difference'],
+      correctIndex: 2,
+      explanation: 'Roughly a 60x lift. The moment of highest engagement is also the shortest-lived, which is why the timing matters more than the wording.'
+    },
+    {
+      type: 'mcq',
+      question: 'What is the endpoint of becoming a trusted expert?',
+      options: [
+        'Higher hourly billing rates',
+        'Referrals that arrive without any cold outreach',
+        'A promotion to sales manager',
+        'A larger territory'
+      ],
+      correctIndex: 1,
+      explanation: 'A trusted expert eventually gets referred business by reputation alone. The highest-leverage prospecting is the kind you do not have to do yourself.'
+    },
+    {
+      type: 'truefalse',
+      statement: 'A sales engagement tool is meant to replace the daily prospecting habits in this lesson.',
+      correct: false,
+      explanation: 'The tool automates the manual grind around outreach — tracking, searching, sequencing, reporting. It does not replace the judgment behind who to reach and what to say.'
+    },
+    {
+      type: 'fillblank',
+      principle: 'The five-before-nine, nine-after-five rule: make five prospecting calls before 9am and ___ after 5pm.',
+      before: '',
+      answer: 'nine',
+      after: '',
+      hint: 'a number',
+      explanation: 'Five before nine, nine after five — timed to catch buyers when they are doing their own admin rather than their day job.'
+    },
+    {
+      type: 'sort',
+      instruction: 'Sort each item into whether it is a habit you build or a task a tool can automate.',
+      items: [
+        { label: 'Deciding which prospect is worth a call', correctBucket: 'habit' },
+        { label: 'Sending follow-up touch number four on schedule', correctBucket: 'tool' },
+        { label: 'Choosing the channel a prospect actually prefers', correctBucket: 'habit' },
+        { label: 'Notifying you the moment an email is opened', correctBucket: 'tool' }
+      ],
+      buckets: [
+        { id: 'habit', label: 'Your habit' },
+        { id: 'tool', label: 'The tool automates it' }
+      ],
+      explanation: 'Tools remove mechanical work. Judgment about who to reach, on what channel, and what to say stays yours.'
+    }
+  ]}
+/>
+
+<LessonFooter to="/learn/sales/open-the-conversation" pathName="How to sell" step={1} totalSteps={9} />
+
+</InlineHighlighter>
+<MarkComplete courseId="find-your-next-prospect" site="vendasta_learn" />

--- a/docusaurus/training/sales/handle-objections.mdx
+++ b/docusaurus/training/sales/handle-objections.mdx
@@ -1,0 +1,208 @@
+---
+title: "Handle objections without flinching"
+sidebar_position: 5
+description: "The five objections you will hear most, and what to say back."
+sidebar_class_name: hide-from-sidebar
+---
+
+import KnowledgeCheck from "@site/src/components/KnowledgeCheck";
+import CourseProgressBar from "@site/src/components/CourseProgressBar";
+import SectionFeedback from "@site/src/components/SectionFeedback";
+import InlineHighlighter from "@site/src/components/InlineHighlighter";
+import MarkComplete from "@site/src/components/MarkComplete";
+import LessonHeader from "@site/src/components/LessonHeader";
+import LessonFooter from "@site/src/components/LessonFooter";
+import FlipCard, { FlipCardGrid } from "@site/src/components/FlipCard";
+
+<InlineHighlighter courseId="handle-objections" site="vendasta_learn">
+
+<CourseProgressBar courseId="handle-objections" site="vendasta_learn" />
+
+{/* VIDEO SLOT 1 (place under "The LAIR sequence"): "Breaking Down Objections using the 'LAIR'
+    Strategy" — Wistia, embed ID `59g98gwzj6`, one of the two clips embedded in the 360Learning
+    course "Handle Sales Objections like an Expert" (619). Transcript filed as
+    Recognizing-Common-Sales-Objections-eng.srt.
+
+    VIDEO SLOT 2 (place under "Five ways to bounce back"): "Five Ways to Bounce Back after
+    Objection" — Wistia, embed ID `bm47k8n12o`, the second clip in the same course. Transcript
+    filed as Five-Ways-to-Bounce-Back-after-Objection-eng.srt.
+
+    Both IDs come from the same 360Learning export that produced several known mismatched IDs, so
+    verify each resolves to the expected clip in Wistia before embedding. Neither shows product
+    UI, so no accuracy pass is expected to be needed. */}
+
+<LessonHeader
+  difficulty="Intermediate"
+  time="about 15 minutes"
+  required={["A strategy already presented to this prospect (Lesson 4's endpoint)"]}
+  video={true}
+  pathName="How to sell"
+  step={5}
+  totalSteps={9}
+  outcomes={[
+    "Recognize that an objection is a request for more information, not a rejection",
+    "Work through any objection using the LAIR sequence",
+    "Recognize the five most common objections and know what to say back to each",
+    "Reach for five specific bounce-back techniques when you need one",
+  ]}
+/>
+
+## An objection is information, not a no
+
+You have done the work — discovery, a strategy that fits, a presentation you were proud of. Then, right as you go to close, the prospect gets cold feet. *"I'm not sure." "We don't have the budget for that." "I already have someone for this."*
+
+It is tempting to hear that as failure. It is not. An objection almost never means what it sounds like on the surface:
+
+- *"I don't know you"* usually means "I'm skeptical about your reputation and I need reassurance."
+- *"It's not my decision"* usually means "I don't feel comfortable deciding this alone."
+- *"I need to think about it"* usually means "I have doubts I haven't said out loud yet."
+
+Every objection is a request for more information, an unmet need, or an unaddressed concern — not a locked door. The reps who close more deals are not the ones who avoid objections. They are the ones who have built a process for working through them.
+
+## The LAIR sequence
+
+LAIR gives you a repeatable order of operations for any objection, before you even know which specific one you are dealing with.
+
+**Listen.** Let the prospect finish, uninterrupted. Do not jump straight to a rebuttal — on the phone, show you are listening with a "mm-hmm" or "I see" rather than silence.
+
+**Acknowledge and clarify.** Tell them their concern is valid, then ask a probing question if you suspect there is more underneath it: *"It sounds like you're concerned about X — can you tell me more?"*
+
+**Identify.** Repeat their concern back in your own words and confirm you have it right. This is the step that proves you were actually listening, not just waiting for your turn to talk.
+
+**Redirect.** Here is the order that matters: respond first with a *question*, not an answer. Only once the prospect is out of that defensive mode will they actually hear your solution. Then redirect — give context, data, or a customer story that speaks to the specific doubt they raised.
+
+<FlipCardGrid>
+  <FlipCard front="Listen" back="Let them finish. Signal you are there, but do not interrupt with a rebuttal." subtext="L" />
+  <FlipCard front="Acknowledge & Identify" back="Validate the concern, then say it back in your own words to confirm you have it right." subtext="A + I" />
+  <FlipCard front="Redirect" back="Answer with a question first. A defensive prospect cannot hear your solution yet." subtext="R" />
+</FlipCardGrid>
+
+## The five objections you will hear most
+
+**1. Price** — *"I can find something cheaper." "This isn't in my budget."*
+They do not see the value yet. "Too expensive" is usually code for "not worth what you're charging." Do not reach for a discount — that just confirms the price was inflated. Highlight the long-term savings, break the cost into smaller units so the number feels less abstract, and offer social proof of customers who came out ahead.
+
+**2. Authority** — *"I need to ask my boss." "It's not my decision."*
+They do not feel confident deciding alone. This is often a stalling tactic rather than a lie, but do not challenge it even if you suspect otherwise — that creates conflict without moving anything forward. Keep the process moving instead: *"I absolutely understand — could we set up a group meeting with the other decision-makers?"*
+
+**3. Trust** — *"I only work with brands I know." "I've read bad reviews."*
+They are skeptical of your reputation and need reassurance, not a defense. Demonstrate capability (know your solution cold), show integrity (real examples of putting the customer first), and give objective proof — case studies, testimonials, references, not just your word.
+
+**4. Complacency** — *"I'm fine with how things are." "Not a priority right now."*
+They are content with the status quo and what you are selling is not urgent to them yet. Highlight the specific positive changes that come from saying yes, then build urgency: the industry is moving, competitors are adapting, and standing still has a cost.
+
+**5. Competitor** — *"We already have someone for that."*
+Good news, actually. They already believe they need what you are selling — they just do not think it should come from you. Ask targeted questions about their experience with the incumbent (*"What's working? What isn't?"*), let them talk their way into naming the gaps, then show how you are different for their specific pain points. Competitor-bashing reads as petty at best and destroys your credibility at worst.
+
+## Five ways to bounce back
+
+These techniques are not tied to one specific objection. Reach for whichever fits the moment, or combine more than one.
+
+**1. Express curiosity.** Ask an open-ended question instead of accepting the objection at face value: *"Out of curiosity, why doesn't this work for you?"* People like explaining themselves, and the act of explaining often surfaces the real issue.
+
+**2. Offer a conditional close.** *"If I can show you this saves you money, can we keep talking?"* A yes to the condition is a soft yes to the sale.
+
+**3. Reframe the objection.** Agree first, then shift the lens: *"Yes, the colour's unusual — that's exactly what makes it memorable."* Do not argue the fact. Change what it means.
+
+**4. Come back with a boomerang.** Repeat their objection, then use it as the reason to buy: *"You're right, you are busy — that's exactly why this saves you five hours a week."*
+
+**5. Show empathy with feel, felt, found.** *"I understand how you feel. Other customers felt the same way. But once they got started, they found [the actual outcome]."* Validate, normalize, resolve.
+
+:::tip Try it now
+Pick an objection you heard this week. Run it through LAIR out loud — what would Listen, Acknowledge, Identify, and Redirect actually sound like for that exact conversation? Then pick one of the five bounce-back techniques you did not use in the moment and rewrite your response with it.
+:::
+
+## What you now have
+
+- The LAIR sequence for working through any objection, in order
+- What each of the five most common objections actually means, and a specific move for each
+- Five bounce-back techniques to combine with the above
+- The reframe that makes all of it work: an objection is a request for information, not a closed door
+
+<SectionFeedback courseId="handle-objections" site="vendasta_learn" section="content" />
+
+<KnowledgeCheck courseId="handle-objections" site="vendasta_learn"
+  sessionSize={5}
+  intro="Five questions on reading an objection correctly and answering it well."
+  questions={[
+    {
+      type: 'mcq',
+      question: 'What does an objection most often actually signal?',
+      options: [
+        'The deal is dead',
+        'A request for more information, an unmet need, or an unaddressed concern',
+        'The prospect is lying to end the conversation',
+        'You made a mistake in your presentation'
+      ],
+      correctIndex: 1,
+      explanation: 'Objections are rarely a hard no. They are the prospect telling you where the gap is, if you listen for it.'
+    },
+    {
+      type: 'mcq',
+      question: 'In the LAIR sequence, what should you do before redirecting to your solution?',
+      options: [
+        'Offer an immediate discount',
+        'Respond first with a question, not an answer',
+        'Restate your unique selling proposition',
+        'Change the subject'
+      ],
+      correctIndex: 1,
+      explanation: 'A prospect in a defensive posture will not absorb your solution. Respond with a question first to get them out of that mode, then redirect.'
+    },
+    {
+      type: 'mcq',
+      question: 'A prospect says "I can find this cheaper somewhere else." What does this lesson say NOT to do?',
+      options: [
+        'Offer social proof from other customers',
+        'Break the cost into smaller units',
+        'Immediately offer a discount',
+        'Explain the long-term savings'
+      ],
+      correctIndex: 2,
+      explanation: 'A quick discount confirms the prospect\'s suspicion that the original price was not justified. It undercuts the value case instead of making it.'
+    },
+    {
+      type: 'mcq',
+      question: 'A prospect mentions they already use a competitor. Why does this lesson call that good news?',
+      options: [
+        'It means the deal is definitely lost',
+        'They already believe they need what you sell — they just need convincing it should come from you',
+        'It means they have a bigger budget than expected',
+        'The competitor will refer business to you'
+      ],
+      correctIndex: 1,
+      explanation: 'The hardest sale is convincing someone they need the category at all. A prospect using a competitor has already made that decision, so the remaining task is smaller.'
+    },
+    {
+      type: 'truefalse',
+      statement: 'If you suspect a prospect is not being fully honest about an authority objection, you should challenge them on it directly.',
+      correct: false,
+      explanation: 'Challenging it creates conflict without moving the deal forward. Keep the process moving instead — propose the joint meeting, or offer something they can share.'
+    },
+    {
+      type: 'match',
+      instruction: 'Match each common objection to what it usually means underneath.',
+      pairs: [
+        { term: 'Price', definition: 'They do not see the value yet' },
+        { term: 'Authority', definition: 'They do not feel comfortable deciding alone' },
+        { term: 'Trust', definition: 'They are skeptical of your reputation and need proof' },
+        { term: 'Complacency', definition: 'The status quo feels fine, so this is not urgent' }
+      ],
+      explanation: 'Each objection points at a different gap. Answering the surface words instead of the underlying gap is why rebuttals bounce off.'
+    },
+    {
+      type: 'fillblank',
+      principle: 'The three steps of the empathy technique are feel, felt, and ___.',
+      before: '',
+      answer: 'found',
+      after: '',
+      hint: 'what other customers discovered',
+      explanation: 'Feel, felt, found: validate the feeling, normalize it by sharing that others felt the same, then resolve it with what those others found.'
+    }
+  ]}
+/>
+
+<LessonFooter to="/learn/sales/close-and-open-the-relationship" pathName="How to sell" step={5} totalSteps={9} />
+
+</InlineHighlighter>
+<MarkComplete courseId="handle-objections" site="vendasta_learn" />

--- a/docusaurus/training/sales/index.mdx
+++ b/docusaurus/training/sales/index.mdx
@@ -1,0 +1,65 @@
+---
+title: How to sell
+sidebar_position: 0
+sidebar_label: Overview
+description: "The rep's arc from finding a prospect to closing and growing the relationship: prospecting, pitching, discovery, presenting, objections, closing, social selling, consulting, and running your sales day."
+hide_table_of_contents: true
+sidebar_class_name: hide-from-sidebar
+---
+
+import PathRoadmap from "@site/src/components/PathRoadmap";
+
+{/* Draft path, staged ahead of Cal's sixth-path IA sign-off (per proj-010). hide-from-sidebar on this
+    category and every lesson below keeps it off the live nav until that approval lands. */}
+
+This path follows one rep's arc: finding a prospect, opening the conversation, running a discovery call that earns the right to present, presenting so it lands, handling objections without flinching, closing and opening the relationship, selling socially, consulting instead of just pitching, and building the habits that make it repeatable.
+
+<PathRoadmap
+  steps={[
+    {
+      title: "Find your next prospect",
+      description: "Build a pipeline instead of waiting for one to show up.",
+      to: "/learn/sales/find-your-next-prospect",
+    },
+    {
+      title: "Open the conversation",
+      description: "Earn 30 seconds, then earn the meeting.",
+      to: "/learn/sales/open-the-conversation",
+    },
+    {
+      title: "Run a discovery call that actually discovers something",
+      description: "Ask the questions that tell you whether to keep going.",
+      to: "/learn/sales/run-a-discovery-call",
+    },
+    {
+      title: "Present so it lands",
+      description: "Insights, deliverables, value, and the ask, in that order.",
+      to: "/learn/sales/present-so-it-lands",
+    },
+    {
+      title: "Handle objections without flinching",
+      description: "The five objections you will hear most, and what to say back.",
+      to: "/learn/sales/handle-objections",
+    },
+    {
+      title: "Close, then open the relationship",
+      description: "The close is the beginning of the account, not the end of the sale.",
+      to: "/learn/sales/close-and-open-the-relationship",
+    },
+    {
+      title: "Sell socially",
+      description: "Turn LinkedIn into a prospecting channel, not a resume.",
+      to: "/learn/sales/sell-socially",
+    },
+    {
+      title: "Consult, don't just pitch",
+      description: "The questions that make a prospect trust your recommendation.",
+      to: "/learn/sales/consult-dont-just-pitch",
+    },
+    {
+      title: "Build your brand and run your sales day like a pro",
+      description: "The habits and positioning that make the other eight steps repeatable.",
+      to: "/learn/sales/build-your-brand-and-your-day",
+    },
+  ]}
+/>

--- a/docusaurus/training/sales/open-the-conversation.mdx
+++ b/docusaurus/training/sales/open-the-conversation.mdx
@@ -1,0 +1,169 @@
+---
+title: "Open the conversation"
+sidebar_position: 2
+description: "Earn 30 seconds, then earn the meeting."
+sidebar_class_name: hide-from-sidebar
+---
+
+import KnowledgeCheck from "@site/src/components/KnowledgeCheck";
+import CourseProgressBar from "@site/src/components/CourseProgressBar";
+import SectionFeedback from "@site/src/components/SectionFeedback";
+import InlineHighlighter from "@site/src/components/InlineHighlighter";
+import MarkComplete from "@site/src/components/MarkComplete";
+import LessonHeader from "@site/src/components/LessonHeader";
+import LessonFooter from "@site/src/components/LessonFooter";
+import FlipCard, { FlipCardGrid } from "@site/src/components/FlipCard";
+
+<InlineHighlighter courseId="open-the-conversation" site="vendasta_learn">
+
+<CourseProgressBar courseId="open-the-conversation" site="vendasta_learn" />
+
+{/* VIDEO SLOT: "Ep. 3: The Perfect Elevator Pitch" (Master Sales Training Series, Wistia,
+    keep-as-is verdict — talking-head, no product UI). No embed ID recorded: proj-009 catalogued
+    the Wistia library by title, and this clip is not in the 360Learning export that carries IDs.
+    Look it up in the vendasta-1 Wistia account by title. A near-duplicate cut exists as "Master
+    the Elevator Pitch" — use the Ep. 3 cut, it carries the fuller story. */}
+
+<LessonHeader
+  difficulty="Beginner"
+  time="about 12 minutes"
+  required={["A prospect to call (Lesson 1's endpoint)"]}
+  video={true}
+  pathName="How to sell"
+  step={2}
+  totalSteps={9}
+  outcomes={[
+    "Explain what an elevator pitch is actually for, and what it is not",
+    "Build a pitch in four parts: goal, plain-language value, your edge, a question",
+    "Cut a pitch down until it survives the three-floor test",
+    "Rehearse a pitch the way that makes it hold up in a real room",
+  ]}
+/>
+
+## An elevator pitch does not close anything
+
+Picture this: you are on a plane, and the person who just sat down next to you turns out to be the exact prospect you have been trying to reach for months. You have until they put their headphones on. What do you say?
+
+Most reps freeze here because they think the job of that moment is to win the deal. It is not. An elevator pitch has one job: deliver enough value that the other person wants to keep talking. That is it. If you walk into that moment thinking you need a signature in ninety seconds, you have already lost the room.
+
+## Build it in four parts
+
+**1. Identify the goal.** Before you write a word, decide what you want the listener to take away. Not "impress them" — a specific next step: a follow-up call, a meeting, a "tell me more."
+
+**2. Say what you do in as few words as possible.** Test this literally: get in an elevator, press a button three floors up, and explain your value proposition before the doors open. If you need more than three floors, you do not have a pitch yet. You have a speech.
+
+**3. Name your unique selling proposition.** What do you do that the person sitting across the aisle from you cannot also claim? This is the part you back up with a real result, not an adjective.
+
+**4. Ask a question.** Do not end on a statement. End on something that pulls them into the next exchange: *"Does that sound like a problem you are dealing with right now?"* A pitch with no question is a monologue with a deadline.
+
+<FlipCardGrid>
+  <FlipCard front="The goal" back="A specific next step — a call, a meeting, a 'tell me more'. Not 'impress them'." subtext="Part 1" />
+  <FlipCard front="Three floors" back="If your value proposition needs more than three floors, it is a speech, not a pitch." subtext="Part 2" />
+  <FlipCard front="The question" back="End on a question. A pitch with no question is a monologue with a deadline." subtext="Part 4" />
+</FlipCardGrid>
+
+## Edit it until it survives contact
+
+The first version of your pitch is never the one you use. Say it out loud, cut what does not earn its place, say it again.
+
+Practise to a mirror if you need somewhere to start, but the practice that actually sharpens a pitch is the uncomfortable kind: saying it in front of a peer, a manager, or a real prospect and watching their face when something does not land. Junior reps skip this step because it is awkward. It is also the only way you find out your pitch is confusing before a prospect tells you by walking away.
+
+A useful test: if the person on the other end of your pitch looks *more* confused at the end than they did at the start, you do not have a good pitch. You have a bad one that happens to be short.
+
+## The Fort Worth story
+
+Years ago, a seller was pitching a newspaper organization that had built its entire business on selling print advertising — and had no reason, in their own minds, to change. They did not open with "you need digital marketing." They opened with the thing the room already cared about:
+
+> "You have sold a lot of advertising. I have too. And one thing we both know is that the advertising you sell is coming under attack — the client's first comment on the next call is always 'it isn't working like it used to.' It's not your ad that's the problem. It's that they've got broken listings, bad reviews, and a website that takes forever to load. What if the thing you sell could work better, because their virtual doorway finally matches the ad that sent someone looking for it?"
+
+That pitch did not ask anyone to abandon what they were good at. It named a pain they already felt — advertising getting blamed for problems it did not cause — and pointed at a fix that made their existing product stronger instead of replacing it. Five years later, people who were in that room were still using a version of that same pitch on their own prospects.
+
+The lesson underneath the story: **the best elevator pitches do not introduce a new problem. They reframe a problem the prospect is already living with.**
+
+## You need more than one
+
+If you sell more than one thing, you need more than one pitch — one per audience, one per problem you solve. A rep with a single generic elevator pitch for every prospect is a rep who has not done the work yet.
+
+:::tip Try it now
+Pick your next prospect. Write your pitch in four lines: the goal, the value in one sentence, your edge, and the question. Say it out loud. If it takes longer than three floors, cut it and say it again.
+:::
+
+## What you now have
+
+- A four-part structure for building any elevator pitch: goal, value, edge, question
+- The three-floor test for whether a pitch is actually short enough
+- A model for reframing an existing pain instead of inventing a new one
+- The habit of rehearsing out loud, in front of someone who will tell you when it does not land
+
+<SectionFeedback courseId="open-the-conversation" site="vendasta_learn" section="content" />
+
+<KnowledgeCheck courseId="open-the-conversation" site="vendasta_learn"
+  sessionSize={4}
+  intro="Four questions on what a pitch is for, and how to cut one down."
+  questions={[
+    {
+      type: 'mcq',
+      question: 'What is an elevator pitch actually supposed to accomplish?',
+      options: [
+        'Close the deal on the spot',
+        'Move the conversation to a next step',
+        'List every feature of your product',
+        'Establish your credentials'
+      ],
+      correctIndex: 1,
+      explanation: 'A pitch that tries to close instead of open usually does neither. It is designed to earn the next conversation.'
+    },
+    {
+      type: 'mcq',
+      question: 'What does the three-floor test check for?',
+      options: [
+        'Whether your pitch is memorable',
+        'Whether your pitch is short enough to deliver before the moment passes',
+        'Whether your pitch mentions your competitors',
+        'Whether your pitch includes a price'
+      ],
+      correctIndex: 1,
+      explanation: 'If you cannot deliver your value proposition in the time an elevator passes three floors, it is not an elevator pitch. It is a speech.'
+    },
+    {
+      type: 'mcq',
+      question: 'In the Fort Worth story, why did the pitch land with a room of lifelong advertising salespeople?',
+      options: [
+        'It offered them a steep discount on a new product',
+        'It reframed a problem they already had, instead of introducing a new one',
+        'It criticized their existing sales approach directly',
+        'It focused on the seller\'s company history'
+      ],
+      correctIndex: 1,
+      explanation: 'The pitch tied straight into a pain the room already felt — ads getting blamed for problems the ads did not cause — rather than asking them to accept a brand new problem.'
+    },
+    {
+      type: 'truefalse',
+      statement: 'If you sell several different things, one strong general-purpose elevator pitch is enough.',
+      correct: false,
+      explanation: 'One pitch per audience, one per problem you solve. A single generic pitch signals you have not done the work of understanding who you are talking to.'
+    },
+    {
+      type: 'match',
+      instruction: 'Match each part of the four-part pitch to what it does.',
+      pairs: [
+        { term: 'The goal', definition: 'Decide the specific next step you want' },
+        { term: 'The value', definition: 'Say what you do in as few words as possible' },
+        { term: 'Your edge', definition: 'Name what a competitor cannot also claim' },
+        { term: 'The question', definition: 'Pull them into the next exchange' }
+      ],
+      explanation: 'Goal, value, edge, question. Drop any one of the four and the pitch either rambles or dead-ends.'
+    },
+    {
+      type: 'truefalse',
+      statement: 'Practising a pitch alone in front of a mirror is the most effective way to sharpen it.',
+      correct: false,
+      explanation: 'The mirror is a starting point. The practice that actually sharpens a pitch is saying it to a peer, a manager, or a prospect and watching where their face says it did not land.'
+    }
+  ]}
+/>
+
+<LessonFooter to="/learn/sales/run-a-discovery-call" pathName="How to sell" step={2} totalSteps={9} />
+
+</InlineHighlighter>
+<MarkComplete courseId="open-the-conversation" site="vendasta_learn" />

--- a/docusaurus/training/sales/present-so-it-lands.mdx
+++ b/docusaurus/training/sales/present-so-it-lands.mdx
@@ -1,0 +1,177 @@
+---
+title: "Present so it lands"
+sidebar_position: 4
+description: "Structure a presentation around insights, deliverables, value, and the ask, so a discovery call turns into a decision."
+sidebar_class_name: hide-from-sidebar
+---
+
+import KnowledgeCheck from "@site/src/components/KnowledgeCheck";
+import CourseProgressBar from "@site/src/components/CourseProgressBar";
+import SectionFeedback from "@site/src/components/SectionFeedback";
+import InlineHighlighter from "@site/src/components/InlineHighlighter";
+import MarkComplete from "@site/src/components/MarkComplete";
+import LessonHeader from "@site/src/components/LessonHeader";
+import LessonFooter from "@site/src/components/LessonFooter";
+import FlipCard, { FlipCardGrid } from "@site/src/components/FlipCard";
+
+<InlineHighlighter courseId="present-so-it-lands" site="vendasta_learn">
+
+<CourseProgressBar courseId="present-so-it-lands" site="vendasta_learn" />
+
+{/* VIDEO SLOT: source candidate is "Deliver Impact: The Art of Killer Sales Presentations"
+    (360Learning, already audited) — clip pending Workstream A's product-accuracy pass. Per the
+    IA spec (section 6), video is optional and never blocks shipping the text below. */}
+
+<LessonHeader
+  difficulty="Intermediate"
+  time="about 8 minutes"
+  required={["A discovery call already run on this prospect"]}
+  video={true}
+  pathName="How to sell"
+  step={4}
+  totalSteps={9}
+  outcomes={[
+    "Structure a presentation around insights, deliverables, value, and the ask, in that order",
+    "Know exactly where to make the ask, and say it with confidence instead of apology",
+    "Decide what belongs in the appendix instead of the main pitch",
+    "Reuse three ready-made lines for opening, asking, and answering a maybe",
+  ]}
+/>
+
+## A presentation is not a recap
+
+You already ran the discovery call. You know the gaps, you know what the prospect said mattered, and now you are back in front of them with a plan. The mistake at this stage is treating the presentation like a summary of everything you found. A summary is an audit, and nobody signs an audit. A presentation is four moves, always in the same order: show them you listened, tell them what changes, prove it is worth it, and ask.
+
+## Open with what you heard, not what you sell
+
+Start the meeting with the specific things the prospect told you, not with your product. If a landscaping company's owner told you on the discovery call that half her quote requests never get a follow-up, that line opens the presentation:
+
+> "You told me last week that quote requests go cold if nobody follows up within a day. That's the first thing we built this plan around."
+
+This is the insight move, and it does one job: it proves you were listening. A generic opener ("Here's what we do for businesses like yours") sounds like every rep before you. A specific callback sounds like a plan built for this prospect, because it is.
+
+## Say what changes, not what you install
+
+Once they know you listened, tell them what changes for their business. Keep this at the level of outcomes, not features. "We'll set up automated follow-up on every quote request within one hour" is a deliverable. "We'll configure a CRM automation with a conditional trigger on lead status" is a feature tour, and feature tours are for the appendix, not the main pitch.
+
+A useful test: if the sentence describes a click path, it belongs in the appendix. If it describes a change the owner will notice in their business, it belongs here.
+
+## Prove it is worth it before they have to ask
+
+Every owner is running the same math in their head: will this pay for itself. Answer that before they ask instead of after:
+
+> "We'll track quote-to-close rate monthly, and I'll show you the before-and-after myself. If follow-up is really costing you jobs, you'll see it move within the first month."
+
+Naming how you will measure it, and when you will show up with the number, turns "trust me" into a plan the owner can check.
+
+## Make the ask, out loud, in this section
+
+Here is the part most reps flinch on: you have to actually ask for the business, and you have to do it here, not bury it in a follow-up email. After insights, deliverables, and value, say the plan and ask for the yes:
+
+> "That's the plan: automated follow-up, a monthly report on quote-to-close, and I'll be your point of contact the whole way. Can we get you started this week?"
+
+Confidence here is not about volume, it is about not softening the ask into a question about whether you should be asking. You did the discovery, you built the plan around what they told you, and this is the moment it was all leading to.
+
+<FlipCardGrid>
+  <FlipCard front="Insight" back="Open with a specific thing they told you on the discovery call. Proves you listened." subtext="Move 1" />
+  <FlipCard front="Deliverable + value" back="Say what changes for their business, then how you will measure it." subtext="Moves 2–3" />
+  <FlipCard front="The ask" back="Out loud, in the room, right after value. Not in a follow-up email." subtext="Move 4" />
+</FlipCardGrid>
+
+## Everything you are not sure about goes in the appendix
+
+Not every capability belongs in the main story. If a feature might matter to this prospect but you are not certain, do not build the main pitch around a maybe, and do not cut it either. Put it in an appendix and mention that it is there:
+
+> "There's a webchat feature that might be a fit for you too. I've put a page on it at the back in case you want to look at it, but I didn't want to build our whole conversation around something you haven't seen yet."
+
+This keeps the main pitch tight and confident, and it still lets a curious owner go looking without you guessing wrong about what they care about.
+
+:::tip Try it now
+Take the plan you would present to your next prospect and write one sentence for each move: the insight you heard from them, the deliverable, how you will prove it worked, and the exact words you will use to ask. Say the ask out loud before the meeting. If it sounds like a question about whether you should ask, rewrite it.
+:::
+
+## What you now have
+
+- A four-part structure that turns a discovery call into a decision: insight, deliverable, value, ask
+- A test for what belongs in the main pitch versus the appendix: outcomes here, click paths and maybes there
+- Three lines you can adapt word for word: the insight callback, the value proof, and the ask
+- The habit of asking out loud, in the room, instead of hoping the follow-up email does it for you
+
+{/* No "do it, delegate it, or buy it" block here: this lesson teaches a rep's own presentation skill,
+    and there is no Vendasta Services equivalent to delegate a sales conversation to. */}
+
+<SectionFeedback courseId="present-so-it-lands" site="vendasta_learn" section="content" />
+
+<KnowledgeCheck courseId="present-so-it-lands" site="vendasta_learn"
+  sessionSize={4}
+  intro="Four quick questions on structure, what goes where, and making the ask."
+  questions={[
+    {
+      type: 'mcq',
+      question: 'You are opening a presentation. What is the strongest first move?',
+      options: [
+        'A quick overview of everything your product does',
+        'A specific callback to something the prospect told you on the discovery call',
+        'A list of similar clients you have helped',
+        'A question about their budget'
+      ],
+      correctIndex: 1,
+      explanation: 'Opening with a specific detail from the discovery call proves you listened. A generic overview sounds like the same pitch every prospect has already heard.'
+    },
+    {
+      type: 'mcq',
+      question: 'A sentence in your draft presentation describes exactly which buttons the owner will click to set up a feature. Where does it belong?',
+      options: [
+        'The opening insight',
+        'The main deliverables section',
+        'The appendix',
+        'It should be cut entirely'
+      ],
+      correctIndex: 2,
+      explanation: 'Click paths and feature walkthroughs are appendix material. The main pitch stays at the level of outcomes the owner will notice, not the steps that produce them.'
+    },
+    {
+      type: 'mcq',
+      question: 'Where in the flow should you actually ask for the business?',
+      options: [
+        'In a follow-up email after the meeting',
+        'At the very start, before you explain anything',
+        'Right after insights, deliverables, and value, in the same meeting',
+        'Only after the prospect asks about price'
+      ],
+      correctIndex: 2,
+      explanation: 'The ask belongs in the tactics section of the same meeting, after you have shown you listened, said what changes, and proven it is worth it. Waiting for an email loses the momentum you just built.'
+    },
+    {
+      type: 'truefalse',
+      statement: 'A feature you are not sure will matter to this prospect should be left out of the presentation entirely.',
+      correct: false,
+      explanation: 'Leave it in, just not in the main story. Put it in an appendix and mention it is there, so a curious owner can look without you guessing wrong about what they care about.'
+    },
+    {
+      type: 'match',
+      instruction: 'Match each of the four presentation moves to what it does.',
+      pairs: [
+        { term: 'Insight', definition: 'Prove you listened, using their own words' },
+        { term: 'Deliverable', definition: 'Say what changes for their business' },
+        { term: 'Value', definition: 'Show how you will measure it, and when' },
+        { term: 'The ask', definition: 'Request the business, out loud, in the room' }
+      ],
+      explanation: 'Always in that order. Each move earns the right to make the next one.'
+    },
+    {
+      type: 'fillblank',
+      principle: 'A useful test: if the sentence describes a click path, it belongs in the ___.',
+      before: '',
+      answer: 'appendix',
+      after: '',
+      hint: 'the back of the deck',
+      explanation: 'The main pitch stays at the level of outcomes the owner will notice. Click paths and feature tours go in the appendix.'
+    }
+  ]}
+/>
+
+<LessonFooter to="/learn/sales/handle-objections" pathName="How to sell" step={4} totalSteps={9} />
+
+</InlineHighlighter>
+<MarkComplete courseId="present-so-it-lands" site="vendasta_learn" />

--- a/docusaurus/training/sales/run-a-discovery-call.mdx
+++ b/docusaurus/training/sales/run-a-discovery-call.mdx
@@ -1,0 +1,197 @@
+---
+title: "Run a discovery call that actually discovers something"
+sidebar_position: 3
+description: "Ask the questions that tell you whether to keep going."
+sidebar_class_name: hide-from-sidebar
+---
+
+import KnowledgeCheck from "@site/src/components/KnowledgeCheck";
+import CourseProgressBar from "@site/src/components/CourseProgressBar";
+import SectionFeedback from "@site/src/components/SectionFeedback";
+import InlineHighlighter from "@site/src/components/InlineHighlighter";
+import MarkComplete from "@site/src/components/MarkComplete";
+import LessonHeader from "@site/src/components/LessonHeader";
+import LessonFooter from "@site/src/components/LessonFooter";
+import FlipCard, { FlipCardGrid } from "@site/src/components/FlipCard";
+
+<InlineHighlighter courseId="run-a-discovery-call" site="vendasta_learn">
+
+<CourseProgressBar courseId="run-a-discovery-call" site="vendasta_learn" />
+
+{/* VIDEO SLOT: two candidates, neither with a confirmed embed ID.
+    1. "Insights Based Selling" (Wistia, keep-as-is) — the philosophy half. Catalogued by title in
+       proj-009; no ID recorded, look it up in the vendasta-1 Wistia account.
+    2. The "Selling Local" webinar — the 1-2-3 process and Double Diamond mechanics. External
+       webinar recording, not in Wistia, so it may need to be clipped and uploaded first.
+    Do NOT use the ID the 360Learning export lists against course 603 ("Perfecting the Discovery
+    Call", `lpdxav2w39`) — Shiva confirmed that ID actually resolves to "Better Prospecting". */}
+
+<LessonHeader
+  difficulty="Intermediate"
+  time="about 10 minutes"
+  required={["A discovery call booked (Lesson 2's endpoint)"]}
+  video={true}
+  pathName="How to sell"
+  step={3}
+  totalSteps={9}
+  outcomes={[
+    "Ask the three questions that surface the real problem instead of the one a prospect leads with",
+    "Prove you are listening by paraphrasing the problem back before you mention a solution",
+    "Match how deep you go to how complex the opportunity actually is",
+    "Know when to tell a prospect something does not fit, and why that earns trust",
+  ]}
+/>
+
+## Stop opening with the weather
+
+There used to be a rule in sales: spend the first fifteen or twenty minutes of a call on rapport. Ask about their weekend, their family, the weather.
+
+That rule is outdated. Business owners are busier than it assumes, and most of them can tell within the first minute whether you are going to waste their time. Get to why they are on the call, fast. That does not mean skipping rapport — it means proving you are listening a different way: paraphrase back what they just told you, in your own words, before you move on.
+
+> "So if I have got this right, the real issue is [X], and it is costing you [Y]. Is that a fair read?"
+
+That one sentence does more to build trust than twenty minutes of small talk, because it proves you were actually listening instead of waiting for your turn to talk.
+
+## The three questions that do most of the work
+
+You do not need a long list of discovery questions. Three, asked in order, uncover almost everything you need:
+
+> "What's on your mind?"
+>
+> "And what else?"
+>
+> "So what's the real challenge here?"
+
+**"And what else?" is the one reps skip, and it is the one that matters most.** The first answer a prospect gives is rarely the whole picture — it is the thing that was easiest to say out loud. Asking "what else" once, sometimes twice, is what gets you from the surface complaint to the actual problem.
+
+Once you are there, two follow-ups keep the conversation useful instead of just diagnostic:
+
+> "What would solving this actually mean for your business?"
+>
+> "What can I do to help you move forward?"
+
+<FlipCardGrid>
+  <FlipCard front="What's on your mind?" back="Opens the call on their agenda, not yours." subtext="Question 1" />
+  <FlipCard front="And what else?" back="The one reps skip. Gets you past the easiest answer to the real one." subtext="Question 2" />
+  <FlipCard front="What's the real challenge?" back="Names the problem you will actually be solving for." subtext="Question 3" />
+</FlipCardGrid>
+
+## Discover, then define
+
+Treat discovery as two separate moves, not one.
+
+First you **discover**: you ask, and you listen, without jumping to a solution. Then you **define**: you say back what you heard and get the prospect to confirm you understood the real challenge correctly, not just the first thing they mentioned. Only after they have said "yes, that's it" should the conversation move toward what you would recommend.
+
+Skipping straight from discover to a pitch is how you end up solving the wrong problem confidently.
+
+## Come in with some idea of where they stand
+
+You should not walk into a discovery call with a blank page. Before the call, pull what you can — a Snapshot Report gives you a starting read across listings, reviews, social, website, SEO, and advertising, so you already have a hypothesis about where the gaps probably are.
+
+During the call, cover the ground a good discovery conversation always covers, in whatever order the conversation naturally goes:
+
+- Their business, their team, and what they actually sell
+- What they are already using to do the job today
+- Where that is falling short — the challenge, in their words
+- How much they already know about what you could offer
+
+The report gives you a hypothesis. The call is still where you find out if the hypothesis is right. Do not read the report *at* them instead of asking questions.
+
+## Tell them when something does not fit
+
+Here is the part that feels counterintuitive: the strongest trust move in a discovery call is sometimes telling a prospect that something does not fit them.
+
+If a solution genuinely is not going to help their specific situation, say so. It costs you a possible add-on in the moment, and it buys you something worth more — proof that you are solving for their outcome, not your quota. A prospect who hears you say "that one's probably not worth it for you" believes you completely the next time you say something is.
+
+## Match your depth to the opportunity
+
+Not every call needs the same depth of questioning.
+
+A prospect who already knows exactly what they want — a specific placement, a specific fix, no ambiguity — does not need you to challenge their thinking or dig for a hidden strategic problem. Give them fast, efficient service and respect that they have done their own discovery.
+
+A prospect who is trying to build a brand, break into a competitive market, or fix something they cannot quite name yet is a different conversation entirely, and that is where the three questions and the discover-then-define sequence earn their keep.
+
+Running every call the same way wastes effort on the simple ones and shortchanges the complex ones.
+
+:::tip Try it now
+On your next discovery call, use only the three questions above to start — nothing else prepared. When the prospect answers, paraphrase it back before you say anything else. Notice how much of the call you do not have to script once you have actually heard the real answer.
+:::
+
+## What you now have
+
+- Three questions that do most of the diagnostic work on any discovery call
+- A discover-then-define habit: listen, paraphrase, and only then recommend
+- A pre-call habit of pulling a Snapshot for a working hypothesis, without letting it replace the conversation
+- Permission to tell a prospect something does not fit, and the trust that earns you later
+- A way to decide how deep to go, based on the opportunity rather than a fixed script
+
+<SectionFeedback courseId="run-a-discovery-call" site="vendasta_learn" section="content" />
+
+<KnowledgeCheck courseId="run-a-discovery-call" site="vendasta_learn"
+  sessionSize={4}
+  intro="Four questions on getting past the first answer a prospect gives you."
+  questions={[
+    {
+      type: 'mcq',
+      question: 'Why does this lesson push back on spending the first fifteen minutes of a call on small talk?',
+      options: [
+        'Prospects find small talk unprofessional',
+        'Business owners are busy, and proving you listened builds trust faster than rapport time',
+        'It is against most sales policies',
+        'It makes the call run over the scheduled time'
+      ],
+      correctIndex: 1,
+      explanation: 'The lesson does not say skip rapport. It says prove you are listening by paraphrasing what they said, which builds trust faster than minutes spent on the weather.'
+    },
+    {
+      type: 'mcq',
+      question: 'A prospect answers your first discovery question with a surface-level complaint. What comes next?',
+      options: [
+        'Move straight to recommending a solution for that complaint',
+        'Ask "and what else?" to get past the easiest answer to the real one',
+        'End the call and follow up by email',
+        'Repeat the same question in different words'
+      ],
+      correctIndex: 1,
+      explanation: 'The first answer is usually the easiest thing to say out loud, not the full picture. "And what else" is what surfaces the real challenge underneath it.'
+    },
+    {
+      type: 'mcq',
+      question: 'What is the "define" step in the discover-then-define sequence?',
+      options: [
+        'Writing a formal problem statement for internal records',
+        'Paraphrasing back what you heard and getting the prospect to confirm you understood',
+        'Defining which product features you will pitch',
+        'Setting a deadline for the prospect to decide'
+      ],
+      correctIndex: 1,
+      explanation: 'Define means confirming your understanding is right before you move toward a recommendation. Skipping it risks solving the wrong problem confidently.'
+    },
+    {
+      type: 'truefalse',
+      statement: 'A prospect who already knows exactly what they want should get the same deep, challenging discovery treatment as one trying to break into a competitive market.',
+      correct: false,
+      explanation: 'Match depth to the opportunity. A prospect with a clear, simple need is better served by fast, efficient service than a deep strategic conversation they did not ask for.'
+    },
+    {
+      type: 'truefalse',
+      statement: 'Telling a prospect that one of your solutions is not a good fit for them damages your credibility.',
+      correct: false,
+      explanation: 'It does the opposite. Naming what does not fit proves you are solving for their outcome rather than your quota, which makes them believe you the next time you say something does fit.'
+    },
+    {
+      type: 'fillblank',
+      principle: 'Before recommending anything, paraphrase the problem back and get the prospect to ___ that you understood it correctly.',
+      before: '',
+      answer: 'confirm',
+      after: '',
+      hint: 'verb',
+      explanation: 'Confirmation is the whole point of the define step — without it you are guessing that you heard right.'
+    }
+  ]}
+/>
+
+<LessonFooter to="/learn/sales/present-so-it-lands" pathName="How to sell" step={3} totalSteps={9} />
+
+</InlineHighlighter>
+<MarkComplete courseId="run-a-discovery-call" site="vendasta_learn" />

--- a/docusaurus/training/sales/sell-socially.mdx
+++ b/docusaurus/training/sales/sell-socially.mdx
@@ -1,0 +1,185 @@
+---
+title: "Sell socially"
+sidebar_position: 7
+description: "Turn LinkedIn into a prospecting channel, not a resume."
+sidebar_class_name: hide-from-sidebar
+---
+
+import KnowledgeCheck from "@site/src/components/KnowledgeCheck";
+import CourseProgressBar from "@site/src/components/CourseProgressBar";
+import SectionFeedback from "@site/src/components/SectionFeedback";
+import InlineHighlighter from "@site/src/components/InlineHighlighter";
+import MarkComplete from "@site/src/components/MarkComplete";
+import LessonHeader from "@site/src/components/LessonHeader";
+import LessonFooter from "@site/src/components/LessonFooter";
+import FlipCard, { FlipCardGrid } from "@site/src/components/FlipCard";
+
+<InlineHighlighter courseId="sell-socially" site="vendasta_learn">
+
+<CourseProgressBar courseId="sell-socially" site="vendasta_learn" />
+
+{/* VIDEO SLOT: "How to Become a LinkedIn Ninja" (Wistia, ~21 min, keep-as-is verdict —
+    talking-head, no product UI). No embed ID recorded: proj-009 catalogued this clip by title
+    from the vendasta-1 Wistia account, and it is not in the 360Learning export that carries IDs.
+    Look it up by title.
+
+    Secondary option: the audited 360Learning course "Get Started with LinkedIn" (346) carries
+    embed ID `e7xf8v54en`, which is this lesson's primary text source. Verify in Wistia before
+    embedding — IDs in that export have proven unreliable. */}
+
+<LessonHeader
+  difficulty="Beginner"
+  time="about 9 minutes"
+  required={["None — this is a standing habit, start it anytime"]}
+  video={true}
+  pathName="How to sell"
+  step={7}
+  totalSteps={9}
+  outcomes={[
+    "Build a LinkedIn profile that reads like a business card, not a personal photo album",
+    "Use the Social Selling Index as a practical checklist instead of a vanity score",
+    "Spend 10 minutes before every meeting doing the research a prospect is already doing on you",
+    "Share content that builds your authority instead of broadcasting your job title",
+  ]}
+/>
+
+The first six lessons followed a single deal from first contact to signed order. These last three are different: they are the habits that make that cycle repeatable, so you are not starting from zero on every new prospect. This one is a standing habit — you can start it today, regardless of where any particular deal sits.
+
+## LinkedIn is your virtual business card, not your photo album
+
+Treat your profile like the first thing a prospect sees about you, because it usually is. Five things matter more than the rest:
+
+- **A professional photo.** Not the beach photo with your dog — save that for other platforms.
+- **A banner** that matches your brand, or highlights a recent accomplishment.
+- **A headline that reads like a business card.** "VP of Sales, Riverside Marketing" beats "Thinker. Change agent."
+- **A filled-in featured section** linking to your best work.
+- **At least one recommendation** from someone who has actually worked with you.
+
+Most people skip the featured section. Do not be most people.
+
+## The score that tells you if you are actually doing this
+
+LinkedIn's Social Selling Index is not a vanity number — treat it as a checklist. It scores four things:
+
+1. How complete and active your personal brand is
+2. How well you are finding the right people to connect with
+3. How often you engage with insight — actual comments and shares that add something, not just likes
+4. How strong your relationships are getting over time
+
+If your score is low, it is not a mystery why. It is telling you which of those four you are skipping.
+
+<FlipCardGrid>
+  <FlipCard front="Personal brand" back="Complete the profile, publish things worth reading." subtext="SSI pillar 1" />
+  <FlipCard front="Find & engage" back="Use search to reach the right people, then engage with insight rather than likes." subtext="SSI pillars 2–3" />
+  <FlipCard front="Build relationships" back="Depth over volume. The score rewards relationships that actually develop." subtext="SSI pillar 4" />
+</FlipCardGrid>
+
+## Write a headline and summary that make someone care
+
+Two pieces of your profile do more work than people expect.
+
+**Your headline** should say what you do and why someone should care, not just your title. "Helping local businesses fix the gaps in their online presence" tells a prospect more than "Account Executive" does.
+
+**Your summary** should tell a short story, not list your resume. If writing is not your strength, this is worth getting help on — it is one of the highest-leverage 200 words on your whole profile.
+
+Below that, your work experience is what a skeptical prospect checks first: how long you have been doing this, what you have actually done, whether they recognize the companies. And if you claim a skill, get it endorsed. A profile that says "SEO expert" with zero endorsements for SEO reads as a claim nobody was willing to back up.
+
+## Research them, because they are already researching you
+
+Spend 10 minutes on LinkedIn before every meeting: check who you are meeting, what they post about, what you have in common. That is the habit most reps already know they should build.
+
+Here is the half people forget: **the prospect is very likely doing exactly the same thing to you, before the same meeting.** A thin or outdated profile does not just fail to help you — it actively costs you credibility before you have said a word. Treat your own profile as part of your prep, not a setup task you finished two years ago.
+
+## Share content that makes you look like the expert, not the salesperson
+
+Make LinkedIn part of your daily routine rather than a once-a-quarter chore: check connection requests, comment on a couple of posts, share one useful thing.
+
+The content that performs best is the content that helps people learn — not another announcement about your product. One way to do this without writing from scratch every time: when you read something genuinely good from a source your network already trusts, share it with two or three sentences of your own take up front.
+
+You do not need to be the original author to look like the person who finds and understands the good stuff first, and it is a far easier habit to sustain than always creating from a blank page.
+
+:::tip Try it now
+Open your own LinkedIn profile and check three things: does your headline say what you do and why someone should care, is your featured section filled in, and do your top two claimed skills actually have endorsements? Fix whichever is weakest today.
+:::
+
+## What you now have
+
+- A profile checklist: photo, banner, headline, summary, work experience, endorsements, featured content
+- A practical reading of the Social Selling Index as a to-do list rather than a score to feel bad about
+- The habit of 10 minutes of research before every meeting, knowing the prospect is doing the same to you
+- A repeatable way to build authority without writing something new every single day
+
+<SectionFeedback courseId="sell-socially" site="vendasta_learn" section="content" />
+
+<KnowledgeCheck courseId="sell-socially" site="vendasta_learn"
+  sessionSize={4}
+  intro="Four questions on making a profile work as a sales asset."
+  questions={[
+    {
+      type: 'mcq',
+      question: 'Which profile section do most people skip that they should not?',
+      options: ['Their photo', 'Featured content', 'Their location', 'Their connection count'],
+      correctIndex: 1,
+      explanation: 'Featured content links to your best work and is the section most people leave empty. An easy, high-value fix.'
+    },
+    {
+      type: 'mcq',
+      question: 'What should the Social Selling Index actually be used for?',
+      options: [
+        'Comparing your score to competitors publicly',
+        'As a checklist of four specific things you are doing or skipping',
+        'Determining your sales commission',
+        'Nothing — it is only for LinkedIn\'s internal use'
+      ],
+      correctIndex: 1,
+      explanation: 'The four pillars — brand, finding people, engaging with insight, building relationships — point directly at what to fix when the score is low.'
+    },
+    {
+      type: 'mcq',
+      question: 'Why does the lesson say to keep your own profile current, not just research the prospect?',
+      options: [
+        'LinkedIn requires activity to keep an account open',
+        'The prospect is very likely researching you too, so a thin profile costs you credibility before the meeting starts',
+        'Only relevant for prospects who ask about your background',
+        'Recruiters expect it'
+      ],
+      correctIndex: 1,
+      explanation: 'Research runs both directions. The prep habit only protects you if your own profile holds up to the same scrutiny.'
+    },
+    {
+      type: 'truefalse',
+      statement: 'The most effective way to build authority on LinkedIn is to only ever post original content you wrote yourself.',
+      correct: false,
+      explanation: 'Sharing a trusted source\'s content with your own short take is a sustainable way to look like the person who finds and understands the good stuff. You do not need to originate everything.'
+    },
+    {
+      type: 'sort',
+      instruction: 'Sort each item into whether it belongs to your profile setup or your ongoing weekly habit.',
+      items: [
+        { label: 'Professional headshot and banner', correctBucket: 'profile' },
+        { label: 'Commenting on a prospect\'s post', correctBucket: 'habit' },
+        { label: 'Featured content links', correctBucket: 'profile' },
+        { label: '10 minutes of research before a meeting', correctBucket: 'habit' }
+      ],
+      buckets: [
+        { id: 'profile', label: 'Profile setup' },
+        { id: 'habit', label: 'Ongoing habit' }
+      ],
+      explanation: 'Setup is mostly one-time with occasional refreshes. The habit is what actually generates conversations.'
+    },
+    {
+      type: 'fillblank',
+      principle: 'Your headline should say what you do and why someone should ___.',
+      before: '',
+      answer: 'care',
+      after: '',
+      hint: 'the reader\'s motivation',
+      explanation: 'A title states a fact. A headline that answers "why should I care" is what earns the profile visit that follows.'
+    }
+  ]}
+/>
+
+<LessonFooter to="/learn/sales/consult-dont-just-pitch" pathName="How to sell" step={7} totalSteps={9} />
+
+</InlineHighlighter>
+<MarkComplete courseId="sell-socially" site="vendasta_learn" />


### PR DESCRIPTION
Stands up the new partner-facing Sales path at docusaurus/training/sales/, covering a rep's arc from finding a prospect through closing and growing the relationship. This is the second of DOC-829's two acceptance criteria; the Growth Engine video embeds (the first) are not part of this change.

Content is sourced from the keep/refresh verdicts in the DOC-828 repurpose map (enablement-docs proj-009): the George Leith Wistia library plus the sales-related 360Learning course exports.

The path ships hidden. hide-from-sidebar is set on _category_.json and on every lesson, so nothing appears on the live nav until the sixth-path IA sign-off lands — learn-tab-ia-spec.md does not yet define a Sales path.

Each lesson carries:
- LessonHeader with outcomes, difficulty, time and prerequisite
- a 3-card FlipCardGrid (held to 3 deliberately; FlipCardGrid silently truncates past the third card)
- a KnowledgeCheck whose question bank is larger than its session size, so retakes draw a different subset
- a VIDEO SLOT comment naming the intended clip and its Wistia embed ID where one is known

Video is not embedded. Per learn-tab-ia-spec.md section 6 video never blocks shipping text, and no video-embed component exists in the codebase yet. The slot comments also carry a warning that Wistia embed IDs in the 360Learning export are unreliable — four mismatches or duplicates were confirmed — so every ID needs verifying against Wistia before use.

Verified with a local production build: 0 errors, all 10 pages generated, and no broken links or warnings originating from this path.


Claude-Session: https://claude.ai/code/session_01R1rPrrUPqXHs4tnxTRbPaz