### PR TITLE
docs: embed verified Wistia videos in the Sales path (DOC-829)

### DIFF
--- a/docusaurus/training/sales/build-your-brand-and-your-day.mdx
+++ b/docusaurus/training/sales/build-your-brand-and-your-day.mdx
@@ -18,14 +18,34 @@ import FlipCard, { FlipCardGrid } from "@site/src/components/FlipCard";
 
 <CourseProgressBar courseId="build-your-brand-and-your-day" site="vendasta_learn" />
 
-{/* VIDEO SLOT: "The Perfect Sales Day" (Master Sales Training Series, Wistia, keep-as-is verdict
-    — talking-head, no product UI). No embed ID recorded: proj-009 catalogued the Wistia library
-    by title and this clip is not in the 360Learning export that carries IDs. Look it up by title
-    in the vendasta-1 account. A near-duplicate cut exists as "Ep. 1: The Perfect Sales Day" —
-    the standalone cut is the one this lesson was drafted from.
+{/* VIDEO: "The Perfect Sales Day" — Wistia ID `lq5ny4mfmt`, found by Shiva 2026-08-14 (the
+    standalone cut this lesson was drafted from, not the "Ep. 1" near-duplicate).
+    The brand-building half (Part 1) has no associated Wistia clip — sourced from the two
+    audited 360Learning courses instead. */}
 
-    The brand-building half (part 1) has no associated Wistia clip. It is sourced from the two
-    audited 360Learning courses, which may carry their own video inside the original course. */}
+<div
+  className="wistia_responsive_padding"
+  style={{ padding: '56.25% 0 0 0', position: 'relative' }}
+>
+  <div
+    className="wistia_responsive_wrapper"
+    style={{ height: '100%', left: 0, position: 'absolute', top: 0, width: '100%' }}
+  >
+    <iframe
+      src="https://fast.wistia.net/embed/iframe/lq5ny4mfmt?web_component=true&seo=true"
+      title="The Perfect Sales Day"
+      allow="autoplay; fullscreen"
+      allowTransparency
+      frameBorder="0"
+      scrolling="no"
+      className="wistia_embed"
+      name="wistia_embed"
+      width="100%"
+      height="100%"
+    ></iframe>
+  </div>
+</div>
+<script src="https://fast.wistia.net/player.js" async></script>
 
 <LessonHeader
   difficulty="Intermediate"

--- a/docusaurus/training/sales/close-and-open-the-relationship.mdx
+++ b/docusaurus/training/sales/close-and-open-the-relationship.mdx
@@ -18,8 +18,31 @@ import FlipCard, { FlipCardGrid } from "@site/src/components/FlipCard";
 
 <CourseProgressBar courseId="close-and-open-the-relationship" site="vendasta_learn" />
 
-{/* VIDEO SLOT: source is "Close Prospects, Open Relationships" (Wistia, keep-as-is
-    verdict — talking-head, no product UI, no accuracy pass pending). Ready to embed as-is. */}
+{/* VIDEO: "Close Prospects, Open Relationships" — Wistia ID `rnhr7sshu8`, found by Shiva 2026-08-14. */}
+
+<div
+  className="wistia_responsive_padding"
+  style={{ padding: '56.25% 0 0 0', position: 'relative' }}
+>
+  <div
+    className="wistia_responsive_wrapper"
+    style={{ height: '100%', left: 0, position: 'absolute', top: 0, width: '100%' }}
+  >
+    <iframe
+      src="https://fast.wistia.net/embed/iframe/rnhr7sshu8?web_component=true&seo=true"
+      title="Close Prospects, Open Relationships"
+      allow="autoplay; fullscreen"
+      allowTransparency
+      frameBorder="0"
+      scrolling="no"
+      className="wistia_embed"
+      name="wistia_embed"
+      width="100%"
+      height="100%"
+    ></iframe>
+  </div>
+</div>
+<script src="https://fast.wistia.net/player.js" async></script>
 
 <LessonHeader
   difficulty="Intermediate"

--- a/docusaurus/training/sales/consult-dont-just-pitch.mdx
+++ b/docusaurus/training/sales/consult-dont-just-pitch.mdx
@@ -18,17 +18,58 @@ import FlipCard, { FlipCardGrid } from "@site/src/components/FlipCard";
 
 <CourseProgressBar courseId="consult-dont-just-pitch" site="vendasta_learn" />
 
-{/* VIDEO SLOT: two candidates, both talking-head/panel footage with no product UI.
-    1. "Using dynamic and personalized content to fuel growth" — Conquer Local Connect customer
-       panel, Wistia embed ID `u24r2lp4vp`. The stronger of the two: contains the "never automate
-       the sales conversation" exchange that this lesson is built around.
-    2. "Stacking Success: Your Competitive Advantage" — Conquer Local conference talk, Wistia
-       embed ID `4in417wbuj`. Source of the trust-beats-features statistics.
+{/* VIDEO 1: "Using Dynamic and Personalized Content to Fuel Growth" — Wistia ID `u24r2lp4vp`,
+    verified by Shiva 2026-08-14. */}
 
-    Provenance caveat: both IDs are listed in the 360Learning export against unrelated course
-    titles ("Host a Powerful Consultation that Converts" and "Engage and Keep your Clients with
-    Expert Consulting"). Shiva confirmed the IDs resolve to the two clips named above, not to
-    those course titles. Verify in Wistia before embedding. */}
+<div
+  className="wistia_responsive_padding"
+  style={{ padding: '56.25% 0 0 0', position: 'relative' }}
+>
+  <div
+    className="wistia_responsive_wrapper"
+    style={{ height: '100%', left: 0, position: 'absolute', top: 0, width: '100%' }}
+  >
+    <iframe
+      src="https://fast.wistia.net/embed/iframe/u24r2lp4vp?web_component=true&seo=true"
+      title="Using Dynamic and Personalized Content to Fuel Growth"
+      allow="autoplay; fullscreen"
+      allowTransparency
+      frameBorder="0"
+      scrolling="no"
+      className="wistia_embed"
+      name="wistia_embed"
+      width="100%"
+      height="100%"
+    ></iframe>
+  </div>
+</div>
+
+{/* VIDEO 2: "Stacking Success: Your Competitive Advantage" — Wistia ID `4in417wbuj`,
+    verified by Shiva 2026-08-14. */}
+
+<div
+  className="wistia_responsive_padding"
+  style={{ padding: '56.25% 0 0 0', position: 'relative' }}
+>
+  <div
+    className="wistia_responsive_wrapper"
+    style={{ height: '100%', left: 0, position: 'absolute', top: 0, width: '100%' }}
+  >
+    <iframe
+      src="https://fast.wistia.net/embed/iframe/4in417wbuj?web_component=true&seo=true"
+      title="Stacking Success: Your Competitive Advantage"
+      allow="autoplay; fullscreen"
+      allowTransparency
+      frameBorder="0"
+      scrolling="no"
+      className="wistia_embed"
+      name="wistia_embed"
+      width="100%"
+      height="100%"
+    ></iframe>
+  </div>
+</div>
+<script src="https://fast.wistia.net/player.js" async></script>
 
 <LessonHeader
   difficulty="Intermediate"

--- a/docusaurus/training/sales/find-your-next-prospect.mdx
+++ b/docusaurus/training/sales/find-your-next-prospect.mdx
@@ -18,12 +18,31 @@ import FlipCard, { FlipCardGrid } from "@site/src/components/FlipCard";
 
 <CourseProgressBar courseId="find-your-next-prospect" site="vendasta_learn" />
 
-{/* VIDEO SLOT: "Better Prospecting" — Wistia, embed ID `lpdxav2w39`, keep-as-is verdict
-    (talking-head, no product UI, no accuracy pass pending). Transcript filed in
-    wistia-transcripts/ under the "Better Prospecting" title. Note: this ID is listed in the
-    360Learning export against course 603 ("Perfecting the Discovery Call"), but Shiva confirmed
-    it actually resolves to "Better Prospecting" — one of several known mismatched IDs in that
-    export. Verify in Wistia before embedding. */}
+{/* VIDEO: "Better Prospecting" — Wistia ID `lpdxav2w39`, verified by Shiva 2026-08-14. */}
+
+<div
+  className="wistia_responsive_padding"
+  style={{ padding: '56.25% 0 0 0', position: 'relative' }}
+>
+  <div
+    className="wistia_responsive_wrapper"
+    style={{ height: '100%', left: 0, position: 'absolute', top: 0, width: '100%' }}
+  >
+    <iframe
+      src="https://fast.wistia.net/embed/iframe/lpdxav2w39?web_component=true&seo=true"
+      title="Better Prospecting"
+      allow="autoplay; fullscreen"
+      allowTransparency
+      frameBorder="0"
+      scrolling="no"
+      className="wistia_embed"
+      name="wistia_embed"
+      width="100%"
+      height="100%"
+    ></iframe>
+  </div>
+</div>
+<script src="https://fast.wistia.net/player.js" async></script>
 
 <LessonHeader
   difficulty="Beginner"

--- a/docusaurus/training/sales/handle-objections.mdx
+++ b/docusaurus/training/sales/handle-objections.mdx
@@ -18,18 +18,12 @@ import FlipCard, { FlipCardGrid } from "@site/src/components/FlipCard";
 
 <CourseProgressBar courseId="handle-objections" site="vendasta_learn" />
 
-{/* VIDEO SLOT 1 (place under "The LAIR sequence"): "Breaking Down Objections using the 'LAIR'
-    Strategy" — Wistia, embed ID `59g98gwzj6`, one of the two clips embedded in the 360Learning
-    course "Handle Sales Objections like an Expert" (619). Transcript filed as
-    Recognizing-Common-Sales-Objections-eng.srt.
-
-    VIDEO SLOT 2 (place under "Five ways to bounce back"): "Five Ways to Bounce Back after
-    Objection" — Wistia, embed ID `bm47k8n12o`, the second clip in the same course. Transcript
-    filed as Five-Ways-to-Bounce-Back-after-Objection-eng.srt.
-
-    Both IDs come from the same 360Learning export that produced several known mismatched IDs, so
-    verify each resolves to the expected clip in Wistia before embedding. Neither shows product
-    UI, so no accuracy pass is expected to be needed. */}
+{/* Both video embeds for this lesson are placed inline below, under their matching headings.
+    Shiva's 2026-08-14 verification found the two IDs originally listed here were swapped from
+    what this comment said: `bm47k8n12o` is actually the "recognizing common objections" clip
+    (price/authority/trust/complacency/recognition — placed under "The LAIR sequence"), and
+    `59g98gwzj6` is actually the "five ways to bounce back" clip (placed under "Five ways to
+    bounce back"). IDs below reflect the corrected mapping. */}
 
 <LessonHeader
   difficulty="Intermediate"
@@ -60,6 +54,33 @@ It is tempting to hear that as failure. It is not. An objection almost never mea
 Every objection is a request for more information, an unmet need, or an unaddressed concern — not a locked door. The reps who close more deals are not the ones who avoid objections. They are the ones who have built a process for working through them.
 
 ## The LAIR sequence
+
+{/* VIDEO: "Breaking Down Objections using the 'LAIR' Strategy" — Wistia ID `bm47k8n12o`,
+    verified by Shiva 2026-08-14. */}
+
+<div
+  className="wistia_responsive_padding"
+  style={{ padding: '56.25% 0 0 0', position: 'relative' }}
+>
+  <div
+    className="wistia_responsive_wrapper"
+    style={{ height: '100%', left: 0, position: 'absolute', top: 0, width: '100%' }}
+  >
+    <iframe
+      src="https://fast.wistia.net/embed/iframe/bm47k8n12o?web_component=true&seo=true"
+      title="Breaking Down Objections using the 'LAIR' Strategy"
+      allow="autoplay; fullscreen"
+      allowTransparency
+      frameBorder="0"
+      scrolling="no"
+      className="wistia_embed"
+      name="wistia_embed"
+      width="100%"
+      height="100%"
+    ></iframe>
+  </div>
+</div>
+<script src="https://fast.wistia.net/player.js" async></script>
 
 LAIR gives you a repeatable order of operations for any objection, before you even know which specific one you are dealing with.
 
@@ -95,6 +116,32 @@ They are content with the status quo and what you are selling is not urgent to t
 Good news, actually. They already believe they need what you are selling — they just do not think it should come from you. Ask targeted questions about their experience with the incumbent (*"What's working? What isn't?"*), let them talk their way into naming the gaps, then show how you are different for their specific pain points. Competitor-bashing reads as petty at best and destroys your credibility at worst.
 
 ## Five ways to bounce back
+
+{/* VIDEO: "Five Ways to Bounce Back after Objection" — Wistia ID `59g98gwzj6`,
+    verified by Shiva 2026-08-14. */}
+
+<div
+  className="wistia_responsive_padding"
+  style={{ padding: '56.25% 0 0 0', position: 'relative' }}
+>
+  <div
+    className="wistia_responsive_wrapper"
+    style={{ height: '100%', left: 0, position: 'absolute', top: 0, width: '100%' }}
+  >
+    <iframe
+      src="https://fast.wistia.net/embed/iframe/59g98gwzj6?web_component=true&seo=true"
+      title="Five Ways to Bounce Back after Objection"
+      allow="autoplay; fullscreen"
+      allowTransparency
+      frameBorder="0"
+      scrolling="no"
+      className="wistia_embed"
+      name="wistia_embed"
+      width="100%"
+      height="100%"
+    ></iframe>
+  </div>
+</div>
 
 These techniques are not tied to one specific objection. Reach for whichever fits the moment, or combine more than one.
 

--- a/docusaurus/training/sales/open-the-conversation.mdx
+++ b/docusaurus/training/sales/open-the-conversation.mdx
@@ -18,11 +18,31 @@ import FlipCard, { FlipCardGrid } from "@site/src/components/FlipCard";
 
 <CourseProgressBar courseId="open-the-conversation" site="vendasta_learn" />
 
-{/* VIDEO SLOT: "Ep. 3: The Perfect Elevator Pitch" (Master Sales Training Series, Wistia,
-    keep-as-is verdict — talking-head, no product UI). No embed ID recorded: proj-009 catalogued
-    the Wistia library by title, and this clip is not in the 360Learning export that carries IDs.
-    Look it up in the vendasta-1 Wistia account by title. A near-duplicate cut exists as "Master
-    the Elevator Pitch" — use the Ep. 3 cut, it carries the fuller story. */}
+{/* VIDEO: "Ep. 3: The Perfect Elevator Pitch" — Wistia ID `gz3rmoduwo`, found by Shiva 2026-08-14. */}
+
+<div
+  className="wistia_responsive_padding"
+  style={{ padding: '56.25% 0 0 0', position: 'relative' }}
+>
+  <div
+    className="wistia_responsive_wrapper"
+    style={{ height: '100%', left: 0, position: 'absolute', top: 0, width: '100%' }}
+  >
+    <iframe
+      src="https://fast.wistia.net/embed/iframe/gz3rmoduwo?web_component=true&seo=true"
+      title="Ep. 3: The Perfect Elevator Pitch"
+      allow="autoplay; fullscreen"
+      allowTransparency
+      frameBorder="0"
+      scrolling="no"
+      className="wistia_embed"
+      name="wistia_embed"
+      width="100%"
+      height="100%"
+    ></iframe>
+  </div>
+</div>
+<script src="https://fast.wistia.net/player.js" async></script>
 
 <LessonHeader
   difficulty="Beginner"

--- a/docusaurus/training/sales/run-a-discovery-call.mdx
+++ b/docusaurus/training/sales/run-a-discovery-call.mdx
@@ -18,13 +18,56 @@ import FlipCard, { FlipCardGrid } from "@site/src/components/FlipCard";
 
 <CourseProgressBar courseId="run-a-discovery-call" site="vendasta_learn" />
 
-{/* VIDEO SLOT: two candidates, neither with a confirmed embed ID.
-    1. "Insights Based Selling" (Wistia, keep-as-is) — the philosophy half. Catalogued by title in
-       proj-009; no ID recorded, look it up in the vendasta-1 Wistia account.
-    2. The "Selling Local" webinar — the 1-2-3 process and Double Diamond mechanics. External
-       webinar recording, not in Wistia, so it may need to be clipped and uploaded first.
-    Do NOT use the ID the 360Learning export lists against course 603 ("Perfecting the Discovery
-    Call", `lpdxav2w39`) — Shiva confirmed that ID actually resolves to "Better Prospecting". */}
+{/* VIDEO 1: "Insights Based Selling" — Wistia ID `rto0p9fo18`, found by Shiva 2026-08-14. */}
+
+<div
+  className="wistia_responsive_padding"
+  style={{ padding: '56.25% 0 0 0', position: 'relative' }}
+>
+  <div
+    className="wistia_responsive_wrapper"
+    style={{ height: '100%', left: 0, position: 'absolute', top: 0, width: '100%' }}
+  >
+    <iframe
+      src="https://fast.wistia.net/embed/iframe/rto0p9fo18?web_component=true&seo=true"
+      title="Insights Based Selling"
+      allow="autoplay; fullscreen"
+      allowTransparency
+      frameBorder="0"
+      scrolling="no"
+      className="wistia_embed"
+      name="wistia_embed"
+      width="100%"
+      height="100%"
+    ></iframe>
+  </div>
+</div>
+
+{/* VIDEO 2: "Selling Local" webinar — Wistia ID `0zlccoi4iu`, found by Shiva 2026-08-14 (turned out to be in Wistia after all). */}
+
+<div
+  className="wistia_responsive_padding"
+  style={{ padding: '56.25% 0 0 0', position: 'relative' }}
+>
+  <div
+    className="wistia_responsive_wrapper"
+    style={{ height: '100%', left: 0, position: 'absolute', top: 0, width: '100%' }}
+  >
+    <iframe
+      src="https://fast.wistia.net/embed/iframe/0zlccoi4iu?web_component=true&seo=true"
+      title="Selling Local (webinar)"
+      allow="autoplay; fullscreen"
+      allowTransparency
+      frameBorder="0"
+      scrolling="no"
+      className="wistia_embed"
+      name="wistia_embed"
+      width="100%"
+      height="100%"
+    ></iframe>
+  </div>
+</div>
+<script src="https://fast.wistia.net/player.js" async></script>
 
 <LessonHeader
   difficulty="Intermediate"

--- a/docusaurus/training/sales/sell-socially.mdx
+++ b/docusaurus/training/sales/sell-socially.mdx
@@ -18,14 +18,33 @@ import FlipCard, { FlipCardGrid } from "@site/src/components/FlipCard";
 
 <CourseProgressBar courseId="sell-socially" site="vendasta_learn" />
 
-{/* VIDEO SLOT: "How to Become a LinkedIn Ninja" (Wistia, ~21 min, keep-as-is verdict —
-    talking-head, no product UI). No embed ID recorded: proj-009 catalogued this clip by title
-    from the vendasta-1 Wistia account, and it is not in the 360Learning export that carries IDs.
-    Look it up by title.
+{/* VIDEO: "How to Become a LinkedIn Ninja" — Wistia ID `m5blizgpyo`, verified by Shiva 2026-08-14.
+    Note: `e7xf8v54en` (previously listed here as "Get Started with LinkedIn") turned out to be
+    "Getting Started with Yesware" instead — not used. */}
 
-    Secondary option: the audited 360Learning course "Get Started with LinkedIn" (346) carries
-    embed ID `e7xf8v54en`, which is this lesson's primary text source. Verify in Wistia before
-    embedding — IDs in that export have proven unreliable. */}
+<div
+  className="wistia_responsive_padding"
+  style={{ padding: '56.25% 0 0 0', position: 'relative' }}
+>
+  <div
+    className="wistia_responsive_wrapper"
+    style={{ height: '100%', left: 0, position: 'absolute', top: 0, width: '100%' }}
+  >
+    <iframe
+      src="https://fast.wistia.net/embed/iframe/m5blizgpyo?web_component=true&seo=true"
+      title="How to Become a LinkedIn Ninja"
+      allow="autoplay; fullscreen"
+      allowTransparency
+      frameBorder="0"
+      scrolling="no"
+      className="wistia_embed"
+      name="wistia_embed"
+      width="100%"
+      height="100%"
+    ></iframe>
+  </div>
+</div>
+<script src="https://fast.wistia.net/player.js" async></script>
 
 <LessonHeader
   difficulty="Beginner"


### PR DESCRIPTION
## Summary
Wires the actual video embeds into 8 of the 9 Sales-path lessons (`docusaurus/training/sales/`), closing out the video-embedding portion of DOC-829.

- Wistia IDs were verified or looked up by Shiva on 2026-08-14, per Cal's comment flagging that no video should be embedded until IDs are confirmed (the 360Learning export has a known history of mismatched/duplicate IDs — see Lesson 8's earlier source-ID mismatch).
- Lesson 4 (present-so-it-lands) is intentionally left out — its video is blocked on the separate Growth Engine product-accuracy pass (AC1), and video is optional per the IA spec, so it doesn't block shipping.
- Fixes a swapped ID pair in handle-objections.mdx: the two video IDs on file were mapped to the wrong sections (LAIR sequence vs. bounce-back techniques) relative to what they actually contain. Corrected based on content verification.
- All 8 edited files pass an MDX compile check (@mdx-js/mdx v3).

## What's still open on DOC-829 (not in this PR)
- Sixth-path IA sign-off from Cal (path stays hide-from-sidebar until then)
- AC1 — Growth Engine video embeds (separate workstream)

## Test plan
- [x] MDX compiles cleanly for all 8 changed files
- [ ] Visual check that each Wistia embed renders and plays the correct clip
- [ ] Cal's sign-off on the standalone Sales path (tracked separately, not blocking this PR)