### PR TITLE
docs: add triggers and actions overview pages with sidebar reorder

### DIFF
--- a/docusaurus/docs/automations/my-automations/actions-overview.mdx
+++ b/docusaurus/docs/automations/my-automations/actions-overview.mdx
@@ -1,0 +1,64 @@
+---
+title: Actions overview
+description: Actions are the steps your automation performs after a trigger fires — understand action categories, scope rules, and how to build effective workflows.
+sidebar_position: 7
+sidebar_label: Actions overview
+tags: [automations, actions, steps]
+keywords: [automation actions, automation steps, workflow steps, action categories, step scope]
+---
+
+# Actions overview
+
+Actions are the "then" of your automation — what happens after the trigger fires. Build your workflow by adding action steps in sequence.
+
+## How action availability works
+
+The actions you can add depend on your trigger's scope. A company-scoped trigger unlocks company-focused actions; an account-scoped trigger unlocks account-focused actions.
+
+| Trigger scope | Example available actions |
+|---|---|
+| **Account** | Assign salesperson, activate products, add tags, create sales order |
+| **Company** | Assign owner, log call, start campaign, create opportunity |
+| **Contact** | Assign owner, send email, add to list, start campaign |
+| **No entity** | Create company, create contact, send webhook, delay, if/else |
+
+:::tip
+Need actions from a different scope? Use **lookup steps** like Find company, Find contact, or Get associated account to bring additional records into context.
+:::
+
+## Action categories
+
+Vendasta provides 130+ action steps across these categories:
+
+| Category | What it does | Examples |
+|---|---|---|
+| **AI** | Use AI to summarize, categorize, analyze, or prompt | Summarize with AI, Categorize with AI, Send request to AI employee |
+| **Communication** | Send messages across channels | Email, SMS, WhatsApp, Conversations message, review request |
+| **CRM** | Create and update records | Create company, find contact, update fields, log activity |
+| **Sales** | Manage the sales pipeline | Create opportunity, assign salesperson, create proposal |
+| **Campaigns** | Start and manage campaigns | Start campaign, pause campaign, send marketing email |
+| **Billing** | Handle invoicing and payments | Create invoice, charge order, send invoice |
+| **Notifications** | Alert people | Notify user, notify salesperson, send in-app notification |
+| **Products** | Manage product lifecycle | Activate products, deactivate products, start trials |
+| **Sales orders** | Manage order workflow | Create and activate, approve, decline, archive |
+| **Advanced** | Integration and utility | Call endpoint, send webhook, format text, apply account template |
+| **Flow control** | Direct automation logic | If/else, delay, jump, rate filter, end automation |
+
+For the complete list with special cases and examples, see the **[Automation steps reference](./automation-steps-reference.mdx)**.
+
+## Building effective workflows
+
+**Start simple.** Begin with a trigger and one or two actions. Test that the basics work before adding complexity.
+
+**Use delays strategically.** Some data isn't available immediately after a trigger fires (e.g., salesperson assigned a few minutes after account creation). Add a delay step before actions that depend on that data.
+
+**Branch with if/else.** Use [logic steps](./advanced-automation-features.mdx) to route records down different paths based on conditions — like sending different emails based on sentiment analysis.
+
+**Pass data between steps.** Use [data expressions](./data-expressions.mdx) to extract values from one step's output and feed them into another step's input.
+
+## Pages in this section
+
+- **[Automation steps reference](./automation-steps-reference.mdx)** — Complete list of every action step, organized by category
+- **[AI Actions](./ai-actions/)** — Summarize, categorize, analyze sentiment, prompt AI, or request an AI employee
+- **[Step deep-dives](./steps/)** — Detailed guides for Find company, Find custom object, and Copy AI employee
+- **[Bulk actions](./bulk-actions.mdx)** — Run automation-powered actions on demand from CRM views

--- a/docusaurus/docs/automations/my-automations/advanced-automation-features.mdx
+++ b/docusaurus/docs/automations/my-automations/advanced-automation-features.mdx
@@ -1,7 +1,7 @@
 ---
 title: Advanced automation features
 description: Learn about advanced automation features including logic steps, delay until steps, grouping, action sets, and AI employee integration to create sophisticated workflows.
-sidebar_position: 8
+sidebar_position: 12
 ---
 
 # Advanced automation features

--- a/docusaurus/docs/automations/my-automations/ai-actions/_category_.json
+++ b/docusaurus/docs/automations/my-automations/ai-actions/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "AI Actions",
-  "position": 6,
+  "position": 9,
   "collapsed": true,
   "link": { "type": "doc", "id": "automations/my-automations/ai-actions/index" }
 }

--- a/docusaurus/docs/automations/my-automations/automation-steps-reference.mdx
+++ b/docusaurus/docs/automations/my-automations/automation-steps-reference.mdx
@@ -1,7 +1,7 @@
 ---
 title: Automation steps reference
 description: Complete reference for every step (action) your automations can perform, organized by category.
-sidebar_position: 5
+sidebar_position: 8
 ---
 
 # Automation steps reference

--- a/docusaurus/docs/automations/my-automations/automation-triggers-reference.mdx
+++ b/docusaurus/docs/automations/my-automations/automation-triggers-reference.mdx
@@ -1,7 +1,7 @@
 ---
 title: Automation triggers reference
 description: Complete reference for every trigger that can start an automation workflow, organized by category.
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 # Automation triggers reference

--- a/docusaurus/docs/automations/my-automations/bulk-actions.mdx
+++ b/docusaurus/docs/automations/my-automations/bulk-actions.mdx
@@ -2,7 +2,7 @@
 title: Bulk actions – CRM automations on demand
 sidebar_label: Bulk actions
 description: Trigger predefined automation actions directly from CRM views without setup or workflow creation.
-sidebar_position: 10
+sidebar_position: 11
 tags: [crm, automations, bulk-actions, productivity]
 keywords: [crm bulk actions, run automations, assign leads, send campaign, create follow-up task]
 ---

--- a/docusaurus/docs/automations/my-automations/data-expressions.mdx
+++ b/docusaurus/docs/automations/my-automations/data-expressions.mdx
@@ -1,7 +1,7 @@
 ---
 title: Data expressions in automations
 description: Learn how to use data expressions to extract and transform data between automation steps, enabling dynamic workflows that pass information from one step to the next.
-sidebar_position: 9
+sidebar_position: 13
 tags: [automations, data-expressions, jq, workflows, data-mapping]
 keywords: [data expressions, jq expressions, data mapping, automation data, step data, transform data, extract data, workflow data]
 ---

--- a/docusaurus/docs/automations/my-automations/steps/_category_.json
+++ b/docusaurus/docs/automations/my-automations/steps/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Step deep-dives",
-  "position": 7,
+  "position": 10,
   "collapsed": true,
   "link": { "type": "doc", "id": "automations/my-automations/steps/index" }
 }

--- a/docusaurus/docs/automations/my-automations/time-based-triggers.mdx
+++ b/docusaurus/docs/automations/my-automations/time-based-triggers.mdx
@@ -1,7 +1,7 @@
 ---
 title: Time-based triggers
 description: Learn how to set up automations that run on a schedule - daily, weekly, or monthly - using the On a schedule trigger.
-sidebar_position: 4
+sidebar_position: 5
 sidebar_label: Time-based triggers
 tags: [automations, scheduled, triggers, recurring, time-based]
 keywords: [scheduled automation, recurring automation, daily automation, weekly automation, monthly automation, time-based trigger, on a schedule]

--- a/docusaurus/docs/automations/my-automations/trigger-automation-using-zapier.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-automation-using-zapier.mdx
@@ -2,7 +2,7 @@
 title: Trigger an automation using Zapier
 sidebar_label: Trigger via Zapier
 description: Learn how to connect the Vendasta CRM to 3rd Party systems using Zapier and trigger automations.
-sidebar_position: 11
+sidebar_position: 6
 ---
 
 The Vendasta App in Zapier allows Partners to connect the Vendasta CRM to several 3rd Party systems using Zapier. Users can select any 3rd Party system available in Zapier as a Trigger which would initiate an action in the Vendasta CRM

--- a/docusaurus/docs/automations/my-automations/triggers-overview.mdx
+++ b/docusaurus/docs/automations/my-automations/triggers-overview.mdx
@@ -1,0 +1,61 @@
+---
+title: Triggers overview
+description: Triggers are the events that start your automations — understand trigger types, scoping, and how to choose the right trigger for your workflow.
+sidebar_position: 3
+sidebar_label: Triggers overview
+tags: [automations, triggers]
+keywords: [automation triggers, event triggers, scheduled triggers, manual triggers, trigger types, trigger scope]
+---
+
+# Triggers overview
+
+A trigger is the "when" of your automation — the event that kicks off the workflow. Every automation starts with exactly one trigger.
+
+## Trigger types
+
+| Type | How it works | Example |
+|---|---|---|
+| **Event triggers** | Fires when something happens in the platform | Form submitted, contact created, opportunity stage changed |
+| **Time-based triggers** | Fires on a recurring schedule | Every Monday at 9 AM, first of each month |
+| **Manual triggers** | Fires when you click "Run" on specific records | Run for a selected account, company, or contact |
+| **Advanced triggers** | Fires from external systems or API calls | Webhook received, Zapier integration, API request |
+
+## How trigger scope works
+
+The trigger you choose determines which actions are available downstream:
+
+| Trigger scope | What's in context | Available actions |
+|---|---|---|
+| **Account-scoped** | The account that fired the trigger | Account-focused steps — assign salesperson, activate products, add tags |
+| **Company-scoped** | The company (and its account) | Company-focused steps — assign owner, log call, start campaign |
+| **Contact-scoped** | The contact (and its company/account) | Contact-focused steps — assign owner, send email, add to list |
+| **No entity** | No record in context (webhook, API, schedule) | Entity-creation steps only — create company, send webhook, delay, if/else |
+
+:::tip
+If your automation needs company data but your trigger is contact-scoped, use a **Find company** or **Get company from contact** step to bring the company into scope.
+:::
+
+## Choosing a trigger
+
+**React to user or customer actions** — Use event triggers (form submitted, contact created, opportunity changed). These are the most common and fire in real time.
+
+**Run on a schedule** — Use [time-based triggers](./time-based-triggers.mdx) for recurring tasks like weekly check-ins, monthly invoice reminders, or daily AI employee invocations.
+
+**Start from an external system** — Use [Zapier](./trigger-automation-using-zapier.mdx), webhook, or API triggers to connect third-party apps.
+
+**Run on demand** — Use manual triggers to execute automations for specific records you select in the CRM.
+
+## Trigger conditions
+
+After choosing a trigger, add **conditions** to filter which events actually start the automation:
+
+- **AND conditions** — all must be true (e.g., company industry is "Healthcare" AND company city is "Edmonton")
+- **OR conditions** — any can be true (e.g., trigger on form A OR form B)
+
+Combine AND/OR to build precise filters so your automation only runs for the right records.
+
+## Pages in this section
+
+- **[Automation triggers reference](./automation-triggers-reference.mdx)** — Complete list of every trigger, organized by category
+- **[Time-based triggers](./time-based-triggers.mdx)** — Set up daily, weekly, or monthly schedules
+- **[Trigger via Zapier](./trigger-automation-using-zapier.mdx)** — Connect third-party apps to start automations


### PR DESCRIPTION
## Summary

- Adds **Triggers overview** and **Actions overview** pages to the My automations section — these act as section headers that orient users before they dive into reference pages
- Reorders `sidebar_position` values so pages group by topic: getting started → triggers → actions → logic/advanced → data expressions
- Moves "Trigger via Zapier" from position 11 to position 6 (next to other trigger pages)

### New sidebar order

```
My automations
  Creating and configuring automations     (1)
  Navigating the automation canvas         (2)
  Triggers overview                        (3)  ← NEW
  Automation triggers reference            (4)
  Time-based triggers                      (5)
  Trigger via Zapier                       (6)  ← was 11
  Actions overview                         (7)  ← NEW
  Automation steps reference               (8)
  AI Actions                          ▸    (9)
  Step deep-dives                     ▸    (10)
  Bulk actions                             (11)
  Advanced automation features             (12)
  Data expressions                         (13)
```

### Why

Inspired by [Zapier's help center structure](https://help.zapier.com/hc/en-us/categories/14013973271565-Zap-workflows) — group pages by user mental model (triggers, actions, logic) instead of a flat dump. Overview pages answer "what are triggers and which should I pick?" before the reference table answers "what's every trigger?"

Part 1 of 3 in the My automations IA restructure. Follow-up PRs will split "Advanced automation features" into focused Logic and Reusable workflows pages, and redesign the landing page with card navigation.

## Test plan

- [x] `npm run build` passes with no new broken links
- [x] Sidebar renders correct order at `/automations/my-automations/`
- [x] Both overview pages render correctly with working internal links
- [x] No existing URLs broken (no file moves in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)