### PR TITLE
docs(customize): clarify Buy-it-Yourself vs. self-serve upgrades

### DIFF
--- a/docusaurus/docs/administration/platform-settings/customize/index.mdx
+++ b/docusaurus/docs/administration/platform-settings/customize/index.mdx
@@ -41,6 +41,10 @@ When a client starts a sales order and pays retail, the auto-activation process 
 Products and services offered for free are not part of the BIY experience.
 :::
 
+### Buy-it-Yourself vs. self-serve upgrades
+
+Buy-it-Yourself covers a client's first purchase and activation of a product. If a client already owns a product and wants to move to a higher tier, that's a **self-serve upgrade** instead — a separate setting configured per product under `Partner Center` → `Marketplace` → `Products` → *(select product)* → `Product Info` → `Upgrade Path`. See [Product configuration](/marketplace/products#product-info-tab) for setup steps.
+
 ### Building a custom purchasing experience
 
 To create a controlled purchasing workflow:


### PR DESCRIPTION
## Summary
- Adds a short clarifying note distinguishing Buy-it-Yourself (first purchase/activation) from self-serve upgrades (per-product Upgrade Path setting), linking to the existing Product Info documentation.
- Confirmed the previously reported "Step 2 does not exist" issue in the "How Buy-it-Yourself works" section is already fixed on master from an earlier consolidation pass.

Addresses DOC-850.

## Test plan
- [x] `npm run build` passes with no new broken links/anchors introduced
- [x] Verified `/marketplace/products#product-info-tab` anchor resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)