### PR TITLE
Add service-level.yaml

### DIFF
--- a/service-level.yaml
+++ b/service-level.yaml
@@ -1,0 +1,8 @@
+services:
+  - name: partnercenter-docs
+    owner: documentation
+    language: typescript
+    platform: Cloud Run
+    status: active
+    description: "Partner Center product documentation site (docs.vendasta.com)."
+    nonServiceType: reference


### PR DESCRIPTION
Adds `service-level.yaml` so this repository appears in the service inventory (`data-lake-common.github.src_github_service_level`), which is populated from every repo's `service-level.yaml`.

Fields were derived from the repo itself, not guessed:
- `platform` from the presence of a Cloud Run deploy in `cloudbuild.yaml`
- `language` from the build config (`tsconfig.json`) / file mix
- `owner` from an existing GitHub team, cross-checked against commit history
- `nonServiceType: reference`, matching the existing `amps-docs` precedent

Validated against the production parser (`github_client._parse_service_level_yaml`) — parses cleanly with no errors.

Please correct the `owner` if this should sit with a different team.

🤖 Generated with [Claude Code](https://claude.com/claude-code)