### PR TITLE
docs: fix incorrect nav path in SMS A2P registration article

### DIFF
--- a/docusaurus/docs/business-app/conversations/sms/us-businesses-sms-registration.mdx
+++ b/docusaurus/docs/business-app/conversations/sms/us-businesses-sms-registration.mdx
@@ -11,7 +11,7 @@ For US-based businesses to use Conversations SMS messaging in Conversations AI P
 
 ## How to register
 
-To register a US-based business, a business can go to Business App > Administration > Conversations Settings to see a new registration card. Click "register now" to view the form.
+To register a US-based business, a business can go to Business App → Administration → Conversation to see a new registration card. Click "register now" to view the form.
 
 ![US Business SMS Registration](../img/inbox/us-businesses-sms-registration.jpg)
 
@@ -45,7 +45,7 @@ By unifying the SMS number for both review requests and Conversations AI communi
 
 After activating Conversations AI Pro, your business is automatically assigned an SMS number based on the business profile address. To find it:
 
-1. Go to **Business App > Administration > Conversation Settings**
+1. Go to **Business App → Administration → Conversation**
 2. Look for **Your SMS number**
 
 If a local number is unavailable for your area code, a neighboring area number is assigned. Contact support to request a different area code or a toll-free number as an alternative.


### PR DESCRIPTION
## Summary
- Corrects the nav path in the US SMS A2P registration article — it pointed to **Business App → Administration → Conversation(s) Settings**, but the correct path is **Business App → Administration → Conversation**.
- Fixes two occurrences (intro paragraph and the "Finding your assigned SMS phone number" section).

Closes DOC-788.

## Test plan
- [x] Verified both nav-path mentions in the article now read "Conversation"
- [ ] Spot-check rendered page locally (`npm run start`) if desired

🤖 Generated with [Claude Code](https://claude.com/claude-code)