### PR TITLE
docs: rewrite actions overview and settings page with card catalogs

### DIFF
--- a/docusaurus/docs/automations/my-automations/actions-overview.mdx
+++ b/docusaurus/docs/automations/my-automations/actions-overview.mdx
@@ -7,13 +7,15 @@ tags: [automations, actions, steps]
 keywords: [automation actions, automation steps, workflow steps, action categories, step scope]
 ---
 
+import { Cards, Card } from '@site/src/components/Cards';
+
 # Actions overview
 
 Actions are the "then" of your automation — what happens after the trigger fires. Build your workflow by adding action steps in sequence.
 
 ## How action availability works
 
-The actions you can add depend on your trigger's scope. A company-scoped trigger unlocks company-focused actions; an account-scoped trigger unlocks account-focused actions.
+The actions you can add depend on your trigger's scope.
 
 | Trigger scope | Example available actions |
 |---|---|
@@ -26,42 +28,446 @@ The actions you can add depend on your trigger's scope. A company-scoped trigger
 Need actions from a different scope? Use **lookup steps** like Find company, Find contact, or Get associated account to bring additional records into context.
 :::
 
-## Action categories
+## Available actions
 
-Vendasta provides 130+ action steps across these categories:
+### Companies
 
-| Category | What it does | Examples |
-|---|---|---|
-| **AI** | Use AI to summarize, categorize, analyze, or prompt | Summarize with AI, Categorize with AI, Send request to AI employee |
-| **Communication** | Send messages across channels | Email, SMS, WhatsApp, Conversations message, review request |
-| **CRM** | Create and update records | Create company, find contact, update fields, log activity |
-| **Sales** | Manage the sales pipeline | Create opportunity, assign salesperson, create proposal |
-| **Campaigns** | Start and manage campaigns | Start campaign, pause campaign, send marketing email |
-| **Billing** | Handle invoicing and payments | Create invoice, charge order, send invoice |
-| **Notifications** | Alert people | Notify user, notify salesperson, send in-app notification |
-| **Products** | Manage product lifecycle | Activate products, deactivate products, start trials |
-| **Sales orders** | Manage order workflow | Create and activate, approve, decline, archive |
-| **Advanced** | Integration and utility | Call endpoint, send webhook, format text, apply account template |
-| **Flow control** | Direct automation logic | If/else, delay, jump, rate filter, end automation |
+<Cards cols={3}>
+  <Card href="/automations/my-automations/automation-steps-reference#companies" title="Assign a company owner / salesperson">
+    Assigns a team member as the owner or salesperson for a company
+  </Card>
+</Cards>
 
-For the complete list with special cases and examples, see the **[Automation steps reference](./automation-steps-reference.mdx)**.
+### Contacts
 
-## Building effective workflows
+<Cards cols={3}>
+  <Card href="/automations/my-automations/automation-steps-reference#contacts" title="Assign a contact owner / salesperson">
+    Assigns a team member as the owner or salesperson for a contact
+  </Card>
+</Cards>
 
-**Start simple.** Begin with a trigger and one or two actions. Test that the basics work before adding complexity.
+### Custom objects
 
-**Use delays strategically.** Some data isn't available immediately after a trigger fires (e.g., salesperson assigned a few minutes after account creation). Add a delay step before actions that depend on that data.
+<Cards cols={3}>
+  <Card href="/automations/my-automations/automation-steps-reference#custom-objects" title="Associate custom object with activity">
+    Links a custom object record to a CRM activity for tracking
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#custom-objects" title="Create a custom object">
+    Creates a new custom object record
+  </Card>
+  <Card href="/automations/my-automations/find-custom-object" title="Find custom object">
+    Looks up a custom object record and brings it into scope
+  </Card>
+</Cards>
 
-**Branch with if/else.** Use [logic steps](./logic-and-flow-control.mdx) to route records down different paths based on conditions — like sending different emails based on sentiment analysis.
+### Users
 
-**Pass data between steps.** Use [data expressions](./data-expressions.mdx) to extract values from one step's output and feed them into another step's input.
+<Cards cols={3}>
+  <Card href="/automations/my-automations/automation-steps-reference#users" title="Create a user from a contact">
+    Creates a Business App user from an existing CRM contact
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#users" title="Get my team member">
+    Retrieves a specific team member for use in later steps
+  </Card>
+</Cards>
 
-## Pages in this section
+### Businesses
 
-- **[Automation steps reference](./automation-steps-reference.mdx)** — Complete list of every action step, organized by category
-- **[Summarize with AI](./summarize-with-ai.mdx)**, **[Categorize with AI](./categorize-with-ai.mdx)**, **[Analyze sentiment](./analyze-sentiment-with-ai.mdx)**, **[Send a prompt to AI](./send-a-prompt-to-ai.mdx)**, **[Send a request to an AI employee](./send-a-request-to-an-ai-employee.mdx)** — AI-powered action steps
-- **[Find company](./find-company.mdx)**, **[Find custom object](./find-custom-object.mdx)**, **[Copy AI employee](./copy-assistant-automation.mdx)** — Detailed step guides
-- **[Bulk actions](./bulk-actions.mdx)** — Run automation-powered actions on demand from CRM views
-- **[Logic & flow control](./logic-and-flow-control.mdx)** — If/else branches, delays, jump steps, rate filters, end automation
-- **[Data expressions](./data-expressions.mdx)** — Extract and transform data between steps using JQ expressions
-- **[Groups and Action Sets](./reusable-workflows.mdx)** — Grouping, action sets, and AI employee integration
+<Cards cols={3}>
+  <Card href="/automations/my-automations/automation-steps-reference#businesses" title="Create a company">
+    Creates a company in the CRM
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#businesses" title="Create a contact">
+    Creates a contact in the CRM
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#businesses" title="Get or create the associated account">
+    Gets the account associated with a company, creating one if needed
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#businesses" title="Get company from contact">
+    Retrieves the company linked to a contact
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#businesses" title="Get company from custom object">
+    Retrieves the company linked to a custom object
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#businesses" title="Get contact from company">
+    Retrieves a contact linked to a company
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#businesses" title="Get contact from custom object">
+    Retrieves a contact linked to a custom object
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#businesses" title="Get custom object from company">
+    Retrieves a custom object record linked to a company
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#businesses" title="Get custom object from contact">
+    Retrieves a custom object record linked to a contact
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#businesses" title="Get the associated company">
+    Gets the company associated with the account in scope
+  </Card>
+  <Card href="/automations/my-automations/find-company" title="Find company">
+    Searches for a company by field criteria and brings it into scope
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#businesses" title="Find contact">
+    Searches for a contact by field criteria and brings it into scope
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#businesses" title="Set account lifecycle stage">
+    Sets an account's lifecycle stage (Lead, Prospect, or Customer)
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#businesses" title="Update company">
+    Updates one or more fields on a company record
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#businesses" title="Update contact">
+    Updates a CRM contact, supports appending or clearing field values
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#businesses" title="Update custom object">
+    Updates one or more fields on a custom object record
+  </Card>
+</Cards>
+
+### Campaigns and emails
+
+<Cards cols={3}>
+  <Card href="/automations/my-automations/automation-steps-reference#campaigns-and-emails" title="Pause campaign for company">
+    Pauses an ongoing campaign for the company
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#campaigns-and-emails" title="Pause campaign for contact">
+    Pauses an ongoing campaign for the contact
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#campaigns-and-emails" title="Pause a campaign for the user">
+    Pauses an ongoing campaign for the user
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#campaigns-and-emails" title="Pause a campaign for the account">
+    Pauses an ongoing campaign for the account
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#campaigns-and-emails" title="Start a campaign for the user">
+    Starts an email campaign for a user
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#campaigns-and-emails" title="Start a campaign for the account">
+    Starts an email campaign for the account and all its users/contacts
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#campaigns-and-emails" title="Start a campaign for the contact">
+    Enrolls a contact in an email campaign
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#campaigns-and-emails" title="Start a Yesware campaign for the contact">
+    Enrolls a contact in a Yesware email sequence
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#campaigns-and-emails" title="Send a plain text email via Gmail">
+    Sends a plain-text email from your connected Gmail account
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#campaigns-and-emails" title="Send a plain text email via Outlook">
+    Sends a plain-text email from your connected Outlook account
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#campaigns-and-emails" title="Send a marketing email template to a company">
+    Sends a one-off marketing email to the company's contacts
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#campaigns-and-emails" title="Send a marketing email template to a contact">
+    Sends a one-off marketing email to the contact
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#campaigns-and-emails" title="Send an email to users">
+    Sends a one-off email to the users on the account
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#campaigns-and-emails" title="Start a campaign for the company">
+    Enrolls all contacts on a company in a campaign
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#campaigns-and-emails" title="Copy email template to another company">
+    Copies an email template from one company to another
+  </Card>
+</Cards>
+
+### Fulfillment
+
+<Cards cols={3}>
+  <Card href="/automations/my-automations/automation-steps-reference#fulfillment" title="Create a fulfillment task">
+    Creates a task in Task Manager
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#fulfillment" title="Create a fulfillment project for the account">
+    Creates a project in Task Manager from a template
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#fulfillment" title="Add account to Task Manager">
+    Adds the account to Task Manager so tasks can generate
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#fulfillment" title="Pause or cancel the Task Manager account">
+    Pauses or cancels a Task Manager account
+  </Card>
+</Cards>
+
+### Lists
+
+<Cards cols={3}>
+  <Card href="/automations/my-automations/automation-steps-reference#lists" title="Add the account to a list">
+    Adds the account to a list
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#lists" title="Remove the account from a list">
+    Removes the account from a list
+  </Card>
+</Cards>
+
+### Notifications
+
+<Cards cols={3}>
+  <Card href="/automations/my-automations/automation-steps-reference#notifications" title="Notify all account users">
+    Sends a notification to every user on the account
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#notifications" title="Notify a user">
+    Sends an in-app and email notification to one or more users
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#notifications" title="Notify a digital agent">
+    Sends a notification to a fulfillment agent
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#notifications" title="Notify a salesperson">
+    Sends a notification to a salesperson
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#notifications" title="Notify the user">
+    Sends a notification to the triggering user
+  </Card>
+</Cards>
+
+### Products
+
+<Cards cols={3}>
+  <Card href="/automations/my-automations/automation-steps-reference#products" title="Activate express products">
+    Activates a specific express product
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#products" title="Activate products">
+    Activates a product for the account
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#products" title="Deactivate products">
+    Deactivates one or more products for the account
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#products" title="Get products' custom field data">
+    Gets custom field data for the account's products
+  </Card>
+</Cards>
+
+### Sales
+
+<Cards cols={3}>
+  <Card href="/automations/my-automations/automation-steps-reference#sales" title="Assign a sales team">
+    Assigns a random salesperson from a team to the account
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#sales" title="Assign a salesperson">
+    Assigns a specific salesperson to the account
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#sales" title="Charge an invoice">
+    Charges a specific invoice against the payment method
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#sales" title="Close all Sales Opportunities">
+    Closes every open opportunity on the account
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#sales" title="Close opportunity">
+    Closes a specific opportunity
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#sales" title="Log activity and hotness rating">
+    Logs a business activity and raises the hotness rating
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#sales" title="Create a sales opportunity">
+    Creates a CRM opportunity on the account
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#sales" title="Create a proposal">
+    Creates a sales proposal on the account
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#sales" title="Create a sales task (legacy)">
+    Creates a legacy sales task
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#sales" title="Create a Snapshot Report">
+    Creates a Snapshot Report for the account or company
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#sales" title="Finalize an invoice">
+    Finalizes a draft invoice for payment collection
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#sales" title="Reopen opportunity">
+    Reopens a previously closed opportunity
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#sales" title="Unassign salespeople">
+    Removes assigned salespeople from the account
+  </Card>
+</Cards>
+
+### Tags
+
+<Cards cols={3}>
+  <Card href="/automations/my-automations/automation-steps-reference#tags" title="Add tags to the account">
+    Adds one or more tags to the account
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#tags" title="Add tags to the order">
+    Adds one or more tags to a sales order
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#tags" title="Remove tags from the account">
+    Removes one or more tags from the account
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#tags" title="Remove tags from the order">
+    Removes one or more tags from a sales order
+  </Card>
+</Cards>
+
+### Conversations
+
+<Cards cols={3}>
+  <Card href="/automations/my-automations/automation-steps-reference#conversations" title="Send a Conversations message">
+    Sends a message to the account's Conversations inbox
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#conversations" title="Send a public system message">
+    Sends a public system message visible to everyone on the account
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#conversations" title="Send an SMS message via Conversations">
+    Sends an SMS message via Conversations to a contact
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#conversations" title="Send an SMS message to a phone number">
+    Sends an SMS to any phone number, including numbers not in CRM
+  </Card>
+</Cards>
+
+### Sales orders
+
+<Cards cols={3}>
+  <Card href="/automations/my-automations/automation-steps-reference#sales-orders" title="Activate products for the order">
+    Activates products associated with a sales order
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#sales-orders" title="Add tags to the order">
+    Adds one or more tags to a sales order
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#sales-orders" title="Approve the order">
+    Approves a pending sales order
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#sales-orders" title="Archive the order">
+    Archives a sales order from active views
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#sales-orders" title="Decline the order">
+    Declines a pending sales order
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#sales-orders" title="Get order data">
+    Retrieves order data and brings it into scope for downstream steps
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#sales-orders" title="Remove tags from the order">
+    Removes one or more tags from a sales order
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#sales-orders" title="Submit the order for admin approval">
+    Submits an order for admin approval before activation
+  </Card>
+</Cards>
+
+### Advanced
+
+<Cards cols={3}>
+  <Card href="/automations/my-automations/automation-steps-reference#advanced" title="Apply account template">
+    Deploys an account template to the target account
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#advanced" title="Associate company with contact">
+    Links a company and contact record in the CRM
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#advanced" title="Update opportunity stage">
+    Updates the pipeline stage of an opportunity
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#advanced" title="Log a call activity to the company">
+    Logs a call record on the company's activity timeline
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#advanced" title="Log a call activity to the contact">
+    Logs a call record on the contact's activity timeline
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#advanced" title="Add a note to the company">
+    Adds a note to a company record
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#advanced" title="Add a note to the contact">
+    Adds a note to a contact record
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#advanced" title="Create a CRM sales task for the company">
+    Creates a CRM sales task on the company
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#advanced" title="Create a CRM sales task for the contact">
+    Creates a CRM sales task on the contact
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#advanced" title="Modify a call activity for the company">
+    Updates an existing call activity on a company
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#advanced" title="Modify custom account data">
+    Writes or updates custom account data fields
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#advanced" title="Modify custom product data">
+    Writes or updates custom product data fields
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#advanced" title="Modify custom sales order data">
+    Writes or updates custom sales order data fields
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#advanced" title="Modify custom user data">
+    Writes or updates custom user data fields
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#advanced" title="Send a webhook">
+    Sends an HTTP POST request with custom data to an external URL
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#advanced" title="Get an opportunity">
+    Gets an opportunity and brings it into scope
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#advanced" title="Format text">
+    Transforms a text value using formatting rules
+  </Card>
+</Cards>
+
+### Integrations
+
+<Cards cols={3}>
+  <Card href="/automations/my-automations/automation-steps-reference#integrations" title="Add contact to Kixie powerlist">
+    Adds a contact to a Kixie powerlist for automated calling
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#integrations" title="Remove contact from Kixie powerlist">
+    Removes a contact from a Kixie powerlist
+  </Card>
+</Cards>
+
+### AI actions
+
+<Cards cols={3}>
+  <Card href="/automations/my-automations/categorize-with-ai" title="Categorize with AI">
+    Classifies text into custom categories and branches accordingly
+  </Card>
+  <Card href="/automations/my-automations/analyze-sentiment-with-ai" title="Analyze sentiment with AI">
+    Detects positive, neutral, or negative tone and branches accordingly
+  </Card>
+  <Card href="/automations/my-automations/summarize-with-ai" title="Summarize with AI">
+    Condenses text into concise summaries for downstream steps
+  </Card>
+  <Card href="/automations/my-automations/automation-steps-reference#advanced" title="Translate with AI">
+    Translates text into another language
+  </Card>
+  <Card href="/automations/my-automations/send-a-request-to-an-ai-employee" title="Send a request to an AI employee">
+    Sends a prompt to a specific AI employee with its knowledge base
+  </Card>
+  <Card href="/automations/my-automations/send-a-prompt-to-ai" title="Send a prompt to AI">
+    Sends a free-form prompt to an AI model and returns the response
+  </Card>
+</Cards>
+
+### Delays
+
+<Cards cols={3}>
+  <Card href="/automations/my-automations/logic-and-flow-control" title="Delay until an event happens">
+    Pauses and waits until a specified event occurs
+  </Card>
+  <Card href="/automations/my-automations/logic-and-flow-control" title="Delay">
+    Pauses the automation for a set amount of time
+  </Card>
+</Cards>
+
+### Conditions
+
+<Cards cols={3}>
+  <Card href="/automations/my-automations/logic-and-flow-control" title="If/else branch">
+    Splits the workflow into two paths based on a condition
+  </Card>
+  <Card href="/automations/my-automations/logic-and-flow-control" title="Jump to a step">
+    Skips forward or backward to a specific step
+  </Card>
+  <Card href="/automations/my-automations/logic-and-flow-control" title="Rate filter">
+    Limits how frequently the automation can proceed per contact
+  </Card>
+</Cards>
+
+### Workflow (Early Access)
+
+<Cards cols={3}>
+  <Card href="/automations/my-automations/logic-and-flow-control" title="A/B branch">
+    Randomly splits contacts into two groups for testing
+  </Card>
+  <Card href="/automations/my-automations/logic-and-flow-control" title="End this automation">
+    Immediately stops the current automation run
+  </Card>
+</Cards>

--- a/docusaurus/docs/automations/my-automations/creating-and-configuring-automations.mdx
+++ b/docusaurus/docs/automations/my-automations/creating-and-configuring-automations.mdx
@@ -1,215 +1,188 @@
 ---
 title: Creating and configuring automations
-description: Learn how to create, configure, and manage automation settings including entry settings, error handling, permissions, and duplication.
+description: Learn how to create automations, configure settings (entry, error handling, goals, timezone, notifications, permissions), and manage automations with tags and duplication.
 sidebar_position: 1
 ---
 
+import { Cards, Card } from '@site/src/components/Cards';
+
 # Creating and configuring automations
 
-This guide covers the complete process of creating automations and configuring their advanced settings to ensure they work exactly as you need them to.
+## Create an automation
 
-## Automation settings
+1. Go to **Partner Center** then **Automations**.
+2. Click **Create automation** (top right).
+3. Choose a template or start with a blank canvas.
+4. Add a name and optional description.
+5. Add your **trigger** — the event that starts the workflow.
+6. Add **actions** — the steps that run when the trigger fires.
+7. Toggle the automation **On** when you're ready.
 
-Several settings can be configured for each automation you create. You can access these settings in the **Advanced** section of the left menu in your automation.
+## Settings
 
-![Automation Settings Tab](./img/automations/automation-settings-tab.jpg)
+Open an automation and click **Settings** in the left menu. Settings are organized into five tabs.
 
-### Entry settings
+<Cards cols={3}>
+  <Card href="#overview" title="Overview">
+    Entry settings and error handling — how often and how reliably your automation runs
+  </Card>
+  <Card href="#goal" title="Goal">
+    Define a success condition that ends the run early when met
+  </Card>
+  <Card href="#timezone" title="Timezone">
+    Set the timezone for schedules, delays, and activity timestamps
+  </Card>
+  <Card href="#notifications" title="Notifications">
+    Get alerted via email and in-app when automations encounter issues
+  </Card>
+  <Card href="#advanced" title="Advanced">
+    Manage permissions and authorization for the automation
+  </Card>
+</Cards>
 
-Many trigger events and conditions can be met multiple times. For example, **A customer makes a payment** trigger with the trigger options set to **Succeeds or fails** will fire each time a customer attempts to pay for an invoice or shopping cart purchase. The entry settings allow you to specify how often the automation should run when the trigger fires.
+### Overview
 
-**Options:**
+#### Entry settings
 
-- **Only once per account** — The automation runs a maximum of one time per account, ever. Once it has run for an account, that account is excluded from all future runs, even if the trigger fires again. Use this for one-time onboarding flows or welcome sequences.
-- **One at a time per account** — Prevents concurrent runs for the same account. If a second trigger fires while a run is already in progress for that account, the second trigger is dropped. Once the first run completes, new triggers will start fresh runs normally. Use this when overlapping runs would cause duplicate actions.
-- **Multiple times per account** — The automation runs every time the trigger conditions are met, with no frequency or concurrency limits. Use this for ongoing notifications, recurring task creation, or any scenario where re-triggering is intentional.
+Controls how often the automation runs per account.
 
-:::warning Common misconception
-**One at a time per account** does not limit the automation to running once total. It only prevents two runs from overlapping simultaneously. If the trigger fires again after the first run finishes, a new run will start. To run only once ever, use **Only once per account**.
+| Setting | Behavior | Use when |
+|---|---|---|
+| **Only once per account** | Runs one time per account, ever. That account is excluded from all future runs. | One-time onboarding, welcome sequences |
+| **One at a time per account** | Prevents concurrent runs. A second trigger is dropped while a run is in progress. New triggers start normally after the first run completes. | Overlapping runs would cause duplicate actions |
+| **Multiple times per account** | Runs every time trigger conditions are met, no limits. | Ongoing notifications, recurring tasks |
+
+:::warning
+**One at a time per account** does not mean "run once." It only prevents two runs from overlapping. After the first run finishes, new triggers start fresh runs. To run only once ever, use **Only once per account**.
 :::
 
-### Error handling settings
+#### Error handling
 
-You can have many steps in an automation workflow. If at any point a step fails to complete, you can choose to have your automation ignore the error and continue with the following steps, or stop that specific automation run.
+Controls what happens when a step fails.
 
-**Options:**
-- **Ignore the error and continue the automation**: If a step fails, the automation will log an error (viewable in the Activity table) and move on to the next step of the workflow.
-- **Stop that specific automation run**: If a step fails, the automation run will completely stop for that account. The automation will not move on to the next step of the workflow. You may manually resume the run from any step in the workflow from the automation activity section.
-
-### Permissions
-
-An automation runs on behalf of whoever turned it on. If that person's access changes — for example, they're deactivated, their role changes, or their consent is revoked — the automation stops processing new triggers until someone re-authorizes it.
-
-To transfer permissions to your own profile, click **Transfer Permissions** and sign in to approve the requested access. See [Fixing "Automation requires valid permissions to run"](../automation-history/automation-permissions-error.mdx) for the full troubleshooting steps.
-
-### Timezone configuration
-
-Set your preferred timezone for time-based automation steps and scheduling. This affects:
-
-- When **On a schedule** triggers fire
-- When **Delay** steps calculate their wait periods
-- How timestamps appear in the Activity tab
-
-To set the timezone, go to the automation's **Settings** tab and select **Timezone**.
+| Setting | Behavior |
+|---|---|
+| **Ignore the error and continue** | Logs an error (viewable in Activity) and moves to the next step |
+| **Stop that specific automation run** | Stops the run for that account. You can resume from any step in the Activity section |
 
 ### Goal
 
-Goals let you define a success condition for the automation. When the goal is met, the run ends early with a **Completed from goal** status instead of running through all remaining steps.
+Define a success condition. When the goal is met, the run ends early with a **Completed from goal** status instead of running through all remaining steps.
 
-To set a goal, go to the automation's **Settings** tab and select **Goal**.
+1. Go to **Settings** then **Goal**.
+2. Define the condition that counts as success.
+3. Save.
 
-### Notification settings
+### Timezone
 
-Subscribe to notifications so you're alerted when automations encounter issues:
+Set the timezone for time-based steps and scheduling. This affects:
 
-1. Go to the automation's **Settings** tab and select **Notifications**.
-2. Choose which events to be notified about (e.g., errors, completion).
+- When **On a schedule** triggers fire
+- When **Delay** steps calculate wait periods
+- How timestamps appear in the Activity tab
+
+Go to **Settings** then **Timezone** and select your timezone.
+
+### Notifications
+
+Get alerted when automations encounter issues.
+
+1. Go to **Settings** then **Notifications**.
+2. Choose which events trigger a notification (e.g., errors, completion).
 3. Select who receives the notifications.
 
 Notifications are sent via email and in-app alerts.
 
-## Duplicating automations
+### Advanced
 
-There may be times when you want to copy an automation you've created. You can do this from the main Automations page, or from a specific automation.
+#### Permissions
+
+An automation runs on behalf of whoever turned it on. If that person's access changes — deactivated, role changed, or consent revoked — the automation stops processing new triggers.
+
+To fix this:
+1. Open the automation and go to **Settings** then **Advanced**.
+2. Click **Transfer Permissions**.
+3. Sign in and approve the requested access.
+
+See [Fixing "Automation requires valid permissions"](../automation-history/automation-permissions-error.mdx) for full troubleshooting steps.
+
+## Manage your automations
+
+<Cards cols={2}>
+  <Card href="#duplicate-an-automation" title="Duplicate">
+    Copy an existing automation to use as a starting point
+  </Card>
+  <Card href="#market-scope" title="Market scope">
+    Restrict automations to specific markets using trigger conditions
+  </Card>
+  <Card href="#organize-with-tags" title="Tags">
+    Group automations into categories and filter them quickly
+  </Card>
+  <Card href="#turn-off-an-automation" title="Turn off">
+    Stop or drain an automation — choose what happens to in-progress runs
+  </Card>
+</Cards>
+
+### Duplicate an automation
+
+Copy an existing automation to use as a starting point.
 
 :::note
-**Important Notes:**
-- Duplicated automations are off by default. Remember to turn on the automation when you're ready.
-- If you have markets enabled, the new automation will be copied into the same market as the original.
+Duplicated automations are **off by default**. Turn it on when you're ready. If you have markets enabled, the copy is scoped to all markets regardless of the original.
 :::
 
-### From the Automations page
-
-To copy an automation from **Partner Center** > [**Automations**](https://partners.vendasta.com/automations):
-
-1. Find the automation you want to copy in the table. Then, click the **Menu** icon at the end of the row.
+**From the Automations list:**
+1. Find the automation in the table and click the **menu icon** at the end of the row.
 2. Click **Duplicate**.
 
 ![Duplicate automation from automations page](./img/automations/duplicating-automations/duplicate_from_automations_page.jpg)
 
-### From a specific automation
-
-To copy an automation from a specific automation:
-
-1. Click **Menu** in the top right corner of the screen.
+**From inside an automation:**
+1. Click the **menu icon** in the top right corner.
 2. Click **Duplicate**.
 
 ![Duplicate from a specific automation](./img/automations/duplicating-automations/duplicate_from_specific_automation.jpg)
 
-## Automation market scope
+### Market scope
 
-Automations apply to **all markets** by default. Single-market automation creation is no longer supported — if you duplicate an automation, the copy will be scoped to all markets regardless of how the original was configured.
-
-To restrict an automation to a specific market, add a market condition to the trigger:
+Automations apply to **all markets** by default. To restrict to a specific market, add a condition to the trigger:
 
 1. In the trigger step, click **Add conditions for starting this automation**.
 2. Set **Condition type** to **Account data**.
-3. Select **Market** → **Is** → choose the market from the dropdown.
-4. Save the trigger.
+3. Select **Market** then **Is** then choose the market.
+4. Save.
 
-The automation will only fire for accounts in that market. To target multiple specific markets, add additional market conditions using **OR** logic.
+To target multiple markets, add additional market conditions using **OR** logic.
 
-## Organizing automations with tags
+### Organize with tags
 
-Tired of scrolling through your long list of automations? You can now add tags to your automations to group them into categories and find them more easily.
+Add tags to group automations into categories and find them faster.
 
-### Common tag examples
-
-Here are some commonly used tags:
-- Leads
-- Onboarding
-- Sales
-- Retention
-- Marketing
-- Trial
-- Pipeline
-
-You can enter any tag you like, so the options are endless!
-
-### Adding tags
-
-To add tags to an automation:
-
-1. Go to **Partner Center** > [**Automations**](https://partners.vendasta.com/automations)
-2. Create new automation by clicking **Create automation** and selecting a template, or selecting an existing automation.
-3. Click the **Edit Details.**
-4. In the **Tags** field, enter one or more tags. To use a new tag, enter the text for the tag, then press **Enter**.
-5. Click **Save**. 
+| Action | How to |
+|---|---|
+| **Add tags** | Open an automation, click **Edit Details**, enter tags in the **Tags** field, press **Enter**, then **Save** |
+| **Remove tags** | Open **Edit Details**, click the **X** on the tag, then **Save** |
+| **Filter by tag** | On the Automations list, click the **Filter** icon and select a tag |
 
 ![Adding tags to automation](./img/automations/add-tags.png)
 
-### Removing tags
+### Turn off an automation
 
-To remove tags from an automation:
+When you turn off an automation, choose between:
 
-1. Repeat steps 1-3 in the **Add tags section**.
-2. In the **Tags** field, click the **Remove** icon on the tag(s) you want to remove. 
-3. Click **Save**.
+| Option | What happens |
+|---|---|
+| **Stop immediately** | All scheduled steps are canceled right away |
+| **Drain** | In-progress runs finish, but no new runs start |
 
-### Filtering by tags
-
-To filter the automation table by tags:
-
-1. Go to **Partner Center** > My [**Automations**](https://partners.vendasta.com/automations)
-2. Click the **Filter** icon ![filter icon](./img/automations/filter-icon.png) on the table.
-3. In the **Tags** section, select a tag to filter the table by.
-
-The table should now be filtered by the selected tag.
-
-![Filtering automations by tags](./img/automations/filter-by-tags.png)
-
-## Turning off automations
-
-You can turn off automation from the Workflow page, or from the main Automations page.
-
-### Drain vs. stop
-
-When you turn off an automation, you can stop it immediately or set it to drain. Automation draining allows you to stop an automation that is running but lets the existing runs finish rather than halting their progress. No new automation runs are started once the automation is stopped.
-
-**Stop immediately**: All scheduled steps will be stopped immediately and canceled.
-**Drain**: Allow remaining steps to complete for accounts currently in progress, but no new runs will start.
-
-### How to turn off an automation
-
-**Method 1: From the Automations List**
-
-Go to **Partner Center > Automations**. Choose the automation you would like to turn off or allow to drain before it completely stops. **Click the kebab icon > Turn off the automation.**
+**From the Automations list:** Click the **menu icon** on the row, then **Turn off**.
 
 ![Turn off automation from kebab menu](./img/automations/turn-off-automation/turn_off_automation_1.jpg)
 
-**Method 2: From Within the Automation**
-
-You can also click into the automation and stop it from there by toggling from 'On' to 'Off'.
+**From inside an automation:** Toggle from **On** to **Off**.
 
 ![Toggle automation off](./img/automations/turn-off-automation/toggle_automation_off.jpg)
 
-### Choosing stop or drain
-
-You will be prompted to either "Stop automation runs in progress" or "drain automation runs". By selecting to stop runs in progress, all scheduled steps will be stopped immediately.
-
-By choosing to drain the automation, you are allowing the remaining steps of the automation to run for any account still in progress, however, no new runs will be activated.
-
-![Drain automation dialog](./img/automations/turn-off-automation/drain_automation_dialog.jpg)
-
 :::warning
-When you turn off automation without selecting the "drain automation runs" option, all scheduled steps are canceled and will not resume if the automation is turned on again. For example, if you have an automation running that sends an email 5 days after a new account is created, any currently running workflows to send emails to the accounts triggered in the last 5 days will be canceled.
+Stopping without drain cancels all scheduled steps permanently. They will not resume if the automation is turned back on. For example, emails scheduled for the next 5 days will be canceled.
 :::
-
-## Best practices for configuration
-
-1. **Test Entry Settings**: Carefully consider whether your automation should run once or multiple times per account
-2. **Plan Error Handling**: Decide upfront how your automation should handle errors based on the criticality of each step
-3. **Use Descriptive Tags**: Implement a consistent tagging strategy to keep your automations organized
-4. **Monitor Performance**: Regularly check automation activity to ensure settings are working as expected
-5. **Document Changes**: When duplicating automations, clearly name and document what changes you're making
-
-<div style={{textAlign: 'center', paddingBottom: '15px'}}>
-  <a 
-    style={{fontSize: '16px', fontWeight: 'bold', color: '#ffffff', backgroundColor: '#33ace2', textDecoration: 'none', borderRadius: '5px', padding: '10px 30px 9px 30px', border: '1px solid #33ACE2', display: 'inline-block', textAlign: 'center'}}
-    href="https://partners.vendasta.com/automations"
-    target="_blank"
-    rel="noopener"
-  >
-    Configure Your Automations
-  </a>
-</div>


### PR DESCRIPTION
## Summary

**Actions overview:** Every available action from the UI as clickable cards, organized by 18 categories including a dedicated AI actions section. Matches the exact action list from the automation editor.

**Creating and configuring:** Restructured to match the 5-tab Settings UI (Overview, Goal, Timezone, Notifications, Advanced) with card navigation for both settings and management sections.

Merge after PR #982 (flatten sidebar).

## Test plan

- [x] `npm run build` passes
- [x] All action cards render and link correctly on `/automations/my-automations/actions-overview`
- [x] Settings card navigation works on `/automations/my-automations/creating-and-configuring-automations`

🤖 Generated with [Claude Code](https://claude.com/claude-code)