### PR TITLE
Docs: timezone dropdown sort order (AUT-4527)

### DIFF
--- a/docusaurus/docs/automations/my-automations/creating-and-configuring-automations.mdx
+++ b/docusaurus/docs/automations/my-automations/creating-and-configuring-automations.mdx
@@ -50,7 +50,7 @@ Set your preferred timezone for time-based automation steps and scheduling. This
 - When **Delay** steps calculate their wait periods
 - How timestamps appear in the Activity tab
 
-To set the timezone, go to the automation's **Settings** tab and select **Timezone**.
+To set the timezone, go to the automation's **Settings** tab and select **Timezone**. Timezones in the list are sorted by UTC offset. Your browser-detected timezone appears at the top of the list for quick selection, in addition to its place in the full list.
 
 ### Goal
 


### PR DESCRIPTION
## JIRA
[AUT-4527](https://vendasta.jira.com/browse/AUT-4527) — "Dropdowns sort by UTC offset, and not alphabetically"

## Classification
UI/UX change — timezone dropdown sort order and default entry, on the automation Settings panel.

## Repo targeted
Partner Center (partner/reseller/agency-facing documentation)

## Summary of updates
Updated the existing "Timezone configuration" section in `creating-and-configuring-automations.mdx` to state that the timezone list sorts by UTC offset (not alphabetically) and that the browser-detected timezone appears pinned at the top of the list in addition to its normal place in the full list.

## Existing vs. new docs
Updated existing documentation — no new page created.

## Placement reasoning
`docusaurus/docs/automations/my-automations/creating-and-configuring-automations.mdx` already has a "Timezone configuration" section describing the same timezone selector this ticket changes. Adding the sort-order detail there keeps it next to the existing description rather than duplicating it in `time-based-triggers.mdx`, which only references the timezone setting without describing the selector UI. This mirrors the equivalent update made to the Business App repo's `automation-settings.md`, since the two repos carry near-duplicate phrasing for this feature.

## Acceptance criteria coverage
- "Sort by UTC offset, should not sort alphabetically" — covered
- "Consider showing the browser-identified timezone at the top of the list (duplicated)" — covered

## Figma/images
None provided or used; based on the ticket's text description and acceptance criteria only.

## Skills used
`pre-push-validation` (manual diff review — single-sentence addition, no frontmatter/tag/link changes)

## Assumptions and limitations
- The ticket's parent, [AUT-3908 "2026 sand items"](https://vendasta.jira.com/browse/AUT-3908), is a generic backlog/tech-debt epic (labels: `sand-items`, `tech-debt`) rather than a feature-rollout epic, and its status is "To Do." Its open children were scanned for gating signals (feature flags, eligibility/access-control, region restrictions); none found relevant to this specific change, so this is treated as already shipped per the story's own "Done" status.
- No reviewer was requested on this PR: GitHub access for this automation is scoped to the two docs repos only, so the engineering repo/PR that implemented AUT-4527 could not be looked up to identify the authoring developer.

@ahnikakuse @haleyserrano @maryam6samadi

---
_Generated by [Claude Code](https://claude.ai/code/session_012yZCwThmrLSARMgCeW83RS)_

[AUT-4527]: https://vendasta.jira.com/browse/AUT-4527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ