### PR TITLE
docs: article verifications for campaigns and premium reports access controls

### DIFF
--- a/.claude/skills/article-verifications/SKILL.md
+++ b/.claude/skills/article-verifications/SKILL.md
@@ -154,15 +154,6 @@ Use AskUserQuestion with options tailored to the context, e.g.:
 - `Replace "[term]" with "[suggested alternative]"`
 - `Leave it for now — I'll handle this manually`
 
-**H1 in article body:**
-
-```
-**Issue:** The article has a top-level heading (H1) in the body. The title is already set in the frontmatter, so this line is a duplicate.
-**Location:** Line [N]
-**Current:** "# [heading text]"
-**Proposed:** Remove this line entirely.
-```
-
 **File rename:**
 
 ```
@@ -385,6 +376,8 @@ These are mechanical, rules-based changes with no risk of affecting product accu
 - **Audience language** — consumer/SMB framing rewritten for a partner audience (e.g., removing "your provider" framing, correcting third-person "users" → "you" when addressing the partner reader)
 - **UI formatting** — bold UI elements and navigation paths converted to inline code (backticks)
 - **Blockquote replacement** — `>` callouts replaced with the appropriate `:::info`, `:::tip`, `:::warning`, or `:::note` block
+- **Duplicate H1 removal** — a top-level heading in the body that duplicates the frontmatter `title` is deleted outright; this is always mechanical since the title already lives in frontmatter
+- **Em dash replacement** — every `—` replaced with a comma, colon, or period depending on context; purely mechanical punctuation, no risk to accuracy
 
 ### Approval required (flag and wait)
 
@@ -482,6 +475,6 @@ The article is mostly clear and well-structured. Two audience-language issues an
 
 - **Never assert** that content is wrong — use "may be outdated" or "verify with SME" when uncertain.
 - **Never infer functionality** from the article text. If a step or feature claim cannot be verified from other current documentation, flag it for SME review.
-- **Apply auto-fixes immediately, flag the rest** — sentence casing, audience language, UI formatting, and blockquote-to-callout fixes are applied directly without asking. All other changes require explicit approval before editing.
+- **Apply auto-fixes immediately, flag the rest** — sentence casing, audience language, UI formatting, blockquote-to-callout fixes, duplicate H1 removal, and em dash replacement are applied directly without asking. All other changes require explicit approval before editing.
 - **Check every link** — do not skip link checks even if the article looks clean. This includes anchor fragments (Step 4) and inbound links from other articles into the ones you're editing (Step 4b) — a heading rename that looks harmless in isolation can silently break a link on a page you never opened.
 - **Report on every article** — even articles that pass should appear in the output with "Status: Pass" and a brief confirmation.

--- a/docusaurus/docs/marketing/campaigns/create-email-campaigns.mdx
+++ b/docusaurus/docs/marketing/campaigns/create-email-campaigns.mdx
@@ -5,8 +5,6 @@ sidebar_label: Create Marketing Emails
 sidebar_position: 1
 ---
 
-# Create marketing emails
-
 Create professional marketing emails that engage your contacts and drive business results. Marketing emails can be deployed through campaigns for scheduled sends or automations for trigger-based delivery. 
 
 ## Overview
@@ -84,16 +82,16 @@ The Email Builder allows you to design engaging emails that look great on any de
 
 With upwards of [80% of emails opened on mobile devices](https://www.litmus.com/blog/email-client-market-share-infographic/), it's crucial to ensure your emails display properly across all devices. The Email Builder provides instant visual feedback so you can see exactly how your emails will appear to recipients.
 
-### Customize Your Logo
+### Customize your logo
 
 Use this feature to hide or customize the logo for each email you design. The logo can be hidden or changed for each different email inside your campaigns, allowing for more personalized content.
 
 ![Email Builder Logo Customization](./img/marketing/campaigns/email_builder_logo_customization.jpg)
 
 The logo customization block has three options:
-- **Default** — Uses the partner logo configured in your branding settings.
-- **Custom** — Upload a different image. You can set the width and alignment, and add a URL so clicking the logo takes recipients to a destination of your choice.
-- **Hide** — Removes the logo from this email entirely.
+- **Default**: Uses the partner logo configured in your branding settings.
+- **Custom**: Upload a different image. You can set the width and alignment, and add a URL so clicking the logo takes recipients to a destination of your choice.
+- **Hide**: Removes the logo from this email entirely.
 
 ### Adjusting padding between content blocks
 
@@ -106,7 +104,7 @@ If you have two images stacked on top of each other and there's an unwanted gap 
 
 This eliminates the space between the two blocks. The same approach works for any adjacent blocks where you want tighter spacing.
 
-### Working with Content Blocks
+### Working with content blocks
 
 All email content is placed in content "blocks." Email Builder provides multiple blocks that you can click and add. The blocks determine what kind of content can be entered as well as the styling and editing options available. Click **"+Add new block"** to start building your email.
 
@@ -120,13 +118,13 @@ Click **"Preview"** in the top right-hand corner to check out your email!
 
 ![Email Builder Preview](./img/marketing/campaigns/email_builder_preview.jpg)
 
-### Preview on Different Devices
+### Preview on different devices
 
 You can see how your email will appear on different devices in real-time with the click of a button. This ensures your emails look great whether opened on desktop, tablet, or mobile.
 
 ![Email Builder Logo Personalization](./img/marketing/campaigns/email_builder_logo_personalization.jpg)
 
-### Additional Email Builder Features
+### Additional email builder features
 
 - **Side-by-side content**: Render images and text side by side with simple click and selection
 - **Color customization**: Change colors for text, titles, subtitles, links, footer text, content background, and page background
@@ -134,11 +132,13 @@ You can see how your email will appear on different devices in real-time with th
 - **Tables**: Add simple tables to arrange data intuitively in your emails
 - **Contact cards**: Personalize emails with contact images and details
 
-### Email Builder Limitations
+### Email builder limitations
 
+{/* SME/writer review: "legacy" and "new" Email Builder violate evergreen style (no past/recency framing). Confirm whether the legacy builder still exists as a distinct product surface, and if so, what evergreen-safe names to use for both versions. */}
 1. Emails built in the legacy Email Builder cannot be edited in the new Email Builder and vice-versa
 2. Emails started in the legacy builder cannot be switched mid-creation to the new Email Builder
 
+{/* SME/writer review: this numbered list starts at 6 with no steps 1-5 anywhere nearby. It isn't clearly a continuation of "Creating custom campaign emails" above (that list ends cleanly at step 5) or any other list in this article. A near-duplicate fragment numbered 7-8 ("Campaign Timing Configuration") also appears later, after the entire Method 2 section, covering the same timing/delivery topic in more detail. Needs a writer/SME to determine where this content actually belongs and how the two fragments should be reconciled — do not guess the placement or renumber without confirming. */}
 **Campaign Setup Process:**
 
 6. Continue adding email events until you have finished creating the campaign
@@ -149,11 +149,11 @@ You can see how your email will appear on different devices in real-time with th
 **Campaign Limitations**: Campaigns provide straightforward drip sequences but lack conditional branching, trigger responses, or dynamic timing. For more sophisticated email marketing with conditional logic and smart triggers, consider using [Automations](/automations) instead.
 :::
 
-## Method 2: Using Email Templates in Automations (Advanced Smart Marketing)
+## Method 2: Using email templates in automations (advanced smart marketing)
 
 Automations are intelligent marketing workflows that support both drip sequences AND conditional logic. Unlike simple campaigns, automations can respond to contact actions, form submissions, business events, and data changes in real-time. This advanced approach enables both scheduled sequences and smart, responsive communication based on contact behavior and business intelligence.
 
-### Setting Up Email Automation
+### Setting up email automation
 
 **To create automated email sequences:**
 
@@ -169,7 +169,7 @@ Automations are intelligent marketing workflows that support both drip sequences
 - **Start Campaign for Company** - Trigger an existing campaign sequence for the company
 - **Campaign Step** - Use existing campaigns as building blocks within automation workflows
 
-### Email Template Creation in Automations
+### Email template creation in automations
 
 When adding email steps to automations:
 
@@ -182,7 +182,7 @@ When adding email steps to automations:
 **Using Campaign Steps in Automations:**
 The "Campaign" step allows you to incorporate existing drip campaigns as building blocks within your automation workflows. This lets you combine the simplicity of pre-built campaigns with the advanced conditional logic of automations.
 
-### Automation Email Benefits
+### Automation email benefits
 
 **Drip Sequence Capabilities (Like Campaigns, But Smarter):**
 - Create time-based email sequences with conditional branching
@@ -225,6 +225,8 @@ The "Campaign" step allows you to incorporate existing drip campaigns as buildin
 
 **Recommendation**: Automations provide superior flexibility and intelligence. Consider using automations for most email marketing needs, as they support everything campaigns can do plus advanced conditional capabilities.
 :::
+
+{/* SME/writer review: this fragment (7-8) covers the same timing/delivery topic as the "Campaign Setup Process" list (6-8) earlier in this article, and sits disconnected here after the entire Method 2 section. See the review note on that list — same open question about where this content belongs and whether these two fragments should be merged. */}
 **Campaign Timing Configuration:**
 
 7. Adjust the "days before starting" or "days before previous event"
@@ -235,7 +237,7 @@ The "Campaign" step allows you to incorporate existing drip campaigns as buildin
 
 ![Campaign Configuration](./img/marketing/marketing-campaigns/campaign-configuration.png)
 
-## Campaign Configuration Settings
+## Campaign configuration settings
 
 In the **Campaign configuration** section of a campaign, you can configure the following settings:
 
@@ -243,14 +245,14 @@ In the **Campaign configuration** section of a campaign, you can configure the f
 
 ![Campaign configuration settings](./img/marketing/marketing-campaigns/configure-campaigns/campaign-config-2-v2.png)
 
-### Time Zone Settings
+### Time zone settings
 
 By default, campaigns are sent in your local time zone. To change this setting:
 
 1. Select a time zone from the dropdown
 2. Click **Save**
 
-### Included Days
+### Included days
 
 By default, emails are only sent Monday-Friday. However, the delays that are set between campaign events count all the days of the week. If an email is scheduled to send on a day that's not included, the email will be sent on the next included day.
 
@@ -266,9 +268,9 @@ To change this setting:
 1. Select the days that emails should be sent on
 2. Click **Save**
 
-### Rate Limiting
+### Rate limiting
 
-This option limits the number of emails that can be sent on behalf of each salesperson per day. The limit only applies when adding a list to a campaign (not adding individual accounts). Only the first email step of a campaign is affected—the remaining emails in a campaign are sent with the delays set in the campaign. Pausing and resuming a campaign will bypass the limit.
+This option limits the number of emails that can be sent on behalf of each salesperson per day. The limit only applies when adding a list to a campaign (not adding individual accounts). Only the first email step of a campaign is affected. The remaining emails in a campaign are sent with the delays set in the campaign. Pausing and resuming a campaign will bypass the limit.
 
 :::note
 For example, if a company has 4 salespeople, and the limit is set to 2 recipients per day, then 8 recipients will be added to the campaign per day. Each recipient will receive subsequent emails in the campaign with the delays that are set in the campaign.
@@ -280,13 +282,13 @@ By default, the limit is disabled. To turn on the limit:
 2. Enter the maximum number of recipients that should be added to the campaign per salesperson per day (from a list)
 3. Click **Save**
 
-### Campaign Sender Settings
+### Campaign sender settings
 
 You can change the 'sender' email address and name in **Partner Center** > **Marketing** > **Email Settings > Sender and Reply Settings.**
 
 ![Campaign email settings](./img/marketing-campaigns/campaign_email_settings.jpg)
 
-### Scheduling Campaigns Walkthrough Video
+### Scheduling campaigns walkthrough video
 
 <iframe 
   src="https://drive.google.com/file/d/17wY5cNDUF8X4WQ2nVLBn5BaSvFA4RoEe/preview" 
@@ -295,11 +297,11 @@ You can change the 'sender' email address and name in **Partner Center** > **Mar
   allowFullScreen
 ></iframe>
 
-## Testing and Optimizing Marketing Emails
+## Testing and optimizing marketing emails
 
 Whether you're using campaigns or automations, thorough testing ensures your emails perform effectively across different email clients and devices.
 
-### Email Testing Process
+### Email testing process
 
 Email clients like Gmail, Apple Mail, and Outlook display emails differently. Always test your emails before sending to ensure optimal presentation and functionality.
 
@@ -319,7 +321,7 @@ Email clients like Gmail, Apple Mail, and Outlook display emails differently. Al
 
 ![Send Test Button](./img/marketing/marketing-campaigns/send-test-button.png)
 
-### Advanced Preview: Testing as Specific Accounts
+### Advanced preview: testing as specific accounts
 
 You can preview email campaigns as a specific account to ensure proper functionality and see exactly how dynamic content will appear for different businesses.
 
@@ -353,7 +355,7 @@ The test email will be customized with the selected account's data, showing you 
 **Note:** For test campaigns to send successfully, there needs to be an account linked to the user receiving the email.
 :::
 
-### Publishing and Activation
+### Publishing and activation
 
 **For Campaigns:**
 Once testing is complete, click **Publish** to make your campaign available for sending.
@@ -363,7 +365,7 @@ Once testing is complete, click **Publish** to make your campaign available for 
 **For Automations:**
 Turn on your automation to begin trigger-based email delivery or use the "Manual" trigger to trigger the automation manually. Monitor initial sends to ensure proper functionality.
 
-## Troubleshooting Common Issues
+## Troubleshooting common issues
 
 ### Error: "Your company hasn't set up campaigns yet"
 
@@ -392,7 +394,7 @@ The contact information is required to send marketing campaigns. This error occu
   allowFullScreen
 ></iframe>
 
-### Other Common Setup Issues
+### Other common setup issues
 
 **Campaign Won't Publish:**
 - Ensure all required email content is complete

--- a/docusaurus/docs/marketing/campaigns/index.mdx
+++ b/docusaurus/docs/marketing/campaigns/index.mdx
@@ -5,15 +5,11 @@ description: Create, manage, and send targeted email campaigns to engage with yo
 sidebar_position: 1
 ---
 
-# Campaigns
-
-Email campaigns are drip-style marketing automation tools for engaging with your contacts through scheduled email sequences. Campaigns provide straightforward, time-based email marketing that's easy to set up and manage, making them ideal for simple marketing sequences with predetermined timing.
-
-## What are Email Campaigns?
+## What are email campaigns?
 
 Email campaigns are drip-style marketing automation that send scheduled email sequences to your contacts, accounts, and lists. They provide straightforward, time-based email marketing with predetermined intervals between messages. You can personalize content with dynamic information and track performance to optimize your communication strategy.
 
-### Campaigns vs Automations
+### Campaigns vs automations
 
 **Campaigns (Drip Marketing):**
 - Simple, time-based email sequences
@@ -32,7 +28,7 @@ Email campaigns are drip-style marketing automation that send scheduled email se
 For most email marketing needs, consider [Automations](/automations) as they provide all campaign capabilities plus advanced conditional features and trigger-based responses.
 :::
 
-## Key Features
+## Key features
 
 - **Professional Email Builder** - Create beautiful emails with drag-and-drop interface
 - **Dynamic Content** - Personalize emails with [CRM contact fields](/crm/contacts/crm-default-contact-fields), [CRM company fields](/crm/companies/crm-default-company-fields), and account information
@@ -41,22 +37,22 @@ For most email marketing needs, consider [Automations](/automations) as they pro
 - **Performance Tracking** - Monitor open rates, click-through rates, and engagement metrics
 - **Template Library** - Access pre-built campaign templates for common business scenarios
 
-## Getting Started
+## Getting started
 
-### 1. Set Up Your Email Settings
+### 1. Set up your email settings
 
 Before creating campaigns, ensure your email authentication is properly configured:
 - **Domain Authentication** - Set up SPF, DKIM, and DMARC records
 - **Sender Information** - Configure your "from" name and email address  
 - **Mailing Address** - Add required business mailing address for compliance
 
-### 2. Create Your First Campaign
+### 2. Create your first campaign
 
 You can create campaigns in two ways:
 - **Use Recommended Templates** - Start with proven templates and customize as needed
 - **Build Custom Campaigns** - Create campaigns from scratch using the Email Builder
 
-### 3. Design Your Emails
+### 3. Design your emails
 
 Use the Email Builder to create professional emails:
 - Add dynamic content to personalize messages
@@ -64,7 +60,7 @@ Use the Email Builder to create professional emails:
 - Optimize for different email clients and devices
 - Test your emails before sending
 
-### 4. Configure Campaign Settings
+### 4. Configure campaign settings
 
 Set up your campaign parameters:
 - **Time Zone** - Choose the appropriate time zone for sending
@@ -72,7 +68,7 @@ Set up your campaign parameters:
 - **Rate Limits** - Control how many emails are sent per day
 - **Event Timing** - Set delays between campaign steps
 
-### 5. Send Your Campaign
+### 5. Send your campaign
 
 Choose from the recommended CRM-based sending methods:
 - **CRM Contacts** - Target individual contacts with full field access and tracking
@@ -81,42 +77,42 @@ Choose from the recommended CRM-based sending methods:
 - **CRM Automation** - Trigger campaigns based on contact actions, product usage, or business events
 - **Account Lists** - Alternative method for specific use cases
 
-## Advanced Campaign Use Cases
+## Advanced campaign use cases
 
-### Automated Business Intelligence Campaigns
+### Automated business intelligence campaigns
 Set up sophisticated automation flows that combine business data with targeted campaigns:
 - **Snapshot Report Delivery**: Automatically generate and send performance reports to companies using their specific business metrics
 - **Product Upselling**: Target companies based on activation status and business size (e.g., upsell Conversation AI to growing businesses without it)  
 - **Account-Based Nurturing**: Send company-focused campaigns that reach all stakeholders with business-relevant insights
 - **Engagement Re-activation**: Send campaigns to contacts based on login patterns or product usage
 
-### Smart Segmentation Examples
+### Smart segmentation examples
 - **Industry-Specific Campaigns**: Target companies by business type with relevant content
 - **Lifecycle Stage Marketing**: Send different campaigns based on customer maturity and engagement
 - **Product Usage Campaigns**: Trigger campaigns based on feature adoption and usage patterns
 - **Geographic Targeting**: Send location-specific offers and updates
 
-### Dynamic Content Personalization  
+### Dynamic content personalization
 - **Company Performance Data**: Include business metrics, rankings, and insights in emails
 - **Contact-Specific Information**: Personalize with job titles, interests, and engagement history
 - **Product Usage Stats**: Reference specific product performance and recommendations
 - **Snapshot Report Integration**: Include live business intelligence data in campaign content
 
-## Best Practices
+## Best practices
 
-### Email Design
+### Email design
 - Keep subject lines clear and compelling
 - Use responsive design for mobile devices
 - Include clear calls-to-action
 - Maintain consistent branding
 
-### Content Strategy
+### Content strategy
 - Personalize messages with dynamic content
 - Provide valuable, relevant information
 - Use appropriate tone for your audience
 - Test different content approaches
 
-### Sending Strategy
+### Sending strategy
 - Send at optimal times for your audience
 - Maintain consistent sending schedule
 - Segment your audience for targeted messaging
@@ -128,7 +124,7 @@ Set up sophisticated automation flows that combine business data with targeted c
 - Respect recipient preferences and opt-outs
 - Follow email marketing best practices
 
-## Frequently Asked Questions
+## Frequently asked questions
 
 <details>
 <summary>Does archiving an active email campaign stop it from sending?</summary>
@@ -139,13 +135,13 @@ Archiving a campaign will **not** stop it from sending to already added accounts
 <details>
 <summary>How do I pause and unpause email campaigns?</summary>
 
-Email campaigns can be paused from Partner Center by going to Marketing > Campaigns, finding your campaign, clicking the three dots, and selecting "Pause Campaign" or "Resume Campaign". Note that pausing will reset drip timing and move buffering recipients to stopped status.
+Email campaigns can be paused from Partner Center by going to `Marketing` → `Campaigns`, finding your campaign, clicking the three dots, and selecting `Pause Campaign` or `Resume Campaign`. Note that pausing will reset drip timing and move buffering recipients to stopped status.
 </details>
 
 <details>
 <summary>Can I remove a user from a campaign?</summary>
 
-Yes, you can remove users from campaigns by going to their account page, finding the user, clicking the menu icon next to them, selecting "Campaigns", and clicking "Pause" next to the active campaign.
+Yes, you can remove users from campaigns by going to their account page, finding the user, clicking the menu icon next to them, selecting `Campaigns`, and clicking `Pause` next to the active campaign.
 </details>
 
 <details>
@@ -163,7 +159,7 @@ This happens because your test email is not associated with a real account on th
 <details>
 <summary>I need to set up a mailing address for campaigns - where do I do this?</summary>
 
-Go to Partner Center > Administration > Customize > Partner Defaults, scroll to "Required Contact Information for Campaigns" and fill out all required fields. Then go to Markets, select your market, and choose whether to use Partner's or Market's contact information.
+Go to `Partner Center` → `Administration` → `Customize` → `Partner Defaults`, scroll to `Required Contact Information for Campaigns` and fill out all required fields. Then go to Markets, select your market, and choose whether to use Partner's or Market's contact information.
 </details>
 
 <details>
@@ -176,7 +172,7 @@ Go to Partner Center > Administration > Customize > Partner Defaults, scroll to 
 <summary>How do I unpublish an email campaign?</summary>
 
 **If no accounts have been added to the campaign yet:**
-You can unpublish a published email campaign by clicking the blue "Unpublish" button in the top right corner of the campaign details page.
+You can unpublish a published email campaign by clicking the blue `Unpublish` button in the top right corner of the campaign details page.
 
 **If accounts have already been added to the campaign:**
 Once an email campaign has accounts added to it, it cannot be unpublished directly. Instead, you have these options:
@@ -195,23 +191,24 @@ This prevents disruption to ongoing campaigns and maintains data integrity for r
 <details>
 <summary>Can I edit a recommended campaign directly, or save it as an email template?</summary>
 
-Recommended campaigns are read-only — you can't edit them in place or save them as a standalone email template. To use one:
+Recommended campaigns are read-only: you can't edit them in place or save them as a standalone email template. To use one:
 
-1. Go to **Marketing** → **Campaigns** → **Recommended Campaigns**.
-2. Click the campaign name, then click **Actions** → **Copy**.
-3. Open the copy and edit it freely — it's now your own campaign in Draft status.
+1. Go to `Marketing` → `Campaigns` → `Recommended Campaigns`.
+2. Click the campaign name, then click `Actions` → `Copy`.
+3. Open the copy and edit it freely. It's now your own campaign in Draft status.
 
 The copy-first model means your edits never affect the original recommended campaign.
 
 **Why do CTAs give a 404 error when I test a recommended campaign?**
 
-If you preview or test a recommended campaign using a generic test account, any CTA buttons that link to the recipient's Business App (such as product activation or report buttons) will return a 404 error — because those links require a real account with a real user. To test CTAs, use a real account and add yourself as a user, then send the campaign to that account.
+If you preview or test a recommended campaign using a generic test account, any CTA buttons that link to the recipient's Business App (such as product activation or report buttons) will return a 404 error, because those links require a real account with a real user. To test CTAs, use a real account and add yourself as a user, then send the campaign to that account.
 </details>
 
 <details>
 <summary>Where did the Acquisition, Adoption, and Upsell campaign sections go?</summary>
 
-These campaign types were previously displayed as separate sections in the Campaigns view. They're now organized using **tags** in the main Campaigns list — the content is all still there, just accessed differently.
+{/* SME/writer review: this FAQ answer references a past change ("previously displayed", "now organized") to explain where old sections went, which conflicts with evergreen style. Confirm whether the historical framing should stay (since that's the question being answered) or be reworded to describe only the current tag-based system. */}
+These campaign types were previously displayed as separate sections in the Campaigns view. They're now organized using **tags** in the main Campaigns list. The content is all still there, just accessed differently.
 
 **To find your old campaigns:**
 1. Go to **Marketing** → **Campaigns**.
@@ -221,7 +218,7 @@ These campaign types were previously displayed as separate sections in the Campa
 1. Open a campaign.
 2. Click **Manage Tags** (or the tag icon) to create a new tag or apply an existing one.
 
-Tags let you organize campaigns any way you like — you're not limited to the three default types. Consider creating tags for your own naming conventions, such as by market, product line, or funnel stage.
+Tags let you organize campaigns any way you like. You're not limited to the three default types. Consider creating tags for your own naming conventions, such as by market, product line, or funnel stage.
 </details>
 
 <details>
@@ -241,7 +238,7 @@ The quota resets daily. If you need a higher email limit, consider upgrading you
 
 **Campaign sending throughput:** Campaigns send at approximately **4 emails per minute** regardless of list size. This rate is fixed to protect domain reputation and deliverability. For large lists, this means a campaign to 1,000 contacts takes roughly 4 hours to complete. To work around this for time-sensitive sends, split your list into smaller segments and schedule them across multiple days.
 
-**SMB sending allowance:** Businesses (SMBs) sending emails through their own Campaigns have a separate daily allowance — up to 100,000 emails per day — once the SMB domain is configured for Campaigns in Email Settings. This allowance is independent of the partner-level quota above.
+**SMB sending allowance:** Businesses (SMBs) sending emails through their own Campaigns have a separate daily allowance, up to 100,000 emails per day, once the SMB domain is configured for Campaigns in Email Settings. This allowance is independent of the partner-level quota above.
 
 </details>
 
@@ -250,9 +247,9 @@ The quota resets daily. If you need a higher email limit, consider upgrading you
 
 Campaigns go through a queue before emails start sending. The processing window is typically **10–15 minutes** before the first batch goes out. If the campaign is still stuck after 15 minutes:
 
-1. **Confirm all required fields are filled in** — Missing sender information, mailing address, or required campaign fields can prevent sending. Check **Partner Center > Administration > Partner Defaults** to verify your mailing address is configured.
-2. **Check for invalid contact addresses** — Invalid or malformed email addresses in your audience can stall the sending queue. Remove any contacts with clearly invalid addresses and retry.
-3. **Retry the campaign** — Go to **Marketing > Campaigns**, find the campaign, and check whether a retry option is available.
+1. **Confirm all required fields are filled in**: Missing sender information, mailing address, or required campaign fields can prevent sending. Check `Partner Center` → `Administration` → `Partner Defaults` to verify your mailing address is configured.
+2. **Check for invalid contact addresses**: Invalid or malformed email addresses in your audience can stall the sending queue. Remove any contacts with clearly invalid addresses and retry.
+3. **Retry the campaign**: Go to `Marketing` → `Campaigns`, find the campaign, and check whether a retry option is available.
 
 If the campaign remains stuck after these steps, contact Vendasta support.
 
@@ -261,9 +258,9 @@ If the campaign remains stuck after these steps, contact Vendasta support.
 <details>
 <summary>Some contacts didn't receive the campaign email. How do I check and retry?</summary>
 
-1. Go to **Marketing > Campaigns** and open the campaign
-2. Check the **Campaign Reports** tab to see delivery status by contact — look for drops, bounces, or undelivered entries
-3. For contacts who were dropped rather than bounced, you may be able to re-add them and resend
+1. Go to `Marketing` → `Campaigns` and open the campaign
+2. Check the **Campaign Reports** tab to see delivery status by contact. Look for drops, bounces, or undelivered entries
+3. For contacts who were dropped rather than bounced, you can re-add them and resend
 4. For very large lists, consider splitting into smaller batches on future sends to make it easier to identify and retry any drops
 
 Hard-bounced addresses (permanent delivery failures) cannot be automatically resubscribed. Contact Vendasta support if you need to reinstate a contact that hard-bounced.
@@ -276,7 +273,7 @@ Hard-bounced addresses (permanent delivery failures) cannot be automatically res
 | Code | Meaning | What to do |
 |------|---------|-----------|
 | `550 Blocked` | The receiving server rejected the email | Check whether your IP or domain is on a blacklist at [MXToolbox](https://mxtoolbox.com/blacklists.aspx) |
-| `550 5.7.509` (DMARC) | Email failed DMARC alignment | Verify your SPF and DKIM records are correctly configured and aligned — see [Email Authentication](/marketing/email-settings/email-authentication) |
+| `550 5.7.509` (DMARC) | Email failed DMARC alignment | Verify your SPF and DKIM records are correctly configured and aligned. See [Email Authentication](/marketing/email-settings/email-authentication) |
 | `550 5.7.606 Access denied` | IP address banned by the receiving server | This requires delisting; contact Vendasta support |
 | `550 5.1.1 User unknown` | The recipient email address doesn't exist | Remove the address from your list |
 
@@ -284,7 +281,7 @@ For a full list of error codes, see [Email Deliverability](/marketing/email-sett
 
 </details>
 
-## Need More Help?
+## Need more help?
 
 - [**Email Settings**](/marketing/email-settings) – Configure domain authentication and sender information
 - [**Automations**](/automations) – Set up automated campaign triggers

--- a/docusaurus/docs/marketing/campaigns/send-marketing-emails.mdx
+++ b/docusaurus/docs/marketing/campaigns/send-marketing-emails.mdx
@@ -6,8 +6,6 @@ sidebar_position: 2
 
 ---
 
-# Send marketing emails
-
 Email campaigns can be sent to contacts, companies, and lists through various methods in the Vendasta platform. The CRM-based approaches provide the most comprehensive functionality and tracking capabilities.
 
 ## Prerequisites
@@ -19,32 +17,32 @@ Before sending email campaigns, ensure you have:
 - **Prepared your audience** - Identify contacts, companies, or lists to receive the campaign. Learn about [CRM contact fields](/crm/contacts/crm-default-contact-fields) and [CRM company fields](/crm/companies/crm-default-company-fields) for targeting options
 - **Verified mailing address** - Ensure your business mailing address is configured in Partner Center. See [Email Settings requirements](/marketing/email-settings/email-settings-requirements) for details
 
-## Primary Methods (Recommended)
+## Primary methods (recommended)
 
-### 1. Send to CRM Contacts
+### 1. Send to CRM contacts
 
-The primary and most powerful way to send campaigns is through CRM contacts, which provides full field support and comprehensive tracking:
+The primary and recommended way to send campaigns is through CRM contacts, which provides full field support and comprehensive tracking:
 
 **Via Contact Selection:**
-1. Go to **Partner Center > CRM > Contacts**
+1. Go to `Partner Center` → `CRM` → `Contacts`
 2. Select the contacts you want to include (Or Apply Filter and click Select All ) 
-3. Click **Actions > Add to campaign**
+3. Click `Actions` → `Add to campaign`
 4. Choose your campaign and configure sending options
 5. Click **Start Campaign**
 
 **Via CRM Contact Lists (Smart or Static):**
-1. Go to **Partner Center > CRM > Lists** 
+1. Go to `Partner Center` → `CRM` → `Lists`
 2. Create or select a contact list (smart lists automatically update based on criteria)
-3. Click **Three dots > More action** from the list menu
-4. Select **"Start Campaign for Contact"** or **"Send Email to Contact"**
+3. Click `Three dots` → `More action` from the list menu
+4. Select `Start Campaign for Contact` or `Send Email to Contact`
 5. Choose your campaign and start sending
 
 **Via Automation Steps:**
-- Use **"Start Campaign for Contact"** automation step
-- Use **"Send Email to Contact"** automation step
+- Use `Start Campaign for Contact` automation step
+- Use `Send Email to Contact` automation step
 - Trigger campaigns based on contact actions, form submissions, or data changes
 
-### 2. Send to CRM Companies
+### 2. Send to CRM companies
 
 Send campaigns to entire companies through the CRM system. When you target a company, the campaign automatically sends emails to all associated contacts at that company (up to 50 contacts per company) while using company-level data for personalization.
 
@@ -55,23 +53,23 @@ Send campaigns to entire companies through the CRM system. When you target a com
 - Perfect for account-based marketing and business-level messaging
 
 **Via CRM Company Lists:**
-1. Go to **Partner Center > CRM > Lists**
+1. Go to `Partner Center` → `CRM` → `Lists`
 2. Create or select a company list
-3. Click **Three dots > More action** from the list menu
-4. Select **"Start Campaign for Company"** or **"Send Email to Company"**
+3. Click `Three dots` → `More action` from the list menu
+4. Select `Start Campaign for Company` or `Send Email to Company`
 5. Choose your campaign targeting companies
 
 **Via Automation Steps:**
-- Use **"Start Campaign for Company"** automation step  
-- Use **"Send Email to Company"** automation step
-- Use **"Get Associated Company"** step if using an account trigger
+- Use `Start Campaign for Company` automation step
+- Use `Send Email to Company` automation step
+- Use `Get Associated Company` step if using an account trigger
 - Target based on company characteristics, product usage, or business data
 
-### 3. Send Through CRM Automation (Advanced)
+### 3. Send through CRM automation (advanced)
 
 Set up sophisticated automated campaigns with business logic:
 
-1. Go to **Partner Center > Automations**
+1. Go to `Partner Center` → `Automations`
 2. Create automation workflows with triggers like:
    - Form submissions
    - Contact engagement patterns
@@ -84,7 +82,7 @@ Set up sophisticated automated campaigns with business logic:
 - **Send Email to Contact/Company** – Sends a direct email to the selected contact or company
 - **Campaign Step** - Use existing campaigns as building blocks within automation workflows
 
-## Benefits of CRM-Based Sending
+## Benefits of CRM-based sending
 
 - **Complete Field Access** - Use all [CRM contact fields](/crm/contacts/crm-default-contact-fields) and [CRM company fields](/crm/companies/crm-default-company-fields) in dynamic content
 - **Primary Company Data** - Company fields automatically use the contact's primary company information  
@@ -92,16 +90,16 @@ Set up sophisticated automated campaigns with business logic:
 - **Smart Segmentation** - Create dynamic lists that automatically update based on criteria
 - **Advanced Automation** - Trigger campaigns based on complex business rules and contact behavior
 
-## Choosing Between Contact vs Company Targeting
+## Choosing between contact vs company targeting
 
-### Send to CRM Contacts When:
+### Send to CRM contacts when:
 - **Individual Focus**: Personalizing content for specific roles, interests, or individual behavior
 - **Role-Based Messaging**: Sending different content to different job functions (owner vs staff)
 - **Personal Relationships**: Building individual relationships and personal touchpoints
 - **Engagement-Based**: Targeting based on individual login, usage, or interaction history
 - **Permission-Based**: Sending only to contacts who have specifically opted in
 
-### Send to CRM Companies When:
+### Send to CRM companies when:
 - **Account-Based Marketing**: Targeting entire business accounts as strategic units
 - **Business Decisions**: Promoting products/services that require business-level decision making  
 - **Company Performance**: Using business metrics, rankings, or performance data for messaging
@@ -109,7 +107,7 @@ Set up sophisticated automated campaigns with business logic:
 - **Revenue Opportunities**: Targeting based on business size, growth potential, or product gaps
 - **Industry Campaigns**: Sending industry-specific content relevant to the entire business
 
-### Company Data Available for Personalization
+### Company data available for personalization
 
 All [CRM company fields](/crm/companies/crm-default-company-fields) are available for dynamic content including:
 - **Company Information**: Company name, website, address details, phone number, number of employees
@@ -121,46 +119,46 @@ All [CRM company fields](/crm/companies/crm-default-company-fields) are availabl
 - **Snapshot Report details**: Enrichment from the Snapshot Report, the section's grades and the details
 - **Product details**: The active products on a company
 
-## Alternative Methods
+## Alternative methods
 
-### Account/User-Based Sending
+### Account/user-based sending
 
 For specific use cases, you can also send campaigns through account management:
 
 **Send to Account Lists:**
-1. Go to **Partner Center > Marketing > Campaigns**  
+1. Go to `Partner Center` → `Marketing` → `Campaigns`
 2. Find your campaign and click the **3-dot menu**
 3. Select **Add account list to campaign**
 4. Configure sending options
 
 **Send to Individual Accounts:**
-1. Go to **Partner Center > Accounts > Manage [Accounts](https://partners.vendasta.com/manage-accounts)**
+1. Go to `Partner Center` → `Accounts` → [`Manage Accounts`](https://partners.vendasta.com/manage-accounts)
 2. Find the company account, then click on the account name
-3. On the account details page, scroll down to the **Users** section. Click the **menu** icon ![Menu icon](./img/marketing/marketing-campaigns/recipient-campaigns/menu-icon.jpg) beside the User
-4. Select **Campaigns** from the menu  
+3. On the account details page, scroll down to the `Users` section. Click the `menu` icon ![Menu icon](./img/marketing/marketing-campaigns/recipient-campaigns/menu-icon.jpg) beside the User
+4. Select `Campaigns` from the menu  
 ![Select Campaigns from menu](./img/marketing/marketing-campaigns/recipient-campaigns/select-campaigns.jpg)
-5. Find the campaign and click **Start** next to the campaign name  
+5. Find the campaign and click `Start` next to the campaign name  
 ![Start campaign](./img/marketing/marketing-campaigns/recipient-campaigns/start-campaign.jpg)
 
-## Smart Automation Examples
+## Smart automation examples
 
-### Product Upselling Campaigns
+### Product upselling campaigns
 Filter companies with no active product (such as Conversation AI) and automatically send upselling campaigns highlighting the benefits and ROI potential for their business size and industry.
 
-### Performance-Based Campaigns  
+### Performance-based campaigns
 Use snapshot report data to identify companies with low listing scores or poor online visibility, then automatically send improvement campaigns with actionable recommendations.
 
-### Engagement Recovery Campaigns
+### Engagement recovery campaigns
 Target contacts who haven't engaged recently, sending re-engagement campaigns with personalized incentives.
 
-## Campaign Configuration Options
+## Campaign configuration options
 
-### Scheduling Options
+### Scheduling options
 When sending campaigns, you can:
 - **Send immediately** - Campaign starts right away
 - **Schedule for later** - Set a specific date and time
 
-### Sender Configuration
+### Sender configuration
 Configure who the campaign is sent from:
 1. **Default sender** - Uses your configured email settings
 2. **Salesperson assignment** - When a salesperson is assigned to an account, their information will be used as the sender, overriding your partner-level sender settings
@@ -168,7 +166,7 @@ Configure who the campaign is sent from:
 
 **How salesperson sender override works:**
 
-When an account has an assigned salesperson, campaign emails go out from the salesperson's email address and name — not your partner-level "from" address. This is by design so replies go directly to the salesperson managing the relationship.
+When an account has an assigned salesperson, campaign emails go out from the salesperson's email address and name, not your partner-level "from" address. This is by design so replies go directly to the salesperson managing the relationship.
 
 If the salesperson's email is on an unverified or unauthenticated domain, the platform automatically sends the email from your verified domain while preserving the salesperson's name as the display name (e.g., `Jane Smith via yourdomain.com`). This may appear in Gmail as "via yourdomain.com" in the sender line.
 
@@ -176,15 +174,15 @@ If the salesperson's email is on an unverified or unauthenticated domain, the pl
 
 **Reply-to addresses:**
 
-The **Reply Address** field in **Marketing** → **Email Settings** → **Sender and Reply Settings** applies to system emails only (such as Daily Digest notifications) — not to campaign emails. Campaign replies go to the sender address (salesperson or partner-level sender, as described above).
+The **Reply Address** field in **Marketing** → **Email Settings** → **Sender and Reply Settings** applies to system emails only (such as Daily Digest notifications), not to campaign emails. Campaign replies go to the sender address (salesperson or partner-level sender, as described above).
 
-### Email Deliverability Settings
+### Email deliverability settings
 Ensure successful delivery by:
 - **Verifying domain authentication** - Check SPF, DKIM, and DMARC records are properly configured. See [Email Authentication](/marketing/email-settings/email-authentication) and [Update Email Settings](/marketing/email-settings/update-email-settings) for setup instructions
 - **Include correct physical address** - CAN-SPAM law requires a valid physical postal address in all commercial emails. Configure your business address in [Email Settings Requirements](/marketing/email-settings/email-settings-requirements)
 - **Testing campaigns** - Always send test emails before launching to full audience. Learn about [Email Deliverability best practices](/marketing/email-settings/email-deliverability) which includes troubleshooting common delivery errors
 
-## Monitor Campaign Performance
+## Monitor campaign performance
 
 After sending campaigns:
 - Track open rates and click-through rates in campaign analytics
@@ -198,7 +196,7 @@ For detailed guidance on analyzing your campaign results, see [Track Email Campa
 Use CRM-based methods whenever possible for better data integration, tracking capabilities, and automation potential. The CRM approach provides more granular control and comprehensive contact management.
 :::
 
-## Frequently Asked Questions
+## Frequently asked questions
 
 <details>
 <summary>Can I customize which users on an account receive an email campaign?</summary>
@@ -208,7 +206,7 @@ No, this is not possible when using account-based sending methods. If an account
 **Alternative approaches for targeted sending:**
 - **Use CRM Contacts**: Send campaigns directly to specific contacts through the CRM system for precise targeting
 - **Use Contact Lists**: Create targeted lists of specific contacts and send campaigns to those lists
-- **Individual Campaign Sending**: Send campaigns to individual users through Partner Center > Accounts > Manage Accounts > User menu > Campaigns
+- **Individual Campaign Sending**: Send campaigns to individual users through `Partner Center` → `Accounts` → `Manage Accounts` → `User menu` → `Campaigns`
 
 The CRM-based contact targeting methods provide much more flexibility and control over exactly who receives your campaigns.
 </details>

--- a/docusaurus/docs/marketing/campaigns/track-email-campaign-performance.mdx
+++ b/docusaurus/docs/marketing/campaigns/track-email-campaign-performance.mdx
@@ -5,8 +5,6 @@ sidebar_label: Track Email Campaign Performance
 sidebar_position: 17
 ---
 
-# Track Email Campaign Performance
-
 ## Overview
 
 Once you start an email marketing campaign, Vendasta tracks how recipients engage with the campaign to help you make insightful decisions. The platform provides campaign statistics that give you visibility into your email performance across multiple levels:
@@ -45,12 +43,12 @@ Unfortunately, these external initiations are out of our control. To maintain ac
 - **Open Rate** - describes what percentage of your emails have been opened by your recipients. This is calculated by dividing the number of opened emails with the number of delivered emails.
 - **CTOR** - stands for Click-to-open rate, and describes what percentage of your opened emails have had links on their content body clicked. This is calculated by dividing the number of clicks captured with the number of emails opened.
 
-### Campaign Details page
+### Campaign details page
 ![Campaign Details page](./img/marketing-campaigns/track-email-campaign-performance/campaign-details-page.png)
 
 #### Campaign status
 - **Recipients** - how many recipients were added to the campaign. This statistic matches the Total Recipients statistic in the Campaigns page.
-- **Rate limited** - how many campaigns are currently unable to progress because of a rate limit in place. See [Rate limit](/marketing/campaigns/configure-campaigns#rate-limit) for details. 
+- **Rate limited** - how many campaigns are currently unable to progress because of a rate limit in place. See [Rate limit](/marketing/campaigns/create-email-campaigns#rate-limiting) for details. 
 - **In progress** - how many campaigns are still in the process of sending emails.
 - **Stopped** - how many campaigns have been manually paused. This includes campaigns whose recipient has unsubscribed from. 
 - **Completed** - how many campaigns whose emails have all been delivered. **Note:** this does not mean that the recipient has received the email; only that SendGrid has successfully sent the email to the recipient's email server. It will be up to the recipient's email server to determine if the email can be sent to the recipient's inbox.
@@ -96,13 +94,13 @@ You can find these cards by clicking on the three dots on any of the step panels
 - **Opens** - how many emails were opened.
 - **Clicks** - how many emails whose links were clicked on the content body.
 
-#### Link Activity
+#### Link activity
 This section gives insights as to what links have been clicked, as well as how many times and by which recipients. 
 
 - **Total Clicks** - how many times a link has been clicked in total. This counts multiple clicks from the same email.
 - **Unique Clicks** - how many recipients have clicked on the link. This filters out multiple clicks from the same email.
 
-#### Delivery Status
+#### Delivery status
 - **Delivered** - how many emails in that step were successfully delivered to the recipient's email server. This matches the Delivered step in the Campaign step overview.
 - **Pending** - how many recipients haven't received the email for that step. This matches the Pending step in the Campaign step overview.
 - **Bounced** - how many emails were rejected from the recipient's email server.
@@ -110,16 +108,12 @@ This section gives insights as to what links have been clicked, as well as how m
 - **Unsubscribed** - how many recipients clicked on the 'Opt Out of All Emails' link.
 - **Dropped** - how many emails were rejected by SendGrid. 
 
-## Export Campaign Activity
+## Export campaign activity
 
 After starting an email campaign, you can export a list of users who interacted with the campaign. Then, you can use that exported data to create a new user list and retarget those users with another campaign.
 
 To export campaign activity:
 
-1. Go to **Marketing > Campaigns**.
+1. Go to `Marketing` → `Campaigns`.
 2. Go to the **Campaign Activity** page.
-3. At the end of a row in the campaigns table, click the three dots next to the Campaign, then click **View History**.
-
-## Why is this important?
-
-The Email Builder streamlines the process of creating emails, offering an easy-to-use drag-and-drop functionality. This empowers you to save time and craft effective emails that engage prospects and drive conversions.
+3. At the end of a row in the campaigns table, click the three dots next to the Campaign, then click `View History`.

--- a/docusaurus/docs/reports/premium-reports/access-controls.mdx
+++ b/docusaurus/docs/reports/premium-reports/access-controls.mdx
@@ -4,12 +4,10 @@ description: How to control who on your team can see Premium Reports and how to 
 sidebar_position: 5
 ---
 
-# Premium Reports access controls
-
 Premium Reports has two layers of access control that work together:
 
-1. **Team-wide access** — a permission on each admin that decides whether they can see Premium Reports at all, and whether they can change who has access.
-2. **Per-report sharing** — Google Docs-style sharing on each individual report that lets you grant or restrict access to specific people.
+1. **Team-wide access**: a permission on each admin that decides whether they can see Premium Reports at all, and whether they can change who has access.
+2. **Per-report sharing**: Google Docs-style sharing on each individual report that lets you grant or restrict access to specific people.
 
 A user must clear both layers to view a report. This page explains how each layer works and how to configure them.
 
@@ -19,9 +17,9 @@ A user must clear both layers to view a report. This page explains how each laye
 
 The team-wide permission lives on each admin in [My Team](/administration/my-account/my-team/).
 
-1. Go to **Partner Center** → **Administration** → **[My Team](https://partners.vendasta.com/my-team)**
+1. Go to `Partner Center` → `Administration` → [`My Team`](https://partners.vendasta.com/my-team)
 2. Click an admin's name to open their permissions
-3. Expand **Show more permissions**
+3. Expand `Show more permissions`
 4. Find the **Premium Reports** dropdown
 
 <img src={require('./img/access-controls-team-member-dropdown.png').default} alt="Premium Reports permission dropdown in the My Team edit panel" style={{width: '50%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
@@ -30,21 +28,21 @@ The team-wide permission lives on each admin in [My Team](/administration/my-acc
 
 | Option | What the user can do |
 |---|---|
-| **No access to reports** | Cannot open Premium Reports. |
-| **View all unrestricted reports** | Can open any report that is shared with the whole team. Cannot change who has access. |
-| **Manage permissions for all unrestricted reports** | Can open any report shared with the whole team, and can change its per-report sharing settings. Required to grant other users access to reports. |
+| `No access to reports` | Cannot open Premium Reports. |
+| `View all unrestricted reports` | Can open any report that is shared with the whole team. Cannot change who has access. |
+| `Manage permissions for all unrestricted reports` | Can open any report shared with the whole team, and can change its per-report sharing settings. Required to grant other users access to reports. |
 
 "Unrestricted reports" are reports that have not been locked down to specific people. See [How the two layers work together](#how-the-two-layers-work-together) below.
 
 ### Who can change this setting
 
-Editing another team member's Premium Reports permission follows the same rules as editing any other admin permission in My Team — the editor must be an admin with the [**Can create and manage admins**](/administration/my-account/my-team/permissions#can-create-and-manage-admins) permission.
+Editing another team member's Premium Reports permission follows the same rules as editing any other admin permission in My Team: the editor must be an admin with the [**Can create and manage admins**](/administration/my-account/my-team/permissions#can-create-and-manage-admins) permission.
 
 ### Defaults and limitations
 
 - This dropdown is only available for team members who have the **admin** role. Salespeople and other non-admin team members cannot be granted access to Premium Reports.
-- New admins are created with **View all unrestricted reports** by default.
-- The dropdown is **disabled** for admins whose market access is restricted to specific [markets](/administration/platform-settings/customize/market-settings). To grant Premium Reports access, the admin must have access to **All markets**.
+- New admins are created with `View all unrestricted reports` by default.
+- The dropdown is **disabled** for admins whose market access is restricted to specific [markets](/administration/platform-settings/customize/market-settings). To grant Premium Reports access, the admin must have access to `All markets`.
 
 :::info
 Changing this dropdown takes effect the next time the user loads Premium Reports.
@@ -52,16 +50,16 @@ Changing this dropdown takes effect the next time the user loads Premium Reports
 
 ## Layer 2: Per-report sharing
 
-Once an admin has team-wide access, you can further restrict each individual report using per-report sharing — similar to how Google Docs and Confluence pages can be shared.
+Once an admin has team-wide access, you can further restrict each individual report using per-report sharing, similar to how Google Docs and Confluence pages can be shared.
 
 ### Where to find it
 
 Open any Premium Report, then either:
 
 - Click the **lock icon** in the report toolbar, or
-- Click the three-dot menu in the top right and choose **Edit permissions**
+- Click the three-dot menu in the top right and choose `Edit permissions`
 
-The lock icon also indicates the report's current sharing mode at a glance — a red lock means the report is restricted to specific people.
+The lock icon also indicates the report's current sharing mode at a glance: a red lock means the report is restricted to specific people.
 
 ### The three sharing modes
 
@@ -69,26 +67,26 @@ The lock icon also indicates the report's current sharing mode at a glance — a
 
 | Mode | Who can view | Who can manage permissions |
 |---|---|---|
-| **Any admin can view and manage** | Any admin with **View** or **Manage permissions** | Any admin with **Manage permissions** |
-| **Any admin can view, only some can manage** | Any admin with **View** or **Manage permissions** | Only the specific people listed |
-| **Only specific people can view or manage** | Only the specific people listed | Only the specific people listed with **Can manage** |
+| `Any admin can view and manage` | Any admin with `View` or `Manage permissions` | Any admin with `Manage permissions` |
+| `Any admin can view, only some can manage` | Any admin with `View` or `Manage permissions` | Only the specific people listed |
+| `Only specific people can view or manage` | Only the specific people listed | Only the specific people listed with `Can manage` |
 
-The first two modes leave the report **unrestricted** — any admin who has team-wide access can open it. The third mode makes the report **restricted** — even admins with team-wide access cannot open it unless they are listed.
+The first two modes leave the report **unrestricted**: any admin who has team-wide access can open it. The third mode makes the report **restricted**: even admins with team-wide access cannot open it unless they are listed.
 
 ### Adding specific people
 
-When the mode is **Any admin can view, only some can manage** or **Only specific people can view or manage**, you can add individual users to the access list.
+When the mode is `Any admin can view, only some can manage` or `Only specific people can view or manage`, you can add individual users to the access list.
 
 <img src={require('./img/access-controls-permissions-specific-people.png').default} alt="Adding specific users to a per-report access list" style={{width: '50%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
 
-1. Type a team member's name in the **Type a user name** field
+1. Type a team member's name in the `Type a user name` field
 2. Pick an access level:
-   - **Can view** — the user can open the report
-   - **Can manage** — the user can open the report and change its sharing settings
-3. Click **Add**
-4. Click **Save** to apply
+   - **Can view**: the user can open the report
+   - **Can manage**: the user can open the report and change its sharing settings
+3. Click `Add`
+4. Click `Save` to apply
 
-Repeat to add more users. Use **Remove** beside an existing entry to revoke access.
+Repeat to add more users. Use `Remove` beside an existing entry to revoke access.
 
 :::tip
 You are always added to the access list with **Can manage** when you save, so you cannot accidentally lock yourself out of a report.
@@ -100,8 +98,8 @@ Two rows always appear at the bottom of the access list:
 
 <img src={require('./img/access-controls-permissions-default-open.png').default} alt="Default Permissions dialog with All admins group rows" style={{width: '50%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
 
-- **All admins with report view access** — represents every admin whose team-wide permission is **View all unrestricted reports**.
-- **All admins with report manage access** — represents every admin whose team-wide permission is **Manage permissions for all unrestricted reports**.
+- `All admins with report view access`: represents every admin whose team-wide permission is `View all unrestricted reports`.
+- `All admins with report manage access`: represents every admin whose team-wide permission is `Manage permissions for all unrestricted reports`.
 
 Their effective access depends on the sharing mode:
 
@@ -117,24 +115,24 @@ These rows let you see at a glance what the rest of your team can do without lis
 
 A user can open a Premium Report only if **both** of the following are true:
 
-1. **Team-wide:** Their My Team permission is **View all unrestricted reports** or **Manage permissions for all unrestricted reports**.
-2. **Per-report:** Either the report's sharing mode is **Any admin can view and manage** or **Any admin can view, only some can manage** *(making it "unrestricted")*, **or** they are listed by name on the report's access list.
+1. **Team-wide:** Their My Team permission is `View all unrestricted reports` or `Manage permissions for all unrestricted reports`.
+2. **Per-report:** Either the report's sharing mode is `Any admin can view and manage` or `Any admin can view, only some can manage` *(making it "unrestricted")*, **or** they are listed by name on the report's access list.
 
-To change a report's sharing settings, a user must also have **Can manage** on that specific report — either through the **Any admin can view and manage** mode plus the **Manage permissions** team-wide permission, or by being listed explicitly with **Can manage** access.
+To change a report's sharing settings, a user must also have `Can manage` on that specific report, either through the `Any admin can view and manage` mode plus the `Manage permissions` team-wide permission, or by being listed explicitly with `Can manage` access.
 
 ## Troubleshooting
 
 **Q: I'm trying to add a teammate to a report and they appear greyed out with "Does not have access to reports".**
 
-A: That teammate's team-wide Premium Reports permission is set to **No access to reports**. Before you can grant them access to a specific report, update their My Team permission to at least **View all unrestricted reports**.
+A: That teammate's team-wide Premium Reports permission is set to `No access to reports`. Before you can grant them access to a specific report, update their My Team permission to at least `View all unrestricted reports`.
 
 **Q: The Premium Reports dropdown is greyed out in My Team.**
 
-A: The admin you are editing is restricted to specific [markets](/administration/platform-settings/customize/market-settings). Premium Reports requires access to **All markets**. Update their market access first, then set the Premium Reports permission.
+A: The admin you are editing is restricted to specific [markets](/administration/platform-settings/customize/market-settings). Premium Reports requires access to `All markets`. Update their market access first, then set the Premium Reports permission.
 
 **Q: A team member can open a report but can't change its sharing settings.**
 
-A: Either their team-wide permission is set to **View all unrestricted reports** (which is view-only) or the report's mode is **Any admin can view, only some can manage** or **Only specific people can view or manage** and they aren't listed with **Can manage**. Add them explicitly with **Can manage**, or change their team-wide permission to **Manage permissions for all unrestricted reports** if appropriate.
+A: Either their team-wide permission is set to `View all unrestricted reports` (which is view-only) or the report's mode is `Any admin can view, only some can manage` or `Only specific people can view or manage` and they aren't listed with `Can manage`. Add them explicitly with `Can manage`, or change their team-wide permission to `Manage permissions for all unrestricted reports` if appropriate.
 
 ## Related articles
 


### PR DESCRIPTION
## Summary
- Runs the daily article-verification batch on 5 flagged articles (issues #951-#955): fixes heading casing, UI/nav-path formatting (bold/quoted → inline code, `>` → `→`), em dashes, duplicate H1s, a broken internal link, an off-topic copy-pasted section, and prohibited marketing/hedge terms
- Flags two remaining items inline in `create-email-campaigns.mdx` and `index.mdx` for SME/writer follow-up rather than guessing: an evergreen-style FAQ answer, and two scrambled/orphaned numbered-step fragments that don't clearly connect to any list in the article
- Updates the `article-verifications` skill so duplicate-H1 removal and em dash replacement are now auto-fixed rather than requiring approval on every run

## Test plan
- [ ] Spot-check the flagged quantitative claims in `index.mdx` (email quotas, bounce codes, sending throughput) against the live product
- [ ] Spot-check salesperson sender-override behavior and the 50-contacts-per-company limit in `send-marketing-emails.mdx`
- [ ] Resolve the two inline SME-review comments in `create-email-campaigns.mdx` (scrambled step lists, "legacy Email Builder" naming) and in `index.mdx` (Acquisition/Adoption/Upsell FAQ evergreen wording)
- [ ] `npm run build` in `docusaurus/` to confirm no broken links/build errors

Closes #954
Closes #953
Closes #951

🤖 Generated with [Claude Code](https://claude.com/claude-code)