### PR TITLE
Instructional-design pass on the partner Sales path

### DIFF
--- a/docusaurus/src/components/ScriptExample.module.css
+++ b/docusaurus/src/components/ScriptExample.module.css
@@ -1,0 +1,35 @@
+.script {
+  margin: 1.5rem 0;
+  padding: 1rem 1.25rem;
+  background: var(--ifm-color-emphasis-100);
+  border-left: 4px solid var(--ifm-color-primary);
+  border-radius: 0 10px 10px 0;
+}
+
+.label {
+  display: block;
+  font-weight: 600;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--ifm-color-primary);
+  margin-bottom: 0.35rem;
+}
+
+.body {
+  line-height: 1.55;
+}
+
+/* Each paragraph is one thing the rep says. Consecutive lines stay visually
+   grouped but individually scannable. */
+.body p {
+  margin: 0 0 0.75rem;
+}
+
+.body p:last-child {
+  margin-bottom: 0;
+}
+
+[data-theme='dark'] .script {
+  background: var(--ifm-color-emphasis-200);
+}

--- a/docusaurus/src/components/ScriptExample.tsx
+++ b/docusaurus/src/components/ScriptExample.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import styles from './ScriptExample.module.css';
+
+export interface ScriptExampleProps {
+  /** Small uppercase label above the script. */
+  label?: string;
+  children: React.ReactNode;
+}
+
+/**
+ * Example language a rep says out loud — a call opener, a check-in question, a
+ * close. Use this instead of a markdown blockquote: `>` is banned repo-wide
+ * because it renders as an unintended blockquote.
+ *
+ * Each paragraph inside is treated as one separate thing the rep says.
+ */
+export function ScriptExample({ label = 'Say it like this', children }: ScriptExampleProps) {
+  return (
+    <div className={styles.script}>
+      <span className={styles.label}>{label}</span>
+      <div className={styles.body}>{children}</div>
+    </div>
+  );
+}
+
+export default ScriptExample;

--- a/docusaurus/training/sales/build-your-brand-and-your-day.mdx
+++ b/docusaurus/training/sales/build-your-brand-and-your-day.mdx
@@ -13,6 +13,7 @@ import MarkComplete from "@site/src/components/MarkComplete";
 import LessonHeader from "@site/src/components/LessonHeader";
 import LessonFooter from "@site/src/components/LessonFooter";
 import FlipCard, { FlipCardGrid } from "@site/src/components/FlipCard";
+import ScriptExample from "@site/src/components/ScriptExample";
 
 <InlineHighlighter courseId="build-your-brand-and-your-day" site="vendasta_learn">
 
@@ -36,11 +37,9 @@ import FlipCard, { FlipCardGrid } from "@site/src/components/FlipCard";
   step={9}
   totalSteps={9}
   outcomes={[
-    "Decide whether to niche down or stay broad, based on local versus global reach",
-    "Build an ideal-client profile that shapes your positioning, not just your pitch",
+    "Decide whether to niche down or stay broad, and build the ideal-client profile that shapes your positioning",
     "Write copy that makes the client the hero, not your agency",
-    "Structure a day so avoided tasks and unmanaged accounts stop quietly costing you deals",
-    "Apply the 60/30/10 rule and the line-by-line test to your own book of business",
+    "Run your day and your book with the A/B/C split, the 60/30/10 rule, and the line-by-line test",
   ]}
 />
 
@@ -79,9 +78,17 @@ Flip it, using the structure behind every story you have ever found compelling:
 6. **The solution** — the problem, solved
 7. **The conclusion** — what their business looks like after
 
-> **Before:** "We've been in business 10 years. Our team of experts handles your digital marketing."
->
-> **After:** "Local businesses struggle to get found online. You have a plan — we help you execute it. Here's what it looks like when your phone rings with qualified leads."
+<ScriptExample label="Before — the agency is the hero">
+
+"We've been in business 10 years. Our team of experts handles your digital marketing."
+
+</ScriptExample>
+
+<ScriptExample label="After — the client is the hero">
+
+"Local businesses struggle to get found online. You have a plan — we help you execute it. Here's what it looks like when your phone rings with qualified leads."
+
+</ScriptExample>
 
 The prospect should see themselves in the first sentence, not your company history.
 

--- a/docusaurus/training/sales/close-and-open-the-relationship.mdx
+++ b/docusaurus/training/sales/close-and-open-the-relationship.mdx
@@ -13,6 +13,7 @@ import MarkComplete from "@site/src/components/MarkComplete";
 import LessonHeader from "@site/src/components/LessonHeader";
 import LessonFooter from "@site/src/components/LessonFooter";
 import FlipCard, { FlipCardGrid } from "@site/src/components/FlipCard";
+import ScriptExample from "@site/src/components/ScriptExample";
 
 <InlineHighlighter courseId="close-and-open-the-relationship" site="vendasta_learn">
 
@@ -32,7 +33,6 @@ import FlipCard, { FlipCardGrid } from "@site/src/components/FlipCard";
   outcomes={[
     "Explain why the moment you close is the start of the real work, not the finish line",
     "Run a 30/60/90-day check-in cadence that proves value before the client has to ask",
-    "Reuse the same moves that won the deal — research, contrast, stories, questions — to keep growing the account",
     "Catch a relationship drifting off course early, before a small gap becomes a lost client",
   ]}
 />
@@ -47,7 +47,11 @@ Here's why that isn't just a feel-good idea: if every new client you sign is jus
 
 Don't wait for the client to wonder whether this was worth it. Check in at 30, 60, and 90 days after the sale, on a schedule you set, not one they have to ask for. Spend that window proving the specific thing you promised is actually happening: pull the before-and-after, not just an opinion.
 
-> "Here's your Snapshot from the day we started next to today's. Your review count is up, and here's the one listing that was dragging your score before we fixed it."
+<ScriptExample label="Show the receipt">
+
+"Here's your Snapshot from the day we started next to today's. Your review count is up, and here's the one listing that was dragging your score before we fixed it."
+
+</ScriptExample>
 
 A client who sees the receipt trusts the next thing you propose. A client who has to ask for it starts wondering what else you're not telling them.
 
@@ -55,7 +59,11 @@ A client who sees the receipt trusts the next thing you propose. A client who ha
 
 The questions that won the deal don't stop mattering once it's signed. Ask them anyway:
 
-> "Is this working the way you expected? What would make it better?"
+<ScriptExample label="Keep asking">
+
+"Is this working the way you expected? What would make it better?"
+
+</ScriptExample>
 
 You already know your product. The client is the only one who knows what their day actually looks like now, and asking is the only way you find out before it becomes a complaint instead of a conversation.
 
@@ -63,7 +71,11 @@ You already know your product. The client is the only one who knows what their d
 
 Once Riverside Landscaping has a real result, ask if you can tell it:
 
-> "Would you be open to being a case study? I'd love to show other landscaping companies what happened with your listings."
+<ScriptExample label="Ask for the story">
+
+"Would you be open to being a case study? I'd love to show other landscaping companies what happened with your listings."
+
+</ScriptExample>
 
 A specific client's story, with their industry and their numbers, is what a similar prospect trusts most — more than anything you could say about yourself. It's also worth more to you than a generic testimonial: name the industry, name the number, and the next Riverside Landscaping you pitch will see themselves in it.
 
@@ -71,7 +83,11 @@ A specific client's story, with their industry and their numbers, is what a simi
 
 Lead with what changed for them, not with what you did. "We configured three automations" is a feature. "You used to lose half your quote requests overnight; now every one gets a same-day response" is a result they can feel. When you check in, don't explain your work — narrate their outcome:
 
-> "Three months ago you were manually following up on every quote request after hours. Now that's automatic, and your close rate on quotes moved from one in five to one in three. That's the difference."
+<ScriptExample label="Narrate their outcome">
+
+"Three months ago you were manually following up on every quote request after hours. Now that's automatic, and your close rate on quotes moved from one in five to one in three. That's the difference."
+
+</ScriptExample>
 
 That contrast is also what keeps you different from whoever they almost hired instead. Anyone can list features; showing the exact gap you closed for this specific client is something a competitor can't copy after the fact.
 
@@ -101,7 +117,11 @@ Sometimes you don't catch the drift in time, or the reason was never yours to fi
 
 When a client is genuinely leaving, the instinct is to either fight it or go quiet. Both cost you. Instead: be efficient about the wind-down, respect their time, don't make them chase you for the last steps, and say plainly that the door is open if things change.
 
-> "I'm sorry this didn't work out the way we planned. I'll get everything wrapped up cleanly on our end this week. If your situation changes down the road, I'd genuinely like to work together again — call me directly."
+<ScriptExample label="Close the door gently">
+
+"I'm sorry this didn't work out the way we planned. I'll get everything wrapped up cleanly on our end this week. If your situation changes down the road, I'd genuinely like to work together again — call me directly."
+
+</ScriptExample>
 
 Businesses change. Budgets come back, owners move to new companies, and the person who left you on good terms is the one who recommends you to someone else — or comes back themselves in eighteen months. A client you lost gracefully is a lead. A client you lost badly is a review you can't undo.
 

--- a/docusaurus/training/sales/consult-dont-just-pitch.mdx
+++ b/docusaurus/training/sales/consult-dont-just-pitch.mdx
@@ -13,6 +13,7 @@ import MarkComplete from "@site/src/components/MarkComplete";
 import LessonHeader from "@site/src/components/LessonHeader";
 import LessonFooter from "@site/src/components/LessonFooter";
 import FlipCard, { FlipCardGrid } from "@site/src/components/FlipCard";
+import ScriptExample from "@site/src/components/ScriptExample";
 
 <InlineHighlighter courseId="consult-dont-just-pitch" site="vendasta_learn">
 
@@ -39,9 +40,8 @@ import FlipCard, { FlipCardGrid } from "@site/src/components/FlipCard";
   step={8}
   totalSteps={9}
   outcomes={[
-    "Explain why the sales conversation itself is where you find out what a client actually needs",
+    "Explain why the sales conversation is where you learn what a client needs, and why it is the one thing never to automate",
     "Ask the questions that let you recommend with confidence instead of guessing",
-    "Name the one thing in your sales process you should never automate, and why",
     "Report results in a way that builds trust instead of triggering skepticism",
   ]}
 />
@@ -52,7 +52,11 @@ A pitch is something you can write before you have met the prospect. A recommend
 
 Three different agency owners, on a panel about what they automate in their sales process, all landed on the same rule without prompting each other: **they will never automate the actual sales conversation.** Not because it is sentimental — because that conversation is the one place they find out what the client actually needs, and a recommendation built on a guess is just a pitch wearing a nicer outfit.
 
-> "This is your chance to understand what the client needs. And after you know what the client needs, this allows you to then map the problem and how you can best solve that."
+<ScriptExample label="From the panel">
+
+"This is your chance to understand what the client needs. And after you know what the client needs, this allows you to then map the problem and how you can best solve that."
+
+</ScriptExample>
 
 That is the whole job in one sentence: understand, then map, then recommend. Skip the first step and you are not consulting, you are guessing out loud.
 
@@ -72,9 +76,13 @@ Walking in with those answers is what separates a consultation from a cold pitch
 
 Once you know what they are chasing, two follow-up questions do most of the remaining work:
 
-> "What does 'better' actually look like for you here?"
->
-> "What's stopped this from getting fixed already?"
+<ScriptExample label="Ask both">
+
+"What does 'better' actually look like for you here?"
+
+"What's stopped this from getting fixed already?"
+
+</ScriptExample>
 
 The first stops you from recommending the wrong *size* of solution — you are aiming at their definition of success, not yours. The second surfaces the real obstacle, which is often not the one they led with.
 

--- a/docusaurus/training/sales/find-your-next-prospect.mdx
+++ b/docusaurus/training/sales/find-your-next-prospect.mdx
@@ -35,9 +35,8 @@ import FlipCard, { FlipCardGrid } from "@site/src/components/FlipCard";
   totalSteps={9}
   outcomes={[
     "Explain why keeping the funnel full matters more than any single deal",
-    "Deliver a concise, headline-first pitch instead of a rambling one",
     "Respond to a prospect at the moment they are most engaged, not hours later",
-    "Use a sales engagement tool to automate the outreach grind instead of doing it by hand",
+    "Automate the outreach grind instead of doing it by hand, and decide what to do, delegate, or buy",
   ]}
 />
 
@@ -62,9 +61,9 @@ Prospecting is not the thing you do when you have spare time. It is the thing th
 **6. Become the trusted expert, so referrals do your prospecting for you.** Bragging is just marketing with worse branding — if customers say good things about you, amplify it. The endpoint of doing this well is referrals: prospects who arrive pre-sold because someone already vouched for you.
 
 <FlipCardGrid>
-  <FlipCard front="Concise first" back="Lead with the headline. Depth only if they ask for it." subtext="Habit 1" />
-  <FlipCard front="60 seconds" back="Reach a prospect within 60 seconds of an open and they are ~60x more likely to convert." subtext="Habit 4" />
-  <FlipCard front="Referrals" back="The endpoint of being the trusted expert: prospecting you no longer have to do yourself." subtext="Habit 6" />
+  <FlipCard front="Say it short, ask it well" back="Lead with the headline, depth only if they ask. Ask questions where you can predict the shape of the answer, not its content." subtext="Habits 1–2" />
+  <FlipCard front="Value, then speed" back="Keep adding value between deals, including to your own customers. When a prospect opens your message, call right then — inside 60 seconds they are ~60x more likely to convert." subtext="Habits 3–4" />
+  <FlipCard front="Their channel, then referrals" back="Meet them where they actually answer — call, text, DM. Do that well enough and referrals arrive pre-sold." subtext="Habits 5–6" />
 </FlipCardGrid>
 
 ## The five-before-nine, nine-after-five rule

--- a/docusaurus/training/sales/handle-objections.mdx
+++ b/docusaurus/training/sales/handle-objections.mdx
@@ -42,8 +42,7 @@ import FlipCard, { FlipCardGrid } from "@site/src/components/FlipCard";
   outcomes={[
     "Recognize that an objection is a request for more information, not a rejection",
     "Work through any objection using the LAIR sequence",
-    "Recognize the five most common objections and know what to say back to each",
-    "Reach for five specific bounce-back techniques when you need one",
+    "Recognize the five most common objections and reach for the right bounce-back for each",
   ]}
 />
 

--- a/docusaurus/training/sales/open-the-conversation.mdx
+++ b/docusaurus/training/sales/open-the-conversation.mdx
@@ -13,6 +13,7 @@ import MarkComplete from "@site/src/components/MarkComplete";
 import LessonHeader from "@site/src/components/LessonHeader";
 import LessonFooter from "@site/src/components/LessonFooter";
 import FlipCard, { FlipCardGrid } from "@site/src/components/FlipCard";
+import ScriptExample from "@site/src/components/ScriptExample";
 
 <InlineHighlighter courseId="open-the-conversation" site="vendasta_learn">
 
@@ -35,8 +36,7 @@ import FlipCard, { FlipCardGrid } from "@site/src/components/FlipCard";
   outcomes={[
     "Explain what an elevator pitch is actually for, and what it is not",
     "Build a pitch in four parts: goal, plain-language value, your edge, a question",
-    "Cut a pitch down until it survives the three-floor test",
-    "Rehearse a pitch the way that makes it hold up in a real room",
+    "Cut a pitch down until it survives the three-floor test, and rehearse it so it holds up in a real room",
   ]}
 />
 
@@ -58,7 +58,7 @@ Most reps freeze here because they think the job of that moment is to win the de
 
 <FlipCardGrid>
   <FlipCard front="The goal" back="A specific next step — a call, a meeting, a 'tell me more'. Not 'impress them'." subtext="Part 1" />
-  <FlipCard front="Three floors" back="If your value proposition needs more than three floors, it is a speech, not a pitch." subtext="Part 2" />
+  <FlipCard front="Few words, then your edge" back="If your value proposition needs more than three floors, it is a speech. Then name what the person across the aisle cannot also claim — backed by a real result, not an adjective." subtext="Parts 2–3" />
   <FlipCard front="The question" back="End on a question. A pitch with no question is a monologue with a deadline." subtext="Part 4" />
 </FlipCardGrid>
 
@@ -74,7 +74,11 @@ A useful test: if the person on the other end of your pitch looks *more* confuse
 
 Years ago, a seller was pitching a newspaper organization that had built its entire business on selling print advertising — and had no reason, in their own minds, to change. They did not open with "you need digital marketing." They opened with the thing the room already cared about:
 
-> "You have sold a lot of advertising. I have too. And one thing we both know is that the advertising you sell is coming under attack — the client's first comment on the next call is always 'it isn't working like it used to.' It's not your ad that's the problem. It's that they've got broken listings, bad reviews, and a website that takes forever to load. What if the thing you sell could work better, because their virtual doorway finally matches the ad that sent someone looking for it?"
+<ScriptExample label="What they opened with">
+
+"You have sold a lot of advertising. I have too. And one thing we both know is that the advertising you sell is coming under attack — the client's first comment on the next call is always 'it isn't working like it used to.' It's not your ad that's the problem. It's that they've got broken listings, bad reviews, and a website that takes forever to load. What if the thing you sell could work better, because their virtual doorway finally matches the ad that sent someone looking for it?"
+
+</ScriptExample>
 
 That pitch did not ask anyone to abandon what they were good at. It named a pain they already felt — advertising getting blamed for problems it did not cause — and pointed at a fix that made their existing product stronger instead of replacing it. Five years later, people who were in that room were still using a version of that same pitch on their own prospects.
 

--- a/docusaurus/training/sales/present-so-it-lands.mdx
+++ b/docusaurus/training/sales/present-so-it-lands.mdx
@@ -13,6 +13,7 @@ import MarkComplete from "@site/src/components/MarkComplete";
 import LessonHeader from "@site/src/components/LessonHeader";
 import LessonFooter from "@site/src/components/LessonFooter";
 import FlipCard, { FlipCardGrid } from "@site/src/components/FlipCard";
+import ScriptExample from "@site/src/components/ScriptExample";
 
 <InlineHighlighter courseId="present-so-it-lands" site="vendasta_learn">
 
@@ -34,7 +35,6 @@ import FlipCard, { FlipCardGrid } from "@site/src/components/FlipCard";
     "Structure a presentation around insights, deliverables, value, and the ask, in that order",
     "Know exactly where to make the ask, and say it with confidence instead of apology",
     "Decide what belongs in the appendix instead of the main pitch",
-    "Reuse three ready-made lines for opening, asking, and answering a maybe",
   ]}
 />
 
@@ -46,7 +46,11 @@ You already ran the discovery call. You know the gaps, you know what the prospec
 
 Start the meeting with the specific things the prospect told you, not with your product. If a landscaping company's owner told you on the discovery call that half her quote requests never get a follow-up, that line opens the presentation:
 
-> "You told me last week that quote requests go cold if nobody follows up within a day. That's the first thing we built this plan around."
+<ScriptExample label="Open with the insight">
+
+"You told me last week that quote requests go cold if nobody follows up within a day. That's the first thing we built this plan around."
+
+</ScriptExample>
 
 This is the insight move, and it does one job: it proves you were listening. A generic opener ("Here's what we do for businesses like yours") sounds like every rep before you. A specific callback sounds like a plan built for this prospect, because it is.
 
@@ -60,7 +64,11 @@ A useful test: if the sentence describes a click path, it belongs in the appendi
 
 Every owner is running the same math in their head: will this pay for itself. Answer that before they ask instead of after:
 
-> "We'll track quote-to-close rate monthly, and I'll show you the before-and-after myself. If follow-up is really costing you jobs, you'll see it move within the first month."
+<ScriptExample label="Prove the value">
+
+"We'll track quote-to-close rate monthly, and I'll show you the before-and-after myself. If follow-up is really costing you jobs, you'll see it move within the first month."
+
+</ScriptExample>
 
 Naming how you will measure it, and when you will show up with the number, turns "trust me" into a plan the owner can check.
 
@@ -68,7 +76,11 @@ Naming how you will measure it, and when you will show up with the number, turns
 
 Here is the part most reps flinch on: you have to actually ask for the business, and you have to do it here, not bury it in a follow-up email. After insights, deliverables, and value, say the plan and ask for the yes:
 
-> "That's the plan: automated follow-up, a monthly report on quote-to-close, and I'll be your point of contact the whole way. Can we get you started this week?"
+<ScriptExample label="Make the ask">
+
+"That's the plan: automated follow-up, a monthly report on quote-to-close, and I'll be your point of contact the whole way. Can we get you started this week?"
+
+</ScriptExample>
 
 Confidence here is not about volume, it is about not softening the ask into a question about whether you should be asking. You did the discovery, you built the plan around what they told you, and this is the moment it was all leading to.
 
@@ -82,7 +94,11 @@ Confidence here is not about volume, it is about not softening the ask into a qu
 
 Not every capability belongs in the main story. If a feature might matter to this prospect but you are not certain, do not build the main pitch around a maybe, and do not cut it either. Put it in an appendix and mention that it is there:
 
-> "There's a webchat feature that might be a fit for you too. I've put a page on it at the back in case you want to look at it, but I didn't want to build our whole conversation around something you haven't seen yet."
+<ScriptExample label="Point at the appendix">
+
+"There's a webchat feature that might be a fit for you too. I've put a page on it at the back in case you want to look at it, but I didn't want to build our whole conversation around something you haven't seen yet."
+
+</ScriptExample>
 
 This keeps the main pitch tight and confident, and it still lets a curious owner go looking without you guessing wrong about what they care about.
 

--- a/docusaurus/training/sales/run-a-discovery-call.mdx
+++ b/docusaurus/training/sales/run-a-discovery-call.mdx
@@ -13,6 +13,7 @@ import MarkComplete from "@site/src/components/MarkComplete";
 import LessonHeader from "@site/src/components/LessonHeader";
 import LessonFooter from "@site/src/components/LessonFooter";
 import FlipCard, { FlipCardGrid } from "@site/src/components/FlipCard";
+import ScriptExample from "@site/src/components/ScriptExample";
 
 <InlineHighlighter courseId="run-a-discovery-call" site="vendasta_learn">
 
@@ -37,8 +38,7 @@ import FlipCard, { FlipCardGrid } from "@site/src/components/FlipCard";
   outcomes={[
     "Ask the three questions that surface the real problem instead of the one a prospect leads with",
     "Prove you are listening by paraphrasing the problem back before you mention a solution",
-    "Match how deep you go to how complex the opportunity actually is",
-    "Know when to tell a prospect something does not fit, and why that earns trust",
+    "Match how deep you go to the size of the opportunity, and say so when something does not fit",
   ]}
 />
 
@@ -48,7 +48,11 @@ There used to be a rule in sales: spend the first fifteen or twenty minutes of a
 
 That rule is outdated. Business owners are busier than it assumes, and most of them can tell within the first minute whether you are going to waste their time. Get to why they are on the call, fast. That does not mean skipping rapport — it means proving you are listening a different way: paraphrase back what they just told you, in your own words, before you move on.
 
-> "So if I have got this right, the real issue is [X], and it is costing you [Y]. Is that a fair read?"
+<ScriptExample label="Paraphrase it back">
+
+"So if I have got this right, the real issue is [X], and it is costing you [Y]. Is that a fair read?"
+
+</ScriptExample>
 
 That one sentence does more to build trust than twenty minutes of small talk, because it proves you were actually listening instead of waiting for your turn to talk.
 
@@ -56,19 +60,27 @@ That one sentence does more to build trust than twenty minutes of small talk, be
 
 You do not need a long list of discovery questions. Three, asked in order, uncover almost everything you need:
 
-> "What's on your mind?"
->
-> "And what else?"
->
-> "So what's the real challenge here?"
+<ScriptExample label="Ask, in this order">
+
+"What's on your mind?"
+
+"And what else?"
+
+"So what's the real challenge here?"
+
+</ScriptExample>
 
 **"And what else?" is the one reps skip, and it is the one that matters most.** The first answer a prospect gives is rarely the whole picture — it is the thing that was easiest to say out loud. Asking "what else" once, sometimes twice, is what gets you from the surface complaint to the actual problem.
 
 Once you are there, two follow-ups keep the conversation useful instead of just diagnostic:
 
-> "What would solving this actually mean for your business?"
->
-> "What can I do to help you move forward?"
+<ScriptExample label="Then follow up with">
+
+"What would solving this actually mean for your business?"
+
+"What can I do to help you move forward?"
+
+</ScriptExample>
 
 <FlipCardGrid>
   <FlipCard front="What's on your mind?" back="Opens the call on their agenda, not yours." subtext="Question 1" />

--- a/docusaurus/training/sales/sell-socially.mdx
+++ b/docusaurus/training/sales/sell-socially.mdx
@@ -38,8 +38,7 @@ import FlipCard, { FlipCardGrid } from "@site/src/components/FlipCard";
   outcomes={[
     "Build a LinkedIn profile that reads like a business card, not a personal photo album",
     "Use the Social Selling Index as a practical checklist instead of a vanity score",
-    "Spend 10 minutes before every meeting doing the research a prospect is already doing on you",
-    "Share content that builds your authority instead of broadcasting your job title",
+    "Research a prospect before every meeting, and share content that builds authority instead of broadcasting your job title",
   ]}
 />
 


### PR DESCRIPTION
## Note from Cal

Good work on this. The writing is strong and the arc holds together — it reads like one path, not nine repurposed exports.

Two things before the next round.

**I'd rather review the content properly once the videos are embedded.** Right now it's hard to judge the flow, and more importantly how much of the surrounding text is actually needed. A fair amount of this prose may be doing work the clip will do better, and I don't want you trimming on a guess before we can see them side by side. Get the embeds in and send it back over.

**Double-check the content a few times before sending it for review.** The FlipCard numbering gaps are exactly the kind of thing a second or third pass catches — a four-part framework recapped as "Part 1, Part 2, Part 4," and the same pattern again in the six-habits recap. There were a couple of other misses in that category. I run a minimum of four sweeps, Claude plus my own eyes, before anything goes out for review. Worth building that habit here.

The rest looks awesome.

One general rule worth keeping: **at least two interactive components per lesson** to break up the text. You're at exactly two right now, and one of them is the end-of-lesson check, so in practice there's only one thing interrupting the prose mid-page. The videos will accomplish this here once they're embedded, so no action needed — just keep it in mind as you build the next path.

Please send it over again for review after the video embedding.

---

Instructional-design pass over the Sales path now that it's on master. Shiva — the writing itself is strong and I changed none of the teaching. Everything here is convention, header discipline, and two rendering bugs.

I checked each finding against the partner site's *own* patterns before flagging it, because `partnercenter-docs` deliberately doesn't follow the internal LEARN standard. Two things I initially thought were problems turned out to be fine, and I've left them alone: retake variety is correct in all nine lessons once you count `fillblank`, `sort` and `match` (not just mcq/truefalse), and every `sort` question passes bucket **ids**, which is what this repo's `KnowledgeCheck` actually compares against. No action on either.

## 1. Blockquotes — 26 of them, across 6 lessons

Repo `CLAUDE.md` bans `>` outright as a CRITICAL rule. I verified before raising it: **zero** blockquote lines in the other 50 training files. Sales was the only path using them.

They were all example dialogue, and there was genuinely nowhere for it to go — `ChatBubble` is hardcoded for AI-receptionist transcripts with a "Customer" label. So this adds a `ScriptExample` component built on the existing `.in-practice` visual grammar (left border, tinted panel, uppercase label, theme-aware in both light and dark).

The label carries the teaching point rather than just saying "example":

- `Paraphrase it back` — the discovery-call trust move
- `Make the ask` — the moment reps flinch on
- `Before — the agency is the hero` / `After — the client is the hero`
- `From the panel` — where the source is a quote, not a script

Worth a look in preview to see whether the labels land the way you'd phrase them. That's the one part of this I'd most expect you to rewrite.

## 2. Outcomes trimmed to 3 per lesson

Lessons promised 4-5 each; `ai-foundations` runs exactly 3 in all six of its lessons. I folded rather than cut, so section coverage is unchanged — e.g. discovery's "match your depth" and "say when it doesn't fit" became one outcome.

One of them was a genuine cross-lesson overlap: `find-your-next-prospect` promised "deliver a concise, headline-first pitch," which is `open-the-conversation`'s job. That one's gone rather than folded.

## 3. FlipCardGrid numbering gaps — the one to actually look at

`FlipCardGrid` caps at `MAX_CARDS = 3`, so a framework with 4+ items can't be recapped one-card-per-item. Two lessons hit that and left visible gaps:

| Lesson | Before | After |
|---|---|---|
| `open-the-conversation` | Part 1, Part 2, **Part 4** | Part 1, **Parts 2-3**, Part 4 |
| `find-your-next-prospect` | Habit 1, **Habit 4**, **Habit 6** | **Habits 1-2**, **Habits 3-4**, **Habits 5-6** |

The first one is the worst of the two: the lesson teaches "Build it in four parts," and the recap rendered as **Part 1, Part 2, Part 4** — silently dropping Part 3, the unique selling proposition, which is arguably the part that differentiates the pitch. On the page it reads as a typo.

The fix uses the fold-with-ranges convention you already used in `present-so-it-lands` ("Moves 2-3") and `sell-socially` ("SSI pillars 2-3") — so this is your own pattern, just applied consistently. Every part and habit is now accounted for.

**Structural note:** any future 4+ item framework will hit the same cap. Options are to keep folding with ranges, or raise `MAX_CARDS` to 4 — the grid is `auto-fill minmax(200px, 1fr)` so it would wrap cleanly, and since every existing path uses exactly 3 cards, raising the cap wouldn't change any page that ships today. Your call, and probably worth deciding once rather than per-lesson.

## Notes for you, no changes made

- **Embed the video first, then I'll review properly.** Ten VIDEO SLOT comments, five with embed IDs. It's hard to judge whether the text is the right length or pitched right while the clip that carries half the teaching isn't in the page. Once the embeds land I'll do a full pass. Putting the unreliable-ID warning inline on every slot instead of once in the commit was the right instinct — nothing should embed until those are verified in the vendasta-1 account.
- **Expect to cut text once video is in.** Assuming a clip per lesson, several of these can lose a chunk of prose that the video will cover better. Don't pre-trim — wait until you can see them side by side.
- **Interactive components sit at the floor.** Every lesson has exactly 2 (one FlipCardGrid, one KnowledgeCheck), and only the grid is mid-lesson — the check is terminal. `find-your-next-prospect`, `handle-objections` and `sell-socially` have nothing interactive between the header and the end. Video takes each lesson to 3, so this may resolve itself, but an accordion or a mid-lesson Q&A card would be worth considering in the two or three longest lessons.
- **The consult/discovery overlap is still open** and tracked separately in DOC-922 — not touched here. I trimmed `consult-dont-just-pitch`'s outcomes to 3, which slightly sharpens the boundary, but the section-level overlap with `run-a-discovery-call` is still yours to resolve before the path unhides.

## Verification

Production build: 0 errors, all pages generated. The single remaining warning is a pre-existing broken link in `docs/crm/`, unrelated to this path. Checked every lesson in local preview at `/learn/sales/`, light and dark.

Path is still hidden — `hide-from-sidebar` untouched on the category and every lesson.

Refs DOC-829, DOC-922

🤖 Generated with [Claude Code](https://claude.com/claude-code)
