### PR TITLE
Docs: AI Employee visibility control (DALE-1532)

### DIFF
--- a/docusaurus/docs/administration/platform-settings/customize-business-app/page-visibility-settings.mdx
+++ b/docusaurus/docs/administration/platform-settings/customize-business-app/page-visibility-settings.mdx
@@ -206,6 +206,43 @@ Controls whether customers see the AI Assistant page.
 
 Show this page when customers have AI features enabled and would benefit from AI-assisted tools.
 
+### Choosing which AI Employees appear
+
+Below the page toggle, a list shows every AI Employee your customers could have. A checkbox on each row controls whether that AI Employee's card can appear on the [AI Workforce page](/ai/ai-workforce/upgrading-ai-employees) in Business App.
+
+Each row shows the AI Employee's avatar, name, and description, along with a `Beta` badge where it applies. A `Visible` or `Hidden` label next to the checkbox shows the current state:
+
+- **Checked (`Visible`)**: the AI Employee's card can appear on the AI Workforce page.
+- **Unchecked (`Hidden`)**: the card never appears on the AI Workforce page, for any customer in that market.
+
+A search box, a count of currently visible AI Employees, and `Show all` / `Hide all` buttons sit above the list. New AI Employees are `Visible` by default — hide one only if you're not ready for customers to ask about it.
+
+:::info Chat Receptionist can't be hidden
+The Chat Receptionist has no row in this list and always appears on the AI Workforce page.
+:::
+
+#### Market defaults and overrides
+
+This list follows the same partner-default-versus-market pattern as other settings on this page:
+
+- Configure defaults at the partner level using `All Markets`.
+- Override for a specific market by selecting it from the dropdown.
+- A market with no override of its own shows disabled rows using the partner default. To use `Show all` or `Hide all` on that market, turn off the market default first.
+
+#### What hiding an AI Employee does (and doesn't do)
+
+Hiding an AI Employee only removes its card from the AI Workforce page. It doesn't:
+
+- **Disable the AI Employee.** A customer who already has it configured keeps full access, and it keeps doing its automatic work.
+- **Remove it from the chat employee menu.** Customers can still open a hidden AI Employee from there and read its past conversations.
+- **Change what customers can buy.** Product availability, editions, and pricing are unaffected.
+
+When you hide an AI Employee that was previously visible, a warning repeats these points before you save. Changes may take a short time to reach the AI Workforce page after you save.
+
+:::tip
+Hiding only affects the AI Workforce page, so it's meant for AI Employees a customer can't buy from you yet — not for stopping a customer from using one they've already set up. To do that, remove access to the underlying product instead.
+:::
+
 ---
 
 ## Executive Report page settings

--- a/docusaurus/docs/ai/ai-workforce/upgrading-ai-employees.mdx
+++ b/docusaurus/docs/ai/ai-workforce/upgrading-ai-employees.mdx
@@ -2,9 +2,9 @@
 id: upgrading-ai-employees
 title: Upgrading AI Employees
 sidebar_position: 8
-description: How locked AI Employee cards in Business App let customers upgrade themselves, how marketplace gating decides which cards appear, and how to configure the upgrade experience in Partner Center.
-tags: [ai, ai-workforce, ai-employees, upgrade, editions, marketplace]
-keywords: [AI workforce upgrade, self-serve upgrade, edition change, upgrade CTA, marketplace gating, AI employees]
+description: How locked AI Employee cards in Business App let customers upgrade themselves, how marketplace gating decides which cards appear, how to hide a card regardless of what you sell, and how to configure the upgrade experience in Partner Center.
+tags: [ai, ai-workforce, ai-employees, upgrade, editions, marketplace, visibility]
+keywords: [AI workforce upgrade, self-serve upgrade, edition change, upgrade CTA, marketplace gating, AI employees, hide AI employee, AI employee visibility]
 ---
 
 The **AI Workforce** page in Business App shows your customer every AI Employee available to them. Some of those employees are already active; others are locked because the product or edition that powers them isn't part of the customer's current plan.
@@ -75,6 +75,17 @@ Locked cards are filtered by what you actually sell, so customers are never show
 - **Active** employees and employees with no backing product are never hidden by this rule.
 
 This means your **stop-selling** and market-availability decisions in the Marketplace directly control the AI Workforce page: stop selling a product in a market, and its locked AI Employee card disappears for customers in that market.
+
+## Hide an AI Employee regardless of what you sell
+
+Marketplace gating only follows what you sell, which doesn't help in two situations:
+
+- **You sell the product, but only a lower edition.** The AI Employee's card still appears, locked, advertising an edition you're not ready to offer.
+- **The product also powers something you still need to sell.** For example, Local SEO unlocks the AI Search Specialist but also powers the Chat Receptionist's `Try It` demo, so you can't stop selling it just to remove one card.
+
+For these cases, hide the AI Employee directly instead of changing what you sell. Go to `Partner Center` → `Accounts` → `Manage Business App` → `Customize Business App` → `Pages` → `AI Assistant`, and turn off that AI Employee's visibility checkbox. See [AI Assistant page settings](/administration/platform-settings/customize-business-app/page-visibility-settings#ai-assistant-page-settings) for the full control.
+
+Hiding an AI Employee this way only removes its card from the AI Workforce page. A customer who already has it configured keeps using it, and it stays reachable from the chat employee menu.
 
 ## Configure the upgrade experience in Partner Center
 


### PR DESCRIPTION
## Summary

- Adds documentation for the new partner-configurable control that hides an AI Employee's card from the Business App **AI Workforce** page, independent of what the partner sells (per-market, set in Partner Center).
- Cross-links the new control from the existing marketplace-gating/upgrade docs so partners land on it from either angle.

## JIRA

[DALE-1532: \[FDE\] Hide AI Employees a partner doesn't want to sell](https://vendasta.jira.com/browse/DALE-1532)

## Change classification

- **UI / UX change** — new settings-page control (row list, search box, visible count, `Show all` / `Hide all`)
- **Feature behavior change** — a partner can now remove an AI Employee's card from the AI Workforce page without changing what they sell

## Repo targeted

**Partner Center docs** only. This is a partner-facing configuration change (new controls on `Customize Business App` → `Pages` → `AI Assistant`). It changes what a partner configures, not what an SMB end user does — an SMB user simply sees fewer cards on a page they already use, with no new interaction to document. No Business App (end-user) docs were updated as a result.

## Docs updated (existing pages only — no new pages)

1. `docusaurus/docs/administration/platform-settings/customize-business-app/page-visibility-settings.mdx`
   Expanded the existing **AI Assistant page settings** section with the new AI Employee visibility list: what each row shows, visible/hidden semantics, the search/count/bulk controls, market-default inheritance, the Chat Receptionist exception, and what hiding does/doesn't affect.
2. `docusaurus/docs/ai/ai-workforce/upgrading-ai-employees.mdx`
   Added a new **Hide an AI Employee regardless of what you sell** section, right after the existing marketplace-gating section, explaining the two gaps this control fills and linking to the settings page above.

## Placement reasoning

`page-visibility-settings.mdx` already documents every other per-page "Show this page" control on the same settings page, including the existing `showAiAssistant` toggle — the new list lives directly under it in the product, so it belongs in the same section rather than a new page. `upgrading-ai-employees.mdx` already documents the only other lever for controlling which AI Workforce cards appear (marketplace/stop-selling gating) and explicitly names both gaps (edition mismatch, shared-product cases) that this new control fixes, so a short cross-referencing section there was a natural, low-duplication fit.

## Acceptance criteria / requirement coverage

Mapped from the ticket's Requirement and the linked RFC ("RFC: Partner-configurable Hidden AI Employees"):

- ✅ Per-partner, per-market control, independent of products sold — documented (market defaults/overrides section)
- ✅ Hiding only affects the AI Workforce page card; the AI Employee keeps operating and stays reachable via the chat employee menu — documented explicitly
- ✅ New AI Employees are visible by default — documented
- ✅ Chat Receptionist can't be hidden — documented as a callout
- ✅ Save-time warning behavior — documented
- ⚠️ Not documented (out of scope for this PR / not yet resolved per the RFC's own Open Issues): the specific DaySmart per-PID hidden list, and the Marketer row's feature-flag gating — these are operational/rollout details, not partner-facing UI behavior, and the RFC lists the DaySmart list as still unconfirmed.

## Figma / visual inputs

No Figma link was provided directly on the ticket. The linked RFC references a Claude Design mock (`AI Employee Visibility.dc.html`) describing the row-list layout (avatar, name, description, Beta badge, checkbox, visible/hidden label, search box, visible count, Show all/Hide all buttons) and an embedded screenshot of that mock. I used the RFC's written description of the mock rather than the design file itself, since the design link wasn't directly accessible from this session. If the shipped UI's copy differs from the RFC's usability section (e.g. exact button/label text), please flag it and I'll correct the wording.

## Skills / tools used

- Jira MCP tools (`getJiraIssue`, `getJiraIssueRemoteIssueLinks`, `searchJiraIssuesUsingJql`) to pull the ticket and check for a parent epic
- Confluence MCP tools (`getConfluencePage`) to read the linked RFC and its companion implementation doc
- Manual repo search (`grep`/`find`) to locate the existing pages this feature extends
- `npm run build` (Docusaurus) to confirm the build succeeds and the two new internal links/anchors resolve correctly

## Assumptions and limitations

- **No parent epic found.** DALE-1532 has no linked epic, so the rollout-verification step (checking an epic + sibling tickets for gating signals) doesn't apply here. The story itself is `Done`/resolved. Its Jira dev-panel PR summary (last synced ~Aug 7) showed 2 pull requests still open, but that panel is flagged stale by Jira's own cache (`isStale: true`), so I've treated the story's `Done` resolution as the more current signal.
- **Reviewer not auto-assigned.** This session's repo access is scoped to `businessapp-docs` and `partnercenter-docs` only, so I couldn't inspect the actual code PRs (in `ai-assistants`, `partner`, `galaxy`, `vendastaapis`) to identify their authors for a reviewer assignment. The ticket's assignee/reporter is Kyle Sheasby (`ksheasby@vendasta.com`), who also authored the RFC — recommending as reviewer, but please add the actual PR author(s) if different.
- **DaySmart's specific PID list and the Reputation/Conversations AI Premium-upsell review are open items in the RFC itself**, not yet resolved — nothing here depends on them, but flagging per the RFC's own "Open Issues" section.
- **Exact TTL / delay after saving** is described in the RFC as an unresolved value (target "on the order of 10 seconds," not finalized) — I intentionally described this as "a short time" rather than citing an unconfirmed number.

---

@ahnikakuse @haleyserrano @maryam6samadi


---
_Generated by [Claude Code](https://claude.ai/code/session_01HB1NDNP1Y4FkHNtsrkPtoc)_