### PR TITLE
docs: consistency pass on the learn paths

### DIFF
--- a/docusaurus/training/sales/_category_.json
+++ b/docusaurus/training/sales/_category_.json
@@ -1,5 +1,5 @@
 {
-  "label": "The Master Sales Series",
+  "label": "The master sales series",
   "position": 8,
   "collapsed": true,
   "link": {

--- a/docusaurus/training/sales/build-your-brand-and-your-day.mdx
+++ b/docusaurus/training/sales/build-your-brand-and-your-day.mdx
@@ -24,7 +24,7 @@ import Accordion from "@site/src/components/Accordion";
   time="about 18 minutes"
   required={["None"]}
   video={true}
-  pathName="The Master Sales Series"
+  pathName="The master sales series"
   step={1}
   totalSteps={5}
   outcomes={[
@@ -313,7 +313,7 @@ Two parts. First, write the "before and after" of your own website's opening lin
 
 <LessonFooter
   to="/learn/sales/find-your-next-prospect"
-  pathName="The Master Sales Series"
+  pathName="The master sales series"
   step={1}
   totalSteps={5}
   description="Now fill the funnel that day is built to work."

--- a/docusaurus/training/sales/build-your-brand-and-your-day.mdx
+++ b/docusaurus/training/sales/build-your-brand-and-your-day.mdx
@@ -37,7 +37,7 @@ import Accordion from "@site/src/components/Accordion";
 />
 
 {/* VIDEO: "The Perfect Sales Day" — Wistia ID `lq5ny4mfmt`, found by Shiva 2026-08-14 (the
-    standalone cut this lesson was drafted from, not the "Ep. 1" near-duplicate).
+    standalone cut this step was drafted from, not the "Ep. 1" near-duplicate).
     The brand-building half (Part 1) has no associated Wistia clip — sourced from the two
     audited 360Learning courses instead. */}
 
@@ -68,7 +68,9 @@ Watch sales expert George Leith walk through what a well-run sales day looks lik
 <script src="https://fast.wistia.net/player.js" async></script>
 
 
-## Build your brand
+## Decide who you serve, and tell their story
+
+A brand is a set of decisions, not a logo. Four of them do most of the work: who you serve, what those clients can expect, whose story your copy tells, and whether your operation keeps the promise.
 
 <Accordion
   items={[
@@ -125,7 +127,9 @@ Watch sales expert George Leith walk through what a well-run sales day looks lik
   ]}
 />
 
-## Run your sales day
+## Structure your selling day
+
+A producing day is a set of habits, not a schedule. These six separate the reps whose day generates conversations from the reps whose day generates admin.
 
 <Accordion
   items={[
@@ -194,6 +198,8 @@ Watch sales expert George Leith walk through what a well-run sales day looks lik
 />
 
 ## Split your book into A, B, and C
+
+Not every account deserves the same hour. Flip each tier to see what it gets from you:
 
 <FlipCardGrid>
   <FlipCard front="A accounts" back="Paying you real money right now. When an A account raises a hand, you drop what you are doing." subtext="Protect" />

--- a/docusaurus/training/sales/find-your-next-prospect.mdx
+++ b/docusaurus/training/sales/find-your-next-prospect.mdx
@@ -23,7 +23,7 @@ import Accordion from "@site/src/components/Accordion";
   time="about 12 minutes"
   required={["None"]}
   video={true}
-  pathName="The Master Sales Series"
+  pathName="The master sales series"
   step={2}
   totalSteps={5}
   outcomes={[
@@ -246,7 +246,7 @@ Both of them work on conversations that arrive at you or have already happened. 
   ]}
 />
 
-<LessonFooter to="/learn/sales/open-the-conversation" pathName="The Master Sales Series" step={2} totalSteps={5} />
+<LessonFooter to="/learn/sales/open-the-conversation" pathName="The master sales series" step={2} totalSteps={5} />
 
 </InlineHighlighter>
 <MarkComplete courseId="find-your-next-prospect" site="vendasta_learn" />

--- a/docusaurus/training/sales/find-your-next-prospect.mdx
+++ b/docusaurus/training/sales/find-your-next-prospect.mdx
@@ -63,7 +63,7 @@ Watch sales expert George Leith on what it takes to keep a funnel full.
 </div>
 <script src="https://fast.wistia.net/player.js" async></script>
 
-## Why the top rep last month is at the bottom this month
+## A full funnel beats a big deal
 
 You have seen it happen: someone crushes every record one month and is scraping the bottom of the leaderboard the next. It is almost never that they got worse at selling. It is that they stopped prospecting while they were busy servicing the deals they just won — and the funnel behind them went empty.
 
@@ -144,7 +144,7 @@ If you work a standard nine-to-five, make five prospecting calls before 9am and 
 
 Even on days this feels arbitrary, the discipline of doing it keeps prospecting as something you think about every day, not something you get to eventually.
 
-## Automate the part that should not take you hours by hand
+## Automate the outreach grind
 
 Everything above is a discipline. The next part is a tool. A sales engagement platform like Yesware plugs into Gmail or Outlook and takes over the mechanical side of outreach, so you spend your time on conversations instead of the busywork around them:
 

--- a/docusaurus/training/sales/handle-objections.mdx
+++ b/docusaurus/training/sales/handle-objections.mdx
@@ -18,7 +18,7 @@ import Accordion from "@site/src/components/Accordion";
 
 <CourseProgressBar courseId="handle-objections" site="vendasta_learn" />
 
-{/* Both video embeds for this lesson are placed inline below, under their matching headings.
+{/* Both video embeds for this step are placed inline below, under their matching headings.
     Shiva's 2026-08-14 verification found the two IDs originally listed here were swapped from
     what this comment said: `bm47k8n12o` is actually the "recognizing common objections" clip
     (price/authority/trust/complacency/recognition — placed under "The LAIR sequence"), and
@@ -78,7 +78,7 @@ Watch the five objections you will hear most, and the LAIR sequence for working 
 </div>
 <script src="https://fast.wistia.net/player.js" async></script>
 
-A repeatable order of operations for any objection, before you know which one you are dealing with.
+LAIR is a repeatable order of operations for any objection, before you know which specific one you are facing. The sequence matters more than any single line inside it.
 
 <Accordion
   items={[
@@ -126,6 +126,8 @@ A repeatable order of operations for any objection, before you know which one yo
 />
 
 ## The five objections you will hear most
+
+Almost every push-back is one of five: price, authority, trust, complacency, or a competitor. Naming which one you are facing tells you what to say back, and each opens with the words you will actually hear.
 
 <Accordion
   items={[
@@ -212,7 +214,7 @@ Then five higher-level strategies for when an objection stalls the deal.
   </div>
 </div>
 
-Not tied to any one objection. Reach for whichever fits the moment, or combine them.
+These five are not tied to any one objection. Reach for whichever fits the moment, or combine more than one when the conversation calls for it.
 
 <Accordion
   items={[

--- a/docusaurus/training/sales/handle-objections.mdx
+++ b/docusaurus/training/sales/handle-objections.mdx
@@ -30,7 +30,7 @@ import Accordion from "@site/src/components/Accordion";
   time="about 15 minutes"
   required={["A strategy already presented to this prospect"]}
   video={true}
-  pathName="The Master Sales Series"
+  pathName="The master sales series"
   step={5}
   totalSteps={5}
   outcomes={[
@@ -358,7 +358,7 @@ Pick an objection you heard this week. Run it through LAIR out loud — what wou
   ]}
 />
 
-<LessonFooter to="/learn/sales/master-sales-skill-check" pathName="The Master Sales Series" step={5} totalSteps={5} title="Last step done. Ready to test it?" />
+<LessonFooter to="/learn/sales/master-sales-skill-check" pathName="The master sales series" step={5} totalSteps={5} title="Last step done. Ready to test it?" />
 
 </InlineHighlighter>
 <MarkComplete courseId="handle-objections" site="vendasta_learn" />

--- a/docusaurus/training/sales/index.mdx
+++ b/docusaurus/training/sales/index.mdx
@@ -54,7 +54,7 @@ Each step pairs a video session with the practice behind it, and ends with a kno
       title: "Six habits for better prospecting",
       description: "Build a pipeline instead of waiting for one to show up.",
       topics: [
-        "Six habits that keep a funnel full",
+        "Automating the outreach grind",
         "The five-before-nine, nine-after-five rule",
         "Which AI Employees carry part of the load",
       ],

--- a/docusaurus/training/sales/index.mdx
+++ b/docusaurus/training/sales/index.mdx
@@ -1,8 +1,8 @@
 ---
-title: The Master Sales Series
+title: The master sales series
 sidebar_position: 0
 sidebar_label: Overview
-description: "The Master Sales Series with George Leith: running your sales day, prospecting, the elevator pitch, the presentation format, and handling objections."
+description: "The master sales series with George Leith: running your sales day, prospecting, the elevator pitch, the presentation format, and handling objections."
 hide_table_of_contents: true
 ---
 
@@ -25,7 +25,7 @@ import PathHeader from "@site/src/components/PathHeader";
   topics={["Prospecting", "Pitching", "Sales presentations", "Handling objections", "Sales productivity"]}
   time="about 1 hour"
   required={["None"]}
-  objective="The Master Sales Series with George Leith; how to run a sales day, keep a funnel full, pitch in the time it takes to ride three floors, structure a presentation that closes, and handle a prospect who pushes back."
+  objective="The master sales series with George Leith; how to run a sales day, keep a funnel full, pitch in the time it takes to ride three floors, structure a presentation that closes, and handle a prospect who pushes back."
   outcomes={[
     "You run a day that produces conversations instead of admin",
     "You keep a pipeline full instead of rebuilding it between big deals",

--- a/docusaurus/training/sales/master-sales-skill-check.mdx
+++ b/docusaurus/training/sales/master-sales-skill-check.mdx
@@ -2,7 +2,7 @@
 title: "Master sales skill check"
 sidebar_label: "Master sales skill check"
 sidebar_position: 6
-description: "Fifteen scenario questions covering the whole Master Sales Series."
+description: "Fifteen scenario questions covering the whole master sales series."
 ---
 
 import SkillCheck from "@site/src/components/SkillCheck";
@@ -19,7 +19,7 @@ import LessonFooter from "@site/src/components/LessonFooter";
 <LessonHeader
   difficulty="Intermediate"
   time="about 15 minutes"
-  required={["The five steps of the Master Sales Series"]}
+  required={["The five steps of the master sales series"]}
   outcomes={[
     "Apply the sales day, prospecting, pitch, presentation, and objection material to situations you have not seen before",
     "Spot which move a scenario calls for, rather than recalling a definition",
@@ -263,7 +263,7 @@ Questions are drawn from every step in the series. They are scenarios rather tha
 
 <LessonFooter
   to="/learn/growth-engine/"
-  pathName="The Master Sales Series"
+  pathName="The master sales series"
   step={5}
   totalSteps={5}
   nextPathName="Your growth engine"

--- a/docusaurus/training/sales/open-the-conversation.mdx
+++ b/docusaurus/training/sales/open-the-conversation.mdx
@@ -23,7 +23,7 @@ import Accordion from "@site/src/components/Accordion";
   time="about 12 minutes"
   required={["A prospect to call"]}
   video={true}
-  pathName="The Master Sales Series"
+  pathName="The master sales series"
   step={3}
   totalSteps={5}
   outcomes={[
@@ -206,7 +206,7 @@ Pick your next prospect. Write your pitch in four lines: the goal, the value in 
   ]}
 />
 
-<LessonFooter to="/learn/sales/present-so-it-lands" pathName="The Master Sales Series" step={3} totalSteps={5} />
+<LessonFooter to="/learn/sales/present-so-it-lands" pathName="The master sales series" step={3} totalSteps={5} />
 
 </InlineHighlighter>
 <MarkComplete courseId="open-the-conversation" site="vendasta_learn" />

--- a/docusaurus/training/sales/open-the-conversation.mdx
+++ b/docusaurus/training/sales/open-the-conversation.mdx
@@ -69,6 +69,8 @@ A pitch has one job: deliver enough value that the other person wants to keep ta
 
 ## Build it in four parts
 
+Every pitch that works carries the same four parts: a goal, the value in plain words, your edge, and a question. Each part earns the next.
+
 <Accordion
   items={[
     {

--- a/docusaurus/training/sales/present-so-it-lands.mdx
+++ b/docusaurus/training/sales/present-so-it-lands.mdx
@@ -23,7 +23,7 @@ import Accordion from "@site/src/components/Accordion";
   time="about 8 minutes"
   required={["A discovery call already run on this prospect"]}
   video={true}
-  pathName="The Master Sales Series"
+  pathName="The master sales series"
   step={4}
   totalSteps={5}
   outcomes={[
@@ -205,7 +205,7 @@ Write one sentence for each move for your next prospect: the insight you heard, 
   ]}
 />
 
-<LessonFooter to="/learn/sales/handle-objections" pathName="The Master Sales Series" step={4} totalSteps={5} />
+<LessonFooter to="/learn/sales/handle-objections" pathName="The master sales series" step={4} totalSteps={5} />
 
 </InlineHighlighter>
 <MarkComplete courseId="present-so-it-lands" site="vendasta_learn" />

--- a/docusaurus/training/sales/present-so-it-lands.mdx
+++ b/docusaurus/training/sales/present-so-it-lands.mdx
@@ -18,10 +18,6 @@ import Accordion from "@site/src/components/Accordion";
 
 <CourseProgressBar courseId="present-so-it-lands" site="vendasta_learn" />
 
-{/* VIDEO SLOT: source candidate is "Deliver Impact: The Art of Killer Sales Presentations"
-    (360Learning, already audited) — clip pending Workstream A's product-accuracy pass. Per the
-    IA spec (section 6), video is optional and never blocks shipping the text below. */}
-
 <LessonHeader
   difficulty="Intermediate"
   time="about 8 minutes"
@@ -135,7 +131,7 @@ The main pitch stays tight, and a curious owner can still go looking.
 Write one sentence for each move for your next prospect: the insight you heard, the deliverable, how you will prove it worked, and the exact words you will use to ask. Say the ask out loud beforehand. If it sounds like a question about whether you should ask, rewrite it.
 :::
 
-{/* No "do it, delegate it, or buy it" block here: this lesson teaches a rep's own presentation skill,
+{/* No "do it, delegate it, or buy it" block here: this step teaches a rep's own presentation skill,
     and there is no Vendasta Services equivalent to delegate a sales conversation to. */}
 
 <SectionFeedback courseId="present-so-it-lands" site="vendasta_learn" section="content" />

--- a/docusaurus/training/vibe/index.mdx
+++ b/docusaurus/training/vibe/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Build with Vibe
 sidebar_position: 0
-sidebar_label: Build with Vibe
+sidebar_label: Overview
 description: Describe what you want in plain English and ship real apps - landing pages, dashboards, and client portals.
 hide_table_of_contents: true
 ---


### PR DESCRIPTION
## For the human

Shiva — small polish PR on top of what merged in #959, nothing structural. Cal reviewed all of it on a local preview before this went up, so your pass here is a light one.

Everything in the sales path holds up as it was: the videos, the step order, the skill check, and the sidebar placement are untouched. This PR fixes the reading experience around them.

Three things changed that you will notice. The path name is now sentence case everywhere it renders, "The master sales series", matching every other category in the sidebar. Four section headings were renamed to match what the video and the outcomes actually promise, the clearest case being "Build your brand", which taught choosing a niche and telling the client's story rather than brand assets, and now says so. And every dropdown section now opens with a two-sentence framing paragraph instead of jumping from the heading straight into collapsed rows.

Nothing to decide and nothing blocking. The detail below has the file-by-file list, and thanks again for the review on the big one.

## Detail

**Heading renames** (no anchors referenced the old ones; TOCs verified in the built output):

| File | Old | New |
|---|---|---|
| `training/sales/build-your-brand-and-your-day.mdx` | Build your brand | Decide who you serve, and tell their story |
| `training/sales/build-your-brand-and-your-day.mdx` | Run your sales day | Structure your selling day |
| `training/sales/find-your-next-prospect.mdx` | Why the top rep last month is at the bottom this month | A full funnel beats a big deal |
| `training/sales/find-your-next-prospect.mdx` | Automate the part that should not take you hours by hand | Automate the outreach grind |

The elevator pitch, presentation, and objections steps were audited and left alone; their headings already track their outcomes.

**Lead-ins before components.** Seven accordion or flip-card sections across `build-your-brand-and-your-day.mdx`, `open-the-conversation.mdx`, and `handle-objections.mdx` now carry a short framing paragraph between the heading and the component. A source-level scan confirms no heading in the path is directly followed by an `<Accordion>` or `<FlipCardGrid>`.

**Small fixes:**

- `present-so-it-lands.mdx`: removed a stale `VIDEO SLOT ... pending` planning comment that sat directly above the video that got embedded.
- `sales/index.mdx`: the "Six habits for better prospecting" card led with the key topic "Six habits that keep a funnel full"; now "Automating the outreach grind", which also matches the renamed heading.
- `vibe/index.mdx`: `sidebar_label` was "Build with Vibe" while every other path overview says "Overview"; aligned. The Vibe category is still hidden, so nothing visible changes today.
- Three internal comments said "this lesson"; now "this step", keeping the banned word out of copy-paste range.

**Path name casing.** "The Master Sales Series" becomes "The master sales series" across the category label, overview title, description, objective, skill check copy, and every `pathName` prop — sentence case, like every other category. The internal comment naming the Wistia folder keeps that folder's actual title.

**Verified:** build passes with no new broken links or anchors; `pathName` matches its category label on all eight paths; the sales footer chain runs step 1 through 5 into the skill check and on to Your growth engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
