### PR TITLE
docs: merge business description update details into AI Search Specialist article

### DIFF
--- a/docusaurus/docs/ai/ai-workforce/ai-search-specialist.mdx
+++ b/docusaurus/docs/ai/ai-workforce/ai-search-specialist.mdx
@@ -66,6 +66,26 @@ You'll see optimization reflected in your listings over time, and you'll be noti
 Business Profile Optimization is turned off by default. Turn it on in the AI Search Specialist's configuration to let it run automatically in the background.
 :::
 
+### Business description updates
+
+Business descriptions are refreshed on a monthly schedule, and only when new services or tracked keywords should be reflected—no action is required from your clients.
+
+Each month, the AI evaluates a client's existing description against:
+
+- Their website and business profile content (services, specialties, voice)
+- Tracked keywords and their search performance data
+- Business category
+
+A description is updated only when there is a meaningful signal to act on—new services, a niche specialty not yet in the description, or tracked keywords missing from it. Descriptions updated within the last 90 days are left untouched, and descriptions that already reflect current services and keywords are skipped until the next cycle.
+
+When a description is updated:
+
+1. The client receives an **AI Search Specialist: Profile Description Updated** notification in Business App.
+2. The notification links to Business Profile so they can review the change.
+3. The updated description syncs to Google, Bing, Apple, and Facebook.
+
+Clients can review and edit their description in Business Profile at any time.
+
 ## Share feedback
 
 The AI Search Specialist is actively being improved based on beta feedback.
@@ -94,6 +114,27 @@ These features move to the SEO AI Premium edition at general availability, targe
 <summary>Can I turn off Business Profile Optimization?</summary>
 
 Business Profile Optimization is turned off by default. You can turn it on in the AI Search Specialist's configuration, and it will run automatically in the background.
+
+</details>
+
+<details>
+<summary>Why did a client's business description change automatically?</summary>
+
+The AI detected new services or tracked keywords that weren't yet reflected in the description. Direct clients to the notification in Business Profile to review the update.
+
+</details>
+
+<details>
+<summary>Can clients undo an automatic description change?</summary>
+
+Yes. Clients can edit or replace their business description in Business Profile at any time.
+
+</details>
+
+<details>
+<summary>How often will Business Profile Optimization change a client's description?</summary>
+
+The AI checks once a month but only updates the description when there's something meaningful to add. Clients with stable services and keyword coverage may see infrequent or no changes.
 
 </details>
 

--- a/docusaurus/docs/ai/ai-workforce/ai-search-specialist.mdx
+++ b/docusaurus/docs/ai/ai-workforce/ai-search-specialist.mdx
@@ -68,7 +68,7 @@ Business Profile Optimization is turned off by default. Turn it on in the AI Sea
 
 ### Business description updates
 
-Business descriptions are refreshed on a monthly schedule, and only when new services or tracked keywords should be reflected—no action is required from your clients.
+Business descriptions are reevaluated on a monthly schedule—no action is required from your clients. Whether a description is actually changed is an AI judgment call, not a guaranteed outcome: detecting a new service or tracked keyword doesn't automatically trigger an update.
 
 Each month, the AI evaluates a client's existing description against:
 
@@ -76,7 +76,7 @@ Each month, the AI evaluates a client's existing description against:
 - Tracked keywords and their search performance data
 - Business category
 
-A description is updated only when there is a meaningful signal to act on—new services, a niche specialty not yet in the description, or tracked keywords missing from it. Descriptions updated within the last 90 days are left untouched, and descriptions that already reflect current services and keywords are skipped until the next cycle.
+The AI only updates a description when it judges there's a meaningful signal to act on—for example, new services, a niche specialty not yet in the description, or tracked keywords missing from it. To avoid changing a client's description too often, a description also has to have gone at least 90 days since its last update before it's eligible to change again—so a description updated within roughly the last 90 days generally won't be touched by this workflow.
 
 When a description is updated:
 
@@ -120,7 +120,7 @@ Business Profile Optimization is turned off by default. You can turn it on in th
 <details>
 <summary>Why did a client's business description change automatically?</summary>
 
-The AI detected new services or tracked keywords that weren't yet reflected in the description. Direct clients to the notification in Business Profile to review the update.
+The AI judged that recent changes—like new services, a specialty, or tracked keywords—were significant enough to warrant an update to the description. Direct clients to the notification in Business Profile to review the update.
 
 </details>
 
@@ -134,7 +134,7 @@ Yes. Clients can edit or replace their business description in Business Profile 
 <details>
 <summary>How often will Business Profile Optimization change a client's description?</summary>
 
-The AI checks once a month but only updates the description when there's something meaningful to add. Clients with stable services and keyword coverage may see infrequent or no changes.
+The AI checks once a month, but updating the description is a judgment call, not a guarantee—and it also requires at least 90 days to have passed since the last update. Clients with stable services and keyword coverage, or whose description changed recently, may see infrequent or no changes.
 
 </details>
 


### PR DESCRIPTION
## Summary
- Folds the automatic description-update behavior from Haley's DAT-4274 branch (`claude/adoring-meitner-41n53l`) into the existing open-beta AI Search Specialist article's Business Profile Optimization section.
- Adds a "Business description updates" subsection: monthly schedule, the signals evaluated (website/profile content, tracked keywords, business category), the 90-day skip logic, and the exact client notification flow.
- Adds three related client-facing FAQs (why the description changed, whether clients can undo it, how often it changes).
- Intentionally drops the "Local SEO Premium subscription" requirement from the original DAT-4274 draft, since it conflicts with this article's framing that these capabilities are free for Local SEO Pro accounts during the open beta.

## Test plan
- [ ] Haley: confirm the merged "Business description updates" content still accurately reflects the feature behavior
- [ ] Confirm dropping the Local SEO Premium requirement note is correct for the open-beta framing
- [ ] Visual check in local dev server (`npm run start`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)