### PR TITLE
Docs: field descriptions for CRM fields in automation conditions (AUT-4550)

### DIFF
--- a/docusaurus/docs/automations/index.mdx
+++ b/docusaurus/docs/automations/index.mdx
@@ -70,6 +70,8 @@ Conditions filter when the workflow runs. You can filter on tags, salespeople, a
 
 ![Trigger conditions example](./my-automations/img/automations/trigger-conditions.jpg)
 
+When you choose a CRM field while building a condition, its field description appears below the field selector so you can confirm you've picked the right field, including any expected format or unit. The description only appears for fields that have one set. See [CRM Objects](/administration/data-management/crm-objects) to add or edit field descriptions.
+
 ## Creating your first automation
 
 1. In Business App go to **Settings** → **Automations**.


### PR DESCRIPTION
## JIRA
[AUT-4550](https://vendasta.jira.com/browse/AUT-4550) — Show field descriptions of crm fields

## Classification
UI/UX change — Partner Center (partner/agency-facing automation builder)

## Repo targeted
Partner Center

## Summary of documentation updates
Added a short note under the **Trigger conditions** section of the Automations overview explaining that a CRM field's description now appears as hint text below the field selector when building a condition, for any field that has one set. Linked to the existing CRM Objects article where field descriptions are created.

## Existing vs. new docs
Updated existing page: `docusaurus/docs/automations/index.mdx`. No new page was created — the Trigger conditions section already covers the filter/condition-building UI this feature extends.

## Placement reasoning
This feature applies to the field selector used while building a trigger condition, so the note was placed directly after the existing "Trigger conditions" explanation and its screenshot, before the "Creating your first automation" section.

## Acceptance criteria coverage
- "CRM field descriptions are shown when a field is chosen by a user" → documented
- "Add a 'hint text' component to show the field description" → documented (described as hint text below the field selector)
- "Works for all fields that have a field description" → documented ("only appears for fields that have one set")
- "Update the descriptions in other languages" → not documented as a user-facing step; this is a localization/backend concern with no distinct UI action for the end user to take, so no separate instructions were added

## Figma/images used
None were provided with this ticket. No visuals were available, so the update is based on the ticket's text description only.

## Skills used
None of this repo's skills matched directly; changes were made manually following the repo's existing markdown/link conventions (`CLAUDE.md`).

## Assumptions/limitations
- The parent epic (AUT-3908, "2026 sand items") is a general backlog/tech-debt epic, not a feature-rollout epic, and is not in "Done" status. Its open sibling tickets were reviewed for rollout-gating signals (feature flags, eligibility, region restrictions) and none were found relevant to this specific field-description feature, so this was treated as shipped.
- No GitHub PRs were linked on the JIRA issue, and this session's GitHub access is scoped to the `businessapp-docs` and `partnercenter-docs` repositories only, so the code-change author could not be identified for reviewer assignment. No reviewer was added — please assign manually.
- No comments or remote links existed on the JIRA issue at the time of writing.

cc @ahnikakuse @haleyserrano @maryam6samadi

---
_Generated by [Claude Code](https://claude.ai/code/session_012firRYHnFP65Dxch5CjHTF)_

[AUT-4550]: https://vendasta.jira.com/browse/AUT-4550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ