### PR TITLE
docs: add Submit a Billing Request article (DOC-939)

### DIFF
--- a/docusaurus/docs/administration/my-account/my-billing/index.mdx
+++ b/docusaurus/docs/administration/my-account/my-billing/index.mdx
@@ -228,3 +228,4 @@ Admins cannot change this setting themselves. Contact [Vendasta Support](https:/
 - **[Payment Methods and Setup](./payment-methods-and-setup.mdx)** – Manage payment methods, billing information, and resolve payment issues
 - **[Billing Reports and Data](./billing-reports-and-data.mdx)** – Access billing reports, view upcoming charges, and export billing data
 - **[Special Features and Credits](./special-features-and-credits.mdx)** – Management fees, credit notes, and vCash virtual credits
+- **[Submit a Billing Request](./submit-a-billing-request.mdx)** – Dispute a charge or request a refund from Vendasta's Finance team

--- a/docusaurus/docs/administration/my-account/my-billing/submit-a-billing-request.mdx
+++ b/docusaurus/docs/administration/my-account/my-billing/submit-a-billing-request.mdx
@@ -1,0 +1,93 @@
+---
+id: submit-a-billing-request
+title: Submit a Billing Request
+sidebar_label: Submit a Billing Request
+description: Learn how to submit a billing request to Vendasta's Finance team if you believe a charge is incorrect or want to request a refund.
+tags: [billing, refund, billing request, administration]
+keywords: [billing request, refund, dispute charge, purchase id, partner id, chargeback, finance team]
+---
+
+## What is a Billing Request?
+
+A billing request is how you ask Vendasta's Finance team to review a charge on your invoice that you believe is wrong, or to ask for money back. Every request is submitted through a dedicated form and reviewed individually by Finance, who reply by email with their decision.
+
+## Why Submit a Billing Request?
+
+Submitting a billing request through the proper channel ensures:
+- Your dispute is routed directly to the team that can review and resolve it
+- You get a trackable confirmation number for any follow-up
+- Finance has the details and evidence needed to make a fast, informed decision
+- You have a documented eligibility window and process instead of an ad hoc email thread
+
+## Before You Start
+
+Have the following ready before you submit a request:
+
+- Your **Partner ID (PID)**
+- The **Purchase ID** for each charge you are asking about
+- A short explanation of what happened
+- Optional: screenshots, invoices, or emails that support your request
+
+## How to Submit a Billing Request
+
+### Find Your Partner ID
+
+1. Log in to [Partner Center](https://partners.vendasta.com)
+2. Your PID appears in the top left corner on most pages, and in your browser's address bar
+3. Copy it into the Partner ID field on the form
+
+### Find Your Purchase ID
+
+1. In Partner Center, go to `Administration` → `My Billing`
+2. Locate the charge you are asking about
+3. Copy its Purchase ID into the form
+
+:::tip
+To include more than one charge, enter a Purchase ID, press **Enter**, and add the next.
+:::
+
+### Submit Your Request
+
+1. Go to **billingrequests.vendasta.com**
+2. Enter your business information, including your PID
+3. Pick the reason category that best matches: **Activation error**, **Product failure / bug**, **Billing error / duplicate charge**, **Dissatisfaction**, **Cancellation within window**, or **Other**
+4. Explain what happened, when, and what you expected instead — specific details get faster decisions
+5. Enter the amount. Your best estimate is fine; Finance confirms the final figure
+6. Attach anything that supports your request. Requests with evidence are processed faster
+7. Submit. You will see a confirmation with your request number (starts with **CR**). Keep it for any follow-up
+
+## What Happens Next
+
+1. You get a confirmation email with your CR number
+2. Finance reviews within **2 business days** (up to 5 during busy periods) and emails you if they need more detail
+3. You get the decision by email with the outcome of the request
+
+## Eligibility
+
+Eligibility and timelines are set by Vendasta's **Terms of Service**, available at [trust.vendasta.com](https://trust.vendasta.com/). If a charge looks wrong, submit a request as soon as you notice it.
+
+## FAQs
+
+<details>
+<summary>Can I include several charges in one request?</summary>
+
+Yes. Enter each Purchase ID and press **Enter** between them.
+</details>
+
+<details>
+<summary>Will I get money back?</summary>
+
+Finance reviews every request and decides the outcome case by case. Submitting a request is not a guarantee it will be approved.
+</details>
+
+<details>
+<summary>How long does a decision take?</summary>
+
+Typically 2 business days, up to 5 during busy periods.
+</details>
+
+<details>
+<summary>Do I need to upload documentation?</summary>
+
+It is optional but strongly recommended. Requests with evidence are decided faster.
+</details>


### PR DESCRIPTION
## Summary
- Publishes "Submit a Billing Request" to Partner Center docs, covering how partners dispute a charge or request a refund through billingrequests.vendasta.com
- Sourced from the [PM1 Confluence draft](https://vendasta.jira.com/wiki/spaces/PM1/pages/4484169841/Support+article+v2+Submit+a+billing+request+Vendasta+Partners)
- Links the new article from the My Billing index page

## Note for Cal
This was drafted with an AI-assisted skill, so it follows our standard What/Why/How template — feel free to cut the **## What is a Billing Request?** and **## Why Submit a Billing Request?** sections if they feel redundant with the rest of the article. Totally your call.

Also worth knowing: the source Confluence page is flagged "Draft v2 for review, not yet live" pending legal review, so it may be worth a quick double check that nothing's changed there before this merges.

## Test plan
- [ ] Confirm content accuracy against current billingrequests.vendasta.com form fields/labels
- [ ] Confirm legal review status for the ToS/eligibility language
- [ ] Add screenshots for the Partner ID / Purchase ID steps (not available to pull from Confluence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)