### PR TITLE
docs: rebuild the Get started path with flip cards and a wayfinding step 2

### DIFF
--- a/docusaurus/src/components/FlipCard.module.css
+++ b/docusaurus/src/components/FlipCard.module.css
@@ -102,3 +102,194 @@
 .cardLink:hover {
   text-decoration: underline;
 }
+
+/* --- Icon variant, ported from the Vendasta LEARN AI Foundations path --- */
+
+.showGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(175px, 1fr));
+  grid-auto-rows: 1fr;
+  gap: 1rem;
+  margin: 2rem 0;
+  align-items: stretch;
+}
+
+.showcase {
+  margin-top: 0;
+  height: 100%;
+  transition: transform 0.2s ease;
+}
+
+.showcase:hover {
+  transform: translateY(-2px);
+}
+
+.showcase:focus-visible {
+  outline: 2px solid var(--ifm-color-primary);
+  outline-offset: 3px;
+  border-radius: 12px;
+}
+
+.showcase .cardInner {
+  display: grid;
+  height: 100%;
+  min-height: 240px;
+  transition: transform 0.5s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.showFront,
+.showBack {
+  position: relative;
+  grid-area: 1 / 1;
+  width: 100%;
+  backface-visibility: hidden;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 1.5rem 1.25rem;
+  border-radius: 12px;
+  transition: box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.showFront {
+  background: var(--vendasta-card, var(--ifm-background-surface-color));
+  border: 1px solid var(--vendasta-border, var(--ifm-color-emphasis-300));
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+  text-align: center;
+}
+
+.showcase:hover .showFront {
+  border-color: var(--ifm-color-primary);
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.1);
+}
+
+.showBack {
+  transform: rotateY(180deg);
+  border: 1px solid transparent;
+  color: #fff;
+  text-align: center;
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.12);
+}
+
+.iconTile {
+  width: 72px;
+  height: 72px;
+  border-radius: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #072337;
+  flex-shrink: 0;
+}
+
+.iconTile svg {
+  width: 36px;
+  height: 36px;
+}
+
+.showFrontLabel {
+  font-weight: 600;
+  font-size: 1.05em;
+  color: var(--ifm-font-color-base);
+}
+
+.showBackTitle {
+  font-weight: 700;
+  font-size: 1.05em;
+  color: #fff;
+}
+
+.showBackText {
+  font-size: 0.92em;
+  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.flipHint,
+.flipHintBack {
+  position: absolute;
+  bottom: 0.6rem;
+  right: 0.75rem;
+  font-size: 0.85rem;
+  color: var(--ifm-color-emphasis-600);
+}
+
+.flipHintBack {
+  left: 0.75rem;
+  right: auto;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+/* No icon: the name is the whole front, so the card shrinks to fit it. */
+.noIcon .cardInner {
+  min-height: 132px;
+}
+
+.noIcon .showFront,
+.noIcon .showBack {
+  padding: 1.25rem 1.25rem 1.6rem;
+}
+
+.noIcon .showFrontLabel {
+  font-weight: 700;
+  font-size: 1.15em;
+  line-height: 1.35;
+}
+
+.noIcon .showBackTitle {
+  font-size: 0.72em;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  opacity: 0.85;
+}
+
+.noIcon .showBack {
+  gap: 0.5rem;
+}
+
+.showLarge .cardInner {
+  min-height: 250px;
+}
+
+.showLarge .showBack {
+  align-items: flex-start;
+  justify-content: flex-start;
+  text-align: left;
+  padding: 1.5rem 1.4rem;
+}
+
+.showLarge .showBackText {
+  font-size: 0.88em;
+}
+
+.showLarge .showBackText ul {
+  margin: 0;
+  padding-left: 1.1rem;
+}
+
+.showLarge .showBackText li {
+  margin-bottom: 0.5rem;
+}
+
+.showLarge .showBackText li:last-child {
+  margin-bottom: 0;
+}
+
+.gradient_blue {
+  background: linear-gradient(135deg, #7cb5f5 0%, #3b6fd4 100%);
+}
+
+.gradient_green {
+  background: linear-gradient(135deg, #7cc896 0%, #2e7655 100%);
+}
+
+.gradient_sunrise {
+  background: linear-gradient(135deg, #f6c66d 0%, #e58a5a 100%);
+}
+
+.gradient_purple {
+  background: linear-gradient(135deg, #a58ee8 0%, #6a4fc4 100%);
+}

--- a/docusaurus/src/components/FlipCard.tsx
+++ b/docusaurus/src/components/FlipCard.tsx
@@ -68,4 +68,65 @@ export function FlipCardGrid({ children }: FlipCardGridProps) {
   return <div className={styles.grid}>{cards}</div>;
 }
 
+/* --- Icon variant, ported from the Vendasta LEARN AI Foundations path --- */
+
+export type IconFlipCardGradient = 'blue' | 'green' | 'sunrise' | 'purple';
+
+export interface IconFlipCardProps {
+  /** The product or feature name: the whole front of the card */
+  front: string;
+  /** What it is and the one consequence worth remembering */
+  back: React.ReactNode;
+  /**
+   * Optional icon element. Left empty on purpose: we have no Vendasta product
+   * icon set, and generic stand-ins read as the wrong product. Pass a real
+   * product icon here when one exists.
+   */
+  icon?: React.ReactNode;
+  /** Gradient used for the back face, and for the icon tile when an icon is passed */
+  gradient?: IconFlipCardGradient;
+  /** 'large' gives a taller card with a left-aligned back, which fits list content */
+  size?: 'default' | 'large';
+}
+
+export function IconFlipCard({
+  front,
+  back,
+  icon,
+  gradient = 'green',
+  size = 'default',
+}: IconFlipCardProps) {
+  const [flipped, setFlipped] = useState(false);
+  const iconNode = icon;
+  const gradientClass = styles[`gradient_${gradient}`];
+  return (
+    <div
+      className={`${styles.card} ${styles.showcase} ${iconNode ? '' : styles.noIcon} ${size === 'large' ? styles.showLarge : ''} ${flipped ? styles.flipped : ''}`}
+      onClick={() => setFlipped(!flipped)}
+      role="button"
+      tabIndex={0}
+      aria-expanded={flipped}
+      onKeyDown={(e) => e.key === 'Enter' && setFlipped(!flipped)}
+    >
+      <div className={styles.cardInner}>
+        <div className={styles.showFront}>
+          {iconNode && <div className={`${styles.iconTile} ${gradientClass}`}>{iconNode}</div>}
+          <span className={styles.showFrontLabel}>{front}</span>
+          <span className={styles.flipHint} aria-hidden="true">&#8600;</span>
+        </div>
+        <div className={`${styles.showBack} ${gradientClass}`}>
+          <span className={styles.showBackTitle}>{front}</span>
+          <div className={styles.showBackText}>{back}</div>
+          <span className={styles.flipHintBack} aria-hidden="true">&#8601;</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function IconFlipCardGrid({ children }: FlipCardGridProps) {
+  const cards = React.Children.toArray(children).slice(0, MAX_CARDS);
+  return <div className={styles.showGrid}>{cards}</div>;
+}
+
 export default FlipCard;

--- a/docusaurus/training/getting-started/accounts-and-users.mdx
+++ b/docusaurus/training/getting-started/accounts-and-users.mdx
@@ -5,12 +5,18 @@ title: Add your customer accounts and users
 description: Learn how to add customers to the platform, give them access to Business App, control permissions, connect accounts, and order products for their success.
 ---
 
-import FlipCard, { FlipCardGrid } from "@site/src/components/FlipCard";
+import { IconFlipCard, IconFlipCardGrid } from "@site/src/components/FlipCard";
 import KnowledgeCheck from "@site/src/components/KnowledgeCheck";
+import CourseProgressBar from "@site/src/components/CourseProgressBar";
+import SectionFeedback from "@site/src/components/SectionFeedback";
+import InlineHighlighter from "@site/src/components/InlineHighlighter";
+import MarkComplete from "@site/src/components/MarkComplete";
 import LessonHeader from "@site/src/components/LessonHeader";
 import LessonFooter from "@site/src/components/LessonFooter";
 
-# Add your customer accounts and users
+<InlineHighlighter courseId="accounts-and-users" site="vendasta_learn">
+
+<CourseProgressBar courseId="accounts-and-users" site="vendasta_learn" />
 
 <LessonHeader
   difficulty="Beginner"
@@ -36,10 +42,18 @@ Adding a customer puts their tools, reporting, and communication in one place un
 
 Every business you work with can have two records in Partner Center, and each one has a clear job. Flip each record:
 
-<FlipCardGrid>
-  <FlipCard front="CRM company" back="Where you log activity: calls, notes, deals, and follow-ups. This is your sales team's working file." />
-  <FlipCard front="Account" back="Where you activate and bill: products, subscriptions, and Business App access. This is the business's service record with you." />
-</FlipCardGrid>
+<IconFlipCardGrid>
+  <IconFlipCard
+    gradient="blue"
+    front="CRM company"
+    back="Where you log activity: calls, notes, deals, and follow-ups. This is your sales team's working file."
+  />
+  <IconFlipCard
+    gradient="green"
+    front="Account"
+    back="Where you activate and bill: products, subscriptions, and Business App access. This is the business's service record with you."
+  />
+</IconFlipCardGrid>
 
 The two stay connected for you. Creating an account automatically creates a linked CRM company. Started from the CRM instead? When the business is ready to buy, create the account right from the company record. Once linked, business information syncs between the two in both directions. A pattern many partners use: prospect in the CRM, and create the account at the moment a business is ready to receive products.
 
@@ -104,7 +118,9 @@ You close a deal with a local restaurant. You add the account in Partner Center.
 :::
 
 
-<KnowledgeCheck courseId="add-your-customer-accounts-and-users" site="vendasta_learn"
+<SectionFeedback courseId="accounts-and-users" site="vendasta_learn" section="content" />
+
+<KnowledgeCheck courseId="accounts-and-users" site="vendasta_learn"
   sessionSize={5}
   intro="Five quick questions on the two records, users and permissions, and ordering products."
   questions={[
@@ -119,3 +135,6 @@ You close a deal with a local restaurant. You add the account in Partner Center.
 />
 
 <LessonFooter to="/learn/getting-started/organize-your-team" pathName="Get started" step={4} totalSteps={6} />
+
+</InlineHighlighter>
+<MarkComplete courseId="accounts-and-users" site="vendasta_learn" />

--- a/docusaurus/training/getting-started/customize-and-brand.mdx
+++ b/docusaurus/training/getting-started/customize-and-brand.mdx
@@ -4,12 +4,18 @@ title: Customize and brand your platform
 description: "What white-labeling means and how to brand your platform: colors, logo, domain, and Business App settings."
 ---
 
-import FlipCard, { FlipCardGrid } from "@site/src/components/FlipCard";
+import { IconFlipCard, IconFlipCardGrid } from "@site/src/components/FlipCard";
 import KnowledgeCheck from "@site/src/components/KnowledgeCheck";
+import CourseProgressBar from "@site/src/components/CourseProgressBar";
+import SectionFeedback from "@site/src/components/SectionFeedback";
+import InlineHighlighter from "@site/src/components/InlineHighlighter";
+import MarkComplete from "@site/src/components/MarkComplete";
 import LessonHeader from "@site/src/components/LessonHeader";
 import LessonFooter from "@site/src/components/LessonFooter";
 
-# Customize and brand your platform
+<InlineHighlighter courseId="customize-and-brand" site="vendasta_learn">
+
+<CourseProgressBar courseId="customize-and-brand" site="vendasta_learn" />
 
 <LessonHeader
   difficulty="Beginner"
@@ -47,10 +53,18 @@ With white labeling, you can be the trusted expert for **anything**, without bei
 
 Your platform is a blank slate for you to completely customize and brand. Two customizations take it from bland to branded. Flip each one:
 
-<FlipCardGrid>
-  <FlipCard front="Your color" back="One main branded color displayed throughout the platform and in email marketing, so your services read as one cohesive set." />
-  <FlipCard front="Your logo" back="Appears wherever white-labeling is used. When your clients log on to Business App, they will not see Vendasta's logo anywhere." />
-</FlipCardGrid>
+<IconFlipCardGrid>
+  <IconFlipCard
+    gradient="blue"
+    front="Your color"
+    back="One main branded color displayed throughout the platform and in email marketing, so your services read as one cohesive set."
+  />
+  <IconFlipCard
+    gradient="green"
+    front="Your logo"
+    back="Appears wherever white-labeling is used. When your clients log on to Business App, they will not see Vendasta's logo anywhere."
+  />
+</IconFlipCardGrid>
 
 When you are ready to apply them, [this guide walks through every branding setting](/getting-started/getting-started-guides/getting-started-with-branding-and-customization).
 
@@ -99,7 +113,9 @@ You add your brand color (navy blue) and upload your logo. You set up app.yourag
 Your visual brand is now set. Your brand's voice, what your AI Employees say and how they say it, is configured on the AI Employees themselves: the [Hire your first AI Employee path](/learn/ai-workforce) covers it.
 
 
-<KnowledgeCheck courseId="customize-and-brand-your-platform" site="vendasta_learn"
+<SectionFeedback courseId="customize-and-brand" site="vendasta_learn" section="content" />
+
+<KnowledgeCheck courseId="customize-and-brand" site="vendasta_learn"
   sessionSize={5}
   intro="Five quick questions on white-labeling and the branding you just set up."
   questions={[
@@ -113,3 +129,6 @@ Your visual brand is now set. Your brand's voice, what your AI Employees say and
 />
 
 <LessonFooter to="/learn/getting-started/accounts-and-users" pathName="Get started" step={3} totalSteps={6} />
+
+</InlineHighlighter>
+<MarkComplete courseId="customize-and-brand" site="vendasta_learn" />

--- a/docusaurus/training/getting-started/get-set-up-to-get-paid.mdx
+++ b/docusaurus/training/getting-started/get-set-up-to-get-paid.mdx
@@ -5,7 +5,7 @@ description: "The wholesale-retail model, connecting a payment method, and setti
 ---
 
 import KnowledgeCheck from "@site/src/components/KnowledgeCheck";
-import FlipCard, { FlipCardGrid } from "@site/src/components/FlipCard";
+import { IconFlipCard, IconFlipCardGrid } from "@site/src/components/FlipCard";
 import CourseProgressBar from "@site/src/components/CourseProgressBar";
 import SectionFeedback from "@site/src/components/SectionFeedback";
 import InlineHighlighter from "@site/src/components/InlineHighlighter";
@@ -38,10 +38,18 @@ Getting paid runs on one relationship: you buy products from Vendasta at a whole
 
 Every product has two prices, and the difference between them is your margin. Flip each one:
 
-<FlipCardGrid>
-  <FlipCard front="Wholesale price" back="What Vendasta charges you while a product is active on an account. The wholesale billing frequency follows your Vendasta contract." />
-  <FlipCard front="Retail price" back="What you charge your client, at the price and billing frequency you set. The Marketplace suggests a retail price; the decision is yours." />
-</FlipCardGrid>
+<IconFlipCardGrid>
+  <IconFlipCard
+    gradient="purple"
+    front="Wholesale price"
+    back="What Vendasta charges you while a product is active on an account. The wholesale billing frequency follows your Vendasta contract."
+  />
+  <IconFlipCard
+    gradient="green"
+    front="Retail price"
+    back="What you charge your client, at the price and billing frequency you set. The Marketplace suggests a retail price; the decision is yours."
+  />
+</IconFlipCardGrid>
 
 Each active product creates two matching subscriptions: a wholesale subscription from you to Vendasta, and a retail subscription from your client to you. You manage both from Partner Center.
 

--- a/docusaurus/training/getting-started/organize-your-team.mdx
+++ b/docusaurus/training/getting-started/organize-your-team.mdx
@@ -5,12 +5,18 @@ title: Organize your team in Partner Center
 description: Learn how Vendasta helps your team work more efficiently with Partner Center for decision-makers and CRM for salespeople.
 ---
 
-import FlipCard, { FlipCardGrid } from "@site/src/components/FlipCard";
+import { IconFlipCard, IconFlipCardGrid } from "@site/src/components/FlipCard";
 import KnowledgeCheck from "@site/src/components/KnowledgeCheck";
+import CourseProgressBar from "@site/src/components/CourseProgressBar";
+import SectionFeedback from "@site/src/components/SectionFeedback";
+import InlineHighlighter from "@site/src/components/InlineHighlighter";
+import MarkComplete from "@site/src/components/MarkComplete";
 import LessonHeader from "@site/src/components/LessonHeader";
 import LessonFooter from "@site/src/components/LessonFooter";
 
-# Organize your team in Partner Center
+<InlineHighlighter courseId="organize-your-team" site="vendasta_learn">
+
+<CourseProgressBar courseId="organize-your-team" site="vendasta_learn" />
 
 <LessonHeader
   difficulty="Beginner"
@@ -39,10 +45,18 @@ Running solo? The same roles still apply: you are the Admin, and the CRM view is
 
 Both roles work inside Partner Center; the difference is how much of it they see. Flip each one:
 
-<FlipCardGrid>
-  <FlipCard front="Admin" back="The full Partner Center workspace, for key decision-makers, managers, and fulfillment teams, at partners.vendasta.com." />
-  <FlipCard front="Salesperson" back="The CRM, a focused view inside Partner Center: pipeline, prospects, and client communication." />
-</FlipCardGrid>
+<IconFlipCardGrid>
+  <IconFlipCard
+    gradient="blue"
+    front="Admin"
+    back="The full Partner Center workspace, for key decision-makers, managers, and fulfillment teams, at partners.vendasta.com."
+  />
+  <IconFlipCard
+    gradient="green"
+    front="Salesperson"
+    back="The CRM, a focused view inside Partner Center: pipeline, prospects, and client communication."
+  />
+</IconFlipCardGrid>
 
 
 ## Step 2: Learn what Partner Center Admins can do (5 min)
@@ -90,7 +104,9 @@ Confirm your team is correctly configured before moving on:
 - Each team member can log in and access the areas they need
 
 
-<KnowledgeCheck courseId="organize-teams-in-the-platform" site="vendasta_learn"
+<SectionFeedback courseId="organize-your-team" site="vendasta_learn" section="content" />
+
+<KnowledgeCheck courseId="organize-your-team" site="vendasta_learn"
   sessionSize={5}
   intro="Five quick questions on who belongs in Partner Center, who belongs in the CRM, and why."
   questions={[
@@ -103,3 +119,6 @@ Confirm your team is correctly configured before moving on:
 />
 
 <LessonFooter to="/learn/getting-started/get-set-up-to-get-paid" pathName="Get started" step={5} totalSteps={6} />
+
+</InlineHighlighter>
+<MarkComplete courseId="organize-your-team" site="vendasta_learn" />

--- a/docusaurus/training/getting-started/partner-center-walkthrough.mdx
+++ b/docusaurus/training/getting-started/partner-center-walkthrough.mdx
@@ -1,10 +1,9 @@
 ---
 sidebar_position: 2
 title: Partner Center walkthrough
-description: "Explore Partner Center: setup, roles, commerce, CRM, branding, and the client-facing tools you configure for every business you serve."
+description: "How Partner Center is organized, and how to find any setting by what it is about: your setup, your clients, your catalog, and your money."
 ---
 
-import FlipCard, { FlipCardGrid } from "@site/src/components/FlipCard";
 import KnowledgeCheck from "@site/src/components/KnowledgeCheck";
 import LessonHeader from "@site/src/components/LessonHeader";
 import LessonFooter from "@site/src/components/LessonFooter";
@@ -19,160 +18,109 @@ import MarkComplete from "@site/src/components/MarkComplete";
 
 <LessonHeader
   difficulty="Beginner"
-  time="20 minutes"
+  time="about 6 minutes"
   required={["Partner Center access"]}
   pathName="Get started"
   step={2}
   totalSteps={6}
   outcomes={[
-    "Navigate Partner Center with confidence",
-    "Set up and configure the platform for optimal performance",
-    "Manage roles and permissions effectively",
-    "Integrate commerce and payment settings",
-    "Utilize client-facing tools to enhance customer engagement inside Business App",
+    "Find any Partner Center setting from what it is about, without memorizing menus",
+    "Name the section that owns your setup, your clients, your catalog, and your money",
+    "Get to the four places you will spend your first week in",
   ]}
 />
 
-Partner Center is the command center where you run your business on the platform. This walkthrough tours it top to bottom: setup, roles, commerce, branding, CRM, and the client-facing tools that reach into Business App.
+{/* Video slot: the Partner Center screen tour embeds here, directly under this heading.
+    When it lands, add the `video` flag to LessonHeader above and raise `time`. */}
 
+## How Partner Center is organized
 
-## Introduction to Partner Center
+*You are here: Partner Center. Everything in this section happens in your workspace.*
 
-Partner Center is where you streamline operations and enhance your ability to serve clients. Key features include your CRM, email marketing, your AI workforce, subscription and billing, and fulfillment.
+Partner Center's left navigation is grouped by what a setting is *about*, not by how often you reach for it. That is the whole trick to finding things: name the subject, and the section follows.
 
-### Key tools and capabilities
+| When you want to | Look in |
+|---|---|
+| Set up your own business: brand, team, billing, platform settings | **Administration** |
+| Open a client's record, their users, or their Business App settings | **Accounts** |
+| Decide what you sell and what it costs | **Marketplace** |
+| Handle orders, subscriptions, invoices, and payouts | **Commerce** |
+| Work your pipeline and log sales activity | **CRM** |
+| Send campaigns under your brand | **Marketing** |
+| Track the work your team is delivering | **Fulfillment** |
+| Make something happen on its own | **Automations** |
+| Configure your own AI Employees | **AI** |
 
-Three tools carry most of your day-to-day work. Flip each one:
+One habit makes this stick: before you change any setting, say out loud whose it is. Your brand and your team live in Administration. A client's products and users live on their account. Settings that look similar sit in different places for exactly that reason.
 
-<FlipCardGrid>
-  <FlipCard front="CRM" back="Centralized management of client relationships and interactions, from first touch to closed deal." />
-  <FlipCard front="Email Marketing" back="Create and manage campaigns that send under your brand." />
-  <FlipCard front="AI Workforce" back="AI Employees like the Chat Receptionist and Voice Receptionist that improve how you communicate with clients." />
-</FlipCardGrid>
+## The four you will live in first
 
+Most of a first week happens in four of those sections.
 
-## Setting up and configuring the platform
+**Administration** is your own setup: branding, My Team, My Billing, and the platform settings that shape what clients see. **Accounts** is where each client exists as a record, and where you activate products for them. **Marketplace** is your catalog: what you have chosen to sell, and the retail price on it. **Commerce** is the money: orders, subscriptions, invoices, payments, and payouts.
 
-The **Administration** section is the central hub for configuring Partner Center. Configure your platform once and you are ready to deliver from day one.
+The rest of this path takes each of those in turn, so there is nothing to set up yet. Right now the goal is only that you know where to land.
 
-### Administration and setup
-
-- **Manage Subscription and Billing:** Oversee financial aspects and service subscriptions
-- **Update Payment Methods:** Keep payment information current for seamless transactions
-
-### Subscription and user management
-
-- **My Team:** Add users and manage seat allocations based on subscription tiers (Starter, Professional, Premium, Custom Enterprise)
-- **Add-On Seats:** Additional seats can be purchased for larger teams
-- **User Management:** Streamlined processes for inviting and managing users enhance team efficiency
-
-
-## Roles and permissions
-
-Three roles cover your team. Flip each one to see what it can do:
-
-<FlipCardGrid>
-  <FlipCard front="Admin" back="Full access: overarching control, sets permissions, and manages user access." />
-  <FlipCard front="Salesperson" back="CRM, commerce, and sales tools: Snapshots, proposals, campaigns, and client interactions." />
-  <FlipCard front="Digital Agent" back="Task Manager: project assignments, fulfilling client requests, and completing projects." />
-</FlipCardGrid>
-
-
-## Commerce and payment settings
-
-**Vendasta Payments** integration simplifies billing. Invoice your clients directly from the platform, with no external systems, and keep sales, billing, and fulfillment connected.
-
-### Custom reports and branding
-
-- **Snapshot Reports:** Modify reports to reflect your branding and your clients' needs
-- **Platform UI:** Update the user interface to align with your brand identity
-
-
-## Customization and branding
-
-Create your unique identity within Partner Center. Customize logos, color themes, and favicons to reflect your brand, so your clients see a consistent brand experience everywhere.
-
-### AI tools for customization
-
-- **Configurable AI Assistants:** Customize capabilities and knowledge sources
-- **Deep Customization:** Align your AI workforce with your workflows and branding
-
-### Client branding options
-
-Clients can customize the look and feel of the Business App. Services are presented in a way that resonates with their brand.
-
-
-## CRM and client management
-
-Your CRM manages all client interactions effectively. It stores chatbot interactions, your messages, and client communications. Both identified and anonymous contacts are managed for a complete view.
-
-### Managing prospects and accounts
-
-- **Accounts Section:** Single source of truth for subscriptions, invoices, and billing settings
-- **Franchise Support:** Customization options for managing multi-location accounts
-- **Feature Management:** Hide or show Business App features based on user roles
-
-<div className="in-practice">
-  <span className="in-practice__icon">💬</span>
-  <div className="in-practice__body">
-    <span className="in-practice__label">In Practice</span>
-    <p>You add a prospect to the CRM after a Snapshot Report. They become an account. You configure their subscription, invite users, and hide features they don't need yet. Their Business App shows your branding. You assign a Digital Agent to set up their listings. The client sees live project status in their dashboard. Partner Center keeps everything in one place.</p>
-  </div>
-</div>
-
-
-## Client-facing crossovers: Partner Center to Business App
-
-You configure the Business App experience for your clients from inside Partner Center. Business App gives each of them the essential tools for their business.
-
-### Business App features
-
-- **CRM Capabilities:** Clients manage contacts and companies
-- **Executive Reports:** Dashboards for social, reputation, and advertising insights
-
-### Email marketing tools
-
-- **Campaign Management:** Create and schedule campaigns with ease
-- **Integration with CRM:** Connect email marketing efforts with CRM contacts
-
-### Proposal builder and sales orders
-
-- **Customizable PDFs:** Create professional documents with branding and product listings
-- **Sales Orders:** Generate orders directly from the CRM, supporting contract terms and customer approval
-
-
-## Marketplace, fulfillment, and automations
-
-### Vendasta Marketplace and custom products
-
-- **Diverse Offerings:** A wide range of solutions across various categories
-- **Custom Products:** Package your own services and bundle them with marketplace solutions
-
-### Task management and fulfillment tools
-
-- **Task Manager:** Assign work to digital agents and track project progress transparently
-- **Client Visibility:** Clients can view live project status in their dashboards
-
-### Workflow automations and triggers
-
-Automations streamline repetitive tasks. Examples: notifications for failed payments, automated report generation after form submissions.
-
+:::tip Try it now
+Open [partners.vendasta.com](https://partners.vendasta.com) and find **Administration**. Without changing anything, look for where your company name and logo would go. That one path, Administration to your brand, is the one you will use most in the next step.
+:::
 
 <SectionFeedback courseId="partner-center-walkthrough" site="vendasta_learn" section="content" />
 
-
 <KnowledgeCheck courseId="partner-center-walkthrough" site="vendasta_learn"
-  sessionSize={5}
-  intro="Five quick questions on what lives where in Partner Center."
+  sessionSize={3}
+  intro="Three quick questions on finding your way to the right section."
   questions={[
-    { type: "mcq", question: "What is the core purpose of Partner Center?", options: ["Provide banking services to enterprise clients and Vendasta staff", "Serve as the partner command center for running and scaling client work", "Host only social media scheduling without CRM or billing", "Sell Marketplace products to partners without client delivery tools"], correctIndex: 1, explanation: "The walkthrough frames Partner Center as the hub that streamlines your operations and client delivery." },
-    { type: "truefalse", statement: "The CRM system is designed to manage all client interactions effectively.", correct: true, explanation: "The CRM stores chatbot interactions, partner messages, and client communications for a complete view." },
-    { type: "mcq", question: "What type of clients does the Business App primarily serve?", options: ["Large corporations", "Local business clients", "Partners and agencies", "Fulfillment officers"], correctIndex: 1, explanation: "Business App gives your local business clients their essential tools, branded and configured by you." },
-    { type: "whicharea", principle: "Where would you learn about Admin, Salesperson, and Digital Agent access levels?", correctArea: "👤 Roles and Permissions", explanation: "That section covers Admin, Salesperson, and Digital Agent roles and their access." },
-    { type: "mcq", question: "What does Vendasta Payments integration enable?", options: ["Social media scheduling", "Direct invoicing of clients from the platform", "AI chatbot configuration", "Task Manager assignments"], correctIndex: 1, explanation: "Vendasta Payments lets partners invoice clients directly from the platform, streamlining operations." }
+    {
+      type: 'mcq',
+      question: 'You want to change the logo your clients see when they log in. Which section do you open?',
+      options: [
+        'Administration, because your brand is part of your own setup',
+        'Accounts, because the logo appears in each client Business App',
+        'Marketplace, because the logo appears on the products you sell',
+        'Commerce, because the logo appears on the invoices you send'
+      ],
+      correctIndex: 0,
+      explanation: 'Ask whose the setting is. The logo is yours, so it lives in Administration, and it flows out to everything clients see from there.'
+    },
+    {
+      type: 'mcq',
+      question: 'A client calls to ask why they were charged twice this month. Where do you go first?',
+      options: [
+        'Commerce, where their invoices and payments are',
+        'Administration, where billing settings are configured',
+        'Marketplace, where the price of the product is set',
+        'CRM, where your record of the conversation lives'
+      ],
+      correctIndex: 0,
+      explanation: 'Commerce holds the actual orders, invoices, and payments. Administration sets the rules for billing; Commerce shows you what was billed.'
+    },
+    {
+      type: 'mcq',
+      question: 'You have decided to start selling a new service and set your own price for it. Which section?',
+      options: [
+        'Marketplace, which is your catalog and your pricing',
+        'Commerce, which is where money moves',
+        'Accounts, which is where products get activated',
+        'Fulfillment, which is where the work gets done'
+      ],
+      correctIndex: 0,
+      explanation: 'Marketplace is what you sell and what you charge. Activating it for one client happens on that client account, and the resulting invoice shows up in Commerce.'
+    },
+    {
+      type: 'mcq',
+      question: 'You want a task created automatically every time a client submits a form. Which section?',
+      options: [
+        'Automations, where a trigger and its actions are built',
+        'Fulfillment, where tasks are assigned and tracked',
+        'CRM, where form submissions arrive',
+        'Administration, where platform behavior is configured'
+      ],
+      correctIndex: 0,
+      explanation: 'Anything that should happen on its own is built in Automations. Fulfillment is where the resulting task is then worked.'
+    }
   ]}
 />
-
 
 <LessonFooter to="/learn/getting-started/customize-and-brand" pathName="Get started" step={2} totalSteps={6} />
 

--- a/docusaurus/training/getting-started/the-vendasta-platform.mdx
+++ b/docusaurus/training/getting-started/the-vendasta-platform.mdx
@@ -5,6 +5,7 @@ description: "The white-label model, who works in the platform, and how it all c
 ---
 
 import KnowledgeCheck from "@site/src/components/KnowledgeCheck";
+import { IconFlipCard, IconFlipCardGrid } from "@site/src/components/FlipCard";
 import CourseProgressBar from "@site/src/components/CourseProgressBar";
 import SectionFeedback from "@site/src/components/SectionFeedback";
 import InlineHighlighter from "@site/src/components/InlineHighlighter";
@@ -95,21 +96,46 @@ Pick the workspace first and everything downstream lands where you expect: chann
 
 ## Products, AI Employees, and automations
 
-Three building blocks, three different jobs:
+Three building blocks, three different jobs. Flip each one:
 
-| | What it is | Where it lives | Example |
-|---|---|---|---|
-| **Product** | Something you activate on an account and resell | Marketplace → the account | Local SEO, Conversations AI |
-| **AI Employee** | A worker you configure with knowledge and capabilities | Partner Center or Business App | AI Receptionist, AI Sales Assistant |
-| **Automation** | A trigger-and-action workflow that runs on its own | Automations, in either workspace | New form submission creates a follow-up task |
+<IconFlipCardGrid>
+  <IconFlipCard
+    gradient="blue"
+    front="Product"
+    back="What you shop for in the Marketplace and resell, like Local SEO, Social AI, or Conversations AI. You activate it on an account, and it is what your client is billed for."
+  />
+  <IconFlipCard
+    gradient="green"
+    front="AI Employee"
+    back="The worker a product turns on. You will not find one for sale in the Marketplace on its own: you sell the product, and the employee is what it unlocks. You configure it with knowledge and capabilities in the workspace it serves."
+  />
+  <IconFlipCard
+    gradient="purple"
+    front="Automation"
+    back="A trigger-and-action workflow that runs on its own, such as a new form submission creating a follow-up task. Automations live in either workspace."
+  />
+</IconFlipCardGrid>
 
-They compose: a product often unlocks an AI Employee, and automations carry work between them. That composition is "AI does the work, you orchestrate" in miniature.
+The order matters: **you sell products, and products unlock AI Employees.** These AI Employees are each powered by a specific product:
+
+| AI Employee | Product that unlocks it |
+|---|---|
+| Voice Receptionist | Conversations AI |
+| Social Media Manager | Social Marketing (Social AI) |
+| Blogger | Social Marketing (Social AI) |
+| Reputation Specialist | Reputation Management |
+| AI Sales Assistant | CRM AI |
+| AI Search Specialist | Local SEO / Listing Builder |
+
+When a client is ready to add an employee, [this guide covers the upgrade path](/ai/ai-workforce/upgrading-ai-employees).
+
+Automations are the third piece, and they carry work between the other two. That composition is "AI does the work, you orchestrate" in miniature.
 
 <SectionFeedback courseId="the-vendasta-platform" site="vendasta_learn" section="content" />
 
 <KnowledgeCheck courseId="the-vendasta-platform" site="vendasta_learn"
   sessionSize={3}
-  intro="Three quick questions on the model, the two workspaces, and where AI Employees live."
+  intro="Three quick questions on the model, the two workspaces, and how products and AI Employees relate."
   questions={[
     {
       type: 'mcq',
@@ -158,6 +184,18 @@ They compose: a product often unlocks an AI Employee, and automations carry work
       ],
       correctIndex: 1,
       explanation: 'An AI Employee lives in the workspace of the business it serves. A client-facing receptionist is configured in that client\'s Business App.'
+    },
+    {
+      type: 'mcq',
+      question: 'A client asks you to sell them a Voice Receptionist. You search the Marketplace and cannot find one. What is going on?',
+      options: [
+        'AI Employees are not sold on their own; you sell Conversations AI and the receptionist is what it unlocks',
+        'Receptionists come free on every account, so there is nothing in the Marketplace to sell',
+        'The receptionist is published from Vendor Center, which is where you activate it for a client',
+        'Vendasta Support has to enable the receptionist for that account before it becomes sellable'
+      ],
+      correctIndex: 0,
+      explanation: 'You shop for products; AI Employees are what those products turn on. Conversations AI unlocks the Voice Receptionist, and one product can unlock several employees: Social AI brings both the Social Media Manager and the Blogger.'
     },
     {
       type: 'mcq',


### PR DESCRIPTION
Brings the six **Get started** learning path steps up to the engagement baseline the AI foundations path already uses. What started as a styling pass turned up several real content defects, and those are the more valuable half of this PR.

**Preview:** https://docs.vendasta.com/learn/getting-started

## The new element

`IconFlipCard` / `IconFlipCardGrid`, ported from the Vendasta LEARN AI Foundations path: gradient back face, capped at three cards per our rulebook. The existing `FlipCard` is untouched, so the AI foundations path and every other consumer render exactly as before.

**Deliberately no icons.** The first pass shipped 13 hand-drawn generic glyphs. A generic mark sitting above a product name reads as *that product's icon*, and we have no Vendasta product icon set to draw from, so a stand-in is worse than nothing. The `icon` prop stays on the component for when real ones exist, and a `noIcon` layout tightens the card when nothing is passed.

## Engagement parity

Steps 3, 4, and 5 were missing `InlineHighlighter`, `CourseProgressBar`, `SectionFeedback`, and `MarkComplete` entirely. All four added, and their stray `H1`s removed so titles come from frontmatter like the other three steps.

Three `courseId` values did not match their filenames (`organize-your-team.mdx` was reporting as `organize-teams-in-the-platform`). Corrected. Safe today because those components are inert stubs and the knowledge check holds state in React only — this stops being safe the moment they are wired to a backend.

## Content fixes, which are the real substance

**Step 1 was hedging the platform's object model.** It said "a product *often* unlocks an AI Employee," buried below the cards, while the Product and AI Employee cards sat side by side looking like peers you could shop for equally. You cannot buy a Voice Receptionist; you buy Conversations AI. The cards now read as cause and effect, the six-row mapping table from `docs/ai/ai-workforce/upgrading-ai-employees.mdx` is inline, and a new knowledge check question tests exactly that trap.

**Step 2 was a feature inventory pretending to be a walkthrough.** All eight of its sections duplicated something steps 3 through 6 teach properly later, so it described navigation without ever showing anyone navigating, and it could not deliver its own outcome ("Navigate Partner Center with confidence"). Rebuilt as a wayfinding step: how the nav is grouped, the habit of asking whose a setting is, and the four sections a partner lives in during week one. 180 lines to 129. The screen tour it actually needs is ET-861, with a slot left in the file.

Also removed in step 2: plan tier names spelled out, a `💬 In Practice` emoji div, Title Case bold labels, and a knowledge check whose distractors included "provide banking services to enterprise clients." Automations was missing from its list of Partner Center tools despite being the thing that connects the others; added.

**Two flip-card sets removed from step 2** because they competed with the rest of the path: its "three tools" triad contradicted step 1's building-blocks triad (AI was a category in one and a peer of Email Marketing in the other), and its roles triad duplicated step 5's. Both are prose lists now with every fact preserved.

## Not in this PR

- **Steps 3, 4, and 5 still carry editorial drift**: contractions, standalone openers, `(3 min)` in headings, non-standard callout titles. Step 5's knowledge check has a `whicharea` answer of `📞 CRM is for Salespeople`, an emoji plus a heading name from a retired version — that one is a live defect. Deliberately left for a prose-only pass so this diff stays reviewable.
- **`IconFlipCard` renders no icons and should be renamed** if we keep it. Left alone pending the call on whether the element survives.
- **Two cross-doc findings for the docs owners**, logged in the review copy: `upgrading-ai-employees.mdx:58` states the unlocking edition is partner-configurable, which contradicts two other lines on its own page and `social-media-manager.mdx:36`; and the platform and Vendasta Services docs name the same AI employees differently.

## Verification

`npm run build` passes. 12 broken-link sources with and without these changes, so nothing new introduced. All six steps verified in a live browser: expected card counts, no back-face overflow at 1280px, single-column stack at narrow width with no horizontal page scroll, and flip transforms resolving to `rotateY(180deg)`.

Screenshots could not be captured — the browser pane in this environment renders black regardless of page — so layout was confirmed by measuring the live DOM. **Worth an eyeball before merge.**

Full review copy with source annotations: `~/mydev/strategy/docs-learn-revamp/drafts/get-started-path-engagement-pass.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
