### PR TITLE
Add individual trigger detail pages for all automation triggers

### DIFF
--- a/docusaurus/docs/automations/my-automations/trigger-account-added-to-list.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-account-added-to-list.mdx
@@ -1,0 +1,47 @@
+---
+title: "Trigger: Account added to a list"
+description: Start an automation whenever an account is added to a list in Partner Center.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, accounts]
+keywords: [account added to list, account list trigger, account segmentation, automation trigger, account scope]
+---
+
+# Account added to a list
+
+The **Account added to a list** trigger starts an automation whenever an account is placed into a list in Partner Center. Use this trigger to act on accounts the moment they're segmented or grouped, without waiting for a manual follow-up.
+
+This trigger operates at the account scope, so all standard account fields are available to downstream steps.
+
+:::info Trigger scope
+This trigger operates at the **account** scope. Account fields, tags, and product data are available downstream.
+:::
+
+## How it works
+
+1. An account is added to a list, either manually or through another automation step.
+2. The account is brought into scope.
+3. Account data and list context become available as dynamic content.
+4. Downstream steps execute using the account data.
+
+## Available data
+
+| Output | Description |
+|---|---|
+| **Account name** | Name of the account added to the list |
+| **Account ID** | Unique identifier for the account |
+| **List name** | The name of the list the account was added to |
+| **Added at** | Timestamp when the account was added to the list |
+| **Account fields** | Standard fields such as address, phone, website, and industry |
+
+## Tips
+
+:::warning Accounts already on the list
+This trigger only fires when an account is added after the automation is activated. Accounts that were already on the list when you set up the trigger will not cause it to fire. To process existing list members, use a bulk action instead.
+:::
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-account-created.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-account-created.mdx
@@ -1,0 +1,46 @@
+---
+title: "Trigger: Account created"
+description: Start an automation whenever a new account is created in Partner Center.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, accounts]
+keywords: [account created trigger, new account, account onboarding, automation trigger, account scope]
+---
+
+# Account created
+
+The **Account created** trigger starts an automation the moment a new account is created in Partner Center. Use this trigger to automate onboarding steps, send welcome communications, or set up initial data without any manual intervention.
+
+This trigger operates at the account scope, so all standard account fields are available to downstream steps.
+
+:::info Trigger scope
+This trigger operates at the **account** scope. Account fields, tags, and product data are available downstream.
+:::
+
+## How it works
+
+1. A new account is created in Partner Center, either manually, via import, or through an API call.
+2. The account is brought into scope.
+3. Standard account fields become available as dynamic content.
+4. Downstream steps execute using the account data.
+
+## Available data
+
+| Output | Description |
+|---|---|
+| **Account name** | The name of the newly created account |
+| **Account ID** | Unique identifier for the account |
+| **Created at** | Timestamp when the account was created |
+| **Account fields** | Standard fields such as address, phone, website, and industry |
+
+## Tips
+
+:::warning Duplicate accounts
+This trigger fires for every new account creation event, including likely duplicates. If your team imports accounts in bulk or creates accounts from multiple sources, add trigger conditions to filter out records that don't meet your criteria before running downstream steps.
+:::
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-account-custom-data-updated.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-account-custom-data-updated.mdx
@@ -1,0 +1,42 @@
+---
+title: "Trigger: Account custom data updated"
+description: Start an automation whenever custom data fields on an account are changed.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, accounts]
+keywords: [custom data trigger, account custom fields, custom data updated, automation trigger, account scope]
+---
+
+# Account custom data updated
+
+The **Account custom data updated** trigger starts an automation whenever a custom data field on an account record changes. Use this trigger to react to structured business data — such as contract status, tier, or any field your team manages outside the standard account fields.
+
+This trigger operates at the account scope, so all account data — including the updated custom fields — is available to downstream steps.
+
+:::info Trigger scope
+This trigger operates at the **account** scope. Account fields, custom data fields, tags, and product data are available downstream.
+:::
+
+## How it works
+
+1. A custom data field on an account is updated, either manually or by an integration.
+2. The account is brought into scope with the new field values.
+3. All account data — including updated custom fields — becomes available as dynamic content.
+4. Downstream steps execute using the account and custom data context.
+
+## Available data
+
+| Output | Description |
+|---|---|
+| **Account name** | Name of the account |
+| **Account ID** | Unique identifier for the account |
+| **Custom data fields** | All custom data fields and their current values after the update |
+| **Updated at** | Timestamp of the change |
+
+Use trigger conditions to filter for changes to a specific custom data field if you only want the automation to run for certain updates.
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-account-updated.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-account-updated.mdx
@@ -1,0 +1,42 @@
+---
+title: "Trigger: Account updated"
+description: Start an automation whenever account details change in Partner Center.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, accounts]
+keywords: [account updated trigger, account changed, account fields updated, automation trigger, account scope]
+---
+
+# Account updated
+
+The **Account updated** trigger starts an automation whenever any detail on an account record changes in Partner Center. Use this trigger to keep downstream systems in sync or to react to data changes in real time.
+
+This trigger operates at the account scope, so all standard account fields — including the updated values — are available to downstream steps.
+
+:::info Trigger scope
+This trigger operates at the **account** scope. Account fields, tags, and product data are available downstream.
+:::
+
+## How it works
+
+1. Any field on an account record is changed — for example, an address update, phone number correction, or industry change.
+2. The account is brought into scope with its updated field values.
+3. Account data, including the newly changed values, becomes available as dynamic content.
+4. Downstream steps execute using the updated account data.
+
+## Available data
+
+| Output | Description |
+|---|---|
+| **Account name** | Current name of the account |
+| **Account ID** | Unique identifier for the account |
+| **Updated at** | Timestamp of the most recent change |
+| **Account fields** | All standard fields reflecting current values after the update |
+
+Use trigger conditions to filter for changes to specific fields if you only want the automation to run for certain types of updates.
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-api-account.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-api-account.mdx
@@ -1,0 +1,44 @@
+---
+title: "Trigger: API call on an account"
+description: Start an automation when an API call invokes the trigger for a specific account.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, advanced]
+keywords: [API trigger, API account trigger, programmatic trigger, developer trigger, account API automation]
+---
+
+# API call on an account
+
+**API call on an account** fires when an external system or custom integration makes an API call that invokes this trigger for a specific account. Use this trigger to start automations programmatically — for example, from your own application, a custom integration, or another platform that can send API requests.
+
+This trigger is intended for developers and technical users who need to initiate account-scoped automations from outside Partner Center.
+
+:::info Trigger scope
+This trigger operates at the **account** scope. Account and contact actions are available downstream.
+:::
+
+## How it works
+
+1. An external system makes an authenticated API call that references the trigger and a specific account ID.
+2. The automation starts with the identified account in context.
+3. Any payload data included in the API call is available as dynamic content in downstream steps.
+4. Downstream steps can use **Add dynamic content** to reference account fields and any data passed in the request.
+
+## Available data
+
+Standard account fields are available via **Add dynamic content**. Additional fields depend on what data your API call passes as part of the request payload.
+
+:::info
+Consult the Vendasta developer documentation for the correct API endpoint, authentication requirements, and payload schema to invoke this trigger.
+:::
+
+## Tips
+
+- Use this trigger when you need to start account-scoped automation workflows from an external system or custom-built integration.
+- Pass relevant context in the API payload to make it available as dynamic data in downstream steps.
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-api-order.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-api-order.mdx
@@ -1,0 +1,44 @@
+---
+title: "Trigger: API call on an order"
+description: Start an automation when an API call invokes the trigger for a specific order.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, advanced]
+keywords: [API trigger, API order trigger, programmatic trigger, order API automation, developer trigger]
+---
+
+# API call on an order
+
+**API call on an order** fires when an external system makes an API call that invokes this trigger for a specific order. Use this trigger to start order-scoped automations programmatically — for example, to kick off fulfillment steps, status updates, or notifications from an external platform or custom integration.
+
+This trigger is intended for developers and technical users who need to initiate order-scoped automations from outside Partner Center.
+
+:::info Trigger scope
+This trigger operates at the **order** scope. Order and account actions are available downstream.
+:::
+
+## How it works
+
+1. An external system makes an authenticated API call that references the trigger and a specific order ID.
+2. The automation starts with the identified order in context.
+3. Any payload data included in the API call is available as dynamic content in downstream steps.
+4. Downstream steps can use **Add dynamic content** to reference order fields and any data passed in the request.
+
+## Available data
+
+Standard order and account fields are available via **Add dynamic content**. Additional fields depend on what data your API call passes as part of the request payload.
+
+:::info
+Consult the Vendasta developer documentation for the correct API endpoint, authentication requirements, and payload schema to invoke this trigger.
+:::
+
+## Tips
+
+- Use this trigger when you need to start order-scoped automation workflows from an external system or custom-built integration.
+- Pass relevant context (such as order status or fulfillment details) in the API payload to make it available as dynamic data in downstream steps.
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-billed-wholesale.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-billed-wholesale.mdx
@@ -1,0 +1,42 @@
+---
+title: "Trigger: Billed wholesale cost of a product"
+description: Start an automation when a wholesale cost is billed for a product on an account.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, billing]
+keywords: [billed wholesale trigger, wholesale cost trigger, product billing, billing automation, account billing trigger]
+---
+
+# Billed wholesale cost of a product
+
+**Billed wholesale cost of a product** fires whenever a wholesale billing event occurs for a product on an account. Use this trigger to automate financial record-keeping, notify account managers of billing events, or kick off fulfillment workflows when a charge is processed.
+
+This trigger is scoped to individual product billing events, so it fires once per billed product per cycle.
+
+:::info Trigger scope
+This trigger operates at the **account** scope. Account and contact actions are available downstream.
+:::
+
+## How it works
+
+1. A wholesale cost is billed for a product associated with an account.
+2. The automation evaluates any trigger conditions you've configured, such as filtering on a specific product.
+3. If conditions are met, the workflow starts with the account and billing event data in context.
+4. Downstream steps can use **Add dynamic content** to reference the product name, wholesale amount, and account fields.
+
+## Available data
+
+Standard account fields and billing event fields are available via **Add dynamic content**.
+
+| Output | Description |
+|---|---|
+| **Product name** | The name of the product that was billed |
+| **Wholesale amount** | The wholesale cost charged for the billing period |
+| **Billing date** | The date the wholesale cost was billed |
+| **Account name** | The name of the account associated with the billing event |
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-call-activity-company.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-call-activity-company.mdx
@@ -1,0 +1,43 @@
+---
+title: "Trigger: A call activity is created or modified for a company"
+description: Start an automation whenever a call is logged or updated on a company record in the CRM.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, company]
+keywords: [call activity trigger, company call logged, CRM call activity, automation trigger call, company scope trigger]
+---
+
+# A call activity is created or modified for a company
+
+The **A call activity is created or modified for a company** trigger starts an automation whenever a call is logged or an existing call activity is updated on a company record in the CRM. Use this trigger to respond instantly to outbound or inbound call activity without any manual steps.
+
+This trigger operates at the company scope, so all company and account context is available to downstream steps.
+
+:::info Trigger scope
+This trigger operates at the **company** scope. Company, account, and contact actions are available downstream.
+:::
+
+## How it works
+
+1. A call activity is created on a company record, or an existing call activity on that record is modified.
+2. The company and its associated account are brought into scope.
+3. The call activity data — including call outcome, notes, and duration — becomes available as dynamic content.
+4. Downstream steps execute using the company, account, and call activity context.
+
+## Available data
+
+| Output | Description |
+|---|---|
+| **Call outcome** | The result recorded for the call (e.g., Connected, No answer) |
+| **Call notes** | Notes logged on the call activity |
+| **Call duration** | Duration of the call, if recorded |
+| **Activity date** | The date and time the call activity was created or last modified |
+| **Associated company** | Name, ID, and standard fields of the company the call is logged on |
+
+Standard company and account fields are also available to downstream steps via **Add dynamic content**.
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-call-activity-contact.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-call-activity-contact.mdx
@@ -1,0 +1,39 @@
+---
+title: "Trigger: A call activity is created or modified for a contact"
+description: Start an automation when a call is logged or updated on a contact record.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, contact]
+keywords: [call activity trigger, contact call logged, call updated, CRM activity, automation trigger]
+---
+
+# A call activity is created or modified for a contact
+
+**A call activity is created or modified for a contact** starts a workflow whenever a call is logged or an existing call record is updated on a contact. Use this trigger to respond automatically when your team records outreach or follow-up calls.
+
+This trigger fires for both new call logs and edits to existing ones, so you can keep downstream records and tasks in sync as call details are refined.
+
+:::info Trigger scope
+This trigger operates at the **contact** scope. Contact, company, and account actions are available downstream.
+:::
+
+## How it works
+
+1. A team member logs a new call — or edits an existing call — on a contact record in the CRM.
+2. The automation evaluates any trigger conditions you've configured (for example, filtering on call outcome or assigned user).
+3. If all conditions are met, the workflow starts with the contact, their associated company, and the account in context.
+4. Downstream steps can use **Add dynamic content** to reference call details, contact fields, and company fields.
+
+## Available data
+
+All standard contact, company, and account fields are available downstream via **Add dynamic content**. This includes fields such as contact name, email, phone, assigned salesperson, company name, and account tags.
+
+:::info
+Call activity fields (such as call notes, duration, and outcome) are available as dynamic data in steps that follow this trigger.
+:::
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx) — trigger types, scoping, and how to choose the right trigger
+- [Automation triggers reference](./automation-triggers-reference.mdx) — full reference for every available trigger
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx) — entry settings, conditions, and error handling
+- [Actions overview](./actions-overview.mdx) — what can happen after a trigger fires

--- a/docusaurus/docs/automations/my-automations/trigger-campaign-email-activity.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-campaign-email-activity.mdx
@@ -1,0 +1,47 @@
+---
+title: "Trigger: Activity on a campaign email"
+description: Start an automation whenever a campaign email is opened or a CTA link is clicked.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, campaigns]
+keywords: [campaign email trigger, email opened, email clicked, CTA click, automation trigger, account scope]
+---
+
+# Activity on a campaign email
+
+The **Activity on a campaign email** trigger starts an automation when a campaign email is opened or a call-to-action link is clicked. Use this trigger to follow up with engaged recipients while their interest is highest.
+
+This trigger operates at the account scope, so account data is available to downstream steps.
+
+:::info Trigger scope
+This trigger operates at the **account** scope. Account fields and campaign email data are available downstream.
+:::
+
+## How it works
+
+1. A campaign email is delivered to a recipient.
+2. The recipient opens the email or clicks a CTA link within it.
+3. The activity event fires and the account is brought into scope.
+4. Downstream steps execute using the account and email activity context.
+
+## Available data
+
+| Output | Description |
+|---|---|
+| **Activity type** | Whether the event was an open or a click |
+| **Campaign name** | The name of the campaign the email belongs to |
+| **Email subject** | Subject line of the email that was interacted with |
+| **Account name** | The account associated with the recipient |
+| **Activity at** | Timestamp of the open or click event |
+
+## Tips
+
+:::warning Click tracking and first-click behavior
+Only clicks on CTA (call-to-action) links are tracked — general unsubscribe or footer links do not count. By default, this trigger fires only for the first user to click unless **Run multiple times** is enabled on the automation. Enable that setting if you want the trigger to fire for every individual click event.
+:::
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-communication-summary-created.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-communication-summary-created.mdx
@@ -1,0 +1,43 @@
+---
+title: "Trigger: An AI communication summary is created"
+description: Start an automation when an AI communication summary is generated for a contact.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, conversations]
+keywords: [communication summary trigger, AI summary trigger, contact summary, conversations automation, AI communication trigger]
+---
+
+# An AI communication summary is created
+
+**An AI communication summary is created** fires whenever the platform generates an AI-powered summary of communications for a contact. Use this trigger to automatically distribute summaries, update CRM records, or notify team members when fresh communication intelligence is ready.
+
+This trigger fires each time a new summary is created, whether generated on a schedule or on demand.
+
+:::info Trigger scope
+This trigger operates at the **contact** scope. Contact, company, and account actions are available downstream.
+:::
+
+## How it works
+
+1. The platform generates an AI communication summary for a contact.
+2. The automation evaluates any trigger conditions you've configured.
+3. If conditions are met, the workflow starts with the contact, their associated company, and the account in context.
+4. Downstream steps can use **Add dynamic content** to reference the summary content, contact fields, and company fields.
+
+## Available data
+
+The AI-generated summary and standard contact, company, and account fields are available via **Add dynamic content**.
+
+| Output | Description |
+|---|---|
+| **Summary content** | The AI-generated text summary of communications |
+| **Contact name** | Full name of the contact the summary was created for |
+| **Contact email** | Primary email address for the contact |
+| **Company name** | The company associated with the contact |
+| **Summary date** | The date and time the summary was generated |
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-company-added-to-list.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-company-added-to-list.mdx
@@ -1,0 +1,39 @@
+---
+title: "Trigger: A company is added to a list"
+description: Start an automation whenever a company is added to a specified CRM list.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, company]
+keywords: [company added to list trigger, CRM list trigger, company list automation, company scope trigger, list membership trigger]
+---
+
+# A company is added to a list
+
+The **A company is added to a list** trigger starts an automation whenever a company is added to a CRM list. Use this trigger to act on list membership changes — such as notifying a team member or updating company fields — the moment a company enters a list.
+
+:::info Trigger scope
+This trigger operates at the **company** scope. Company, account, and contact actions are available downstream.
+:::
+
+## How it works
+
+1. A company is added to a CRM list, either manually or through another automation or bulk action.
+2. The company and its associated account are brought into scope.
+3. The list name and membership event data become available as dynamic content.
+4. Downstream steps execute using the company, account, and list context.
+
+## Available data
+
+| Output | Description |
+|---|---|
+| **List name** | The name of the list the company was added to |
+| **List ID** | The unique identifier of the list |
+| **Associated company** | Name, ID, and standard fields of the company added to the list |
+
+Standard company and account fields are also available to downstream steps via **Add dynamic content**.
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-company-created-or-modified.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-company-created-or-modified.mdx
@@ -1,0 +1,42 @@
+---
+title: "Trigger: A company is created or modified"
+description: Start an automation whenever a company record is created or any field on the record changes.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, company]
+keywords: [company created trigger, company modified trigger, company record changed, CRM company trigger, company scope trigger]
+---
+
+# A company is created or modified
+
+The **A company is created or modified** trigger starts an automation whenever a new company record is created in the CRM or any field on an existing company record changes. Use this trigger to keep downstream systems in sync or to kick off onboarding workflows the moment a company enters or updates in your CRM.
+
+:::info Trigger scope
+This trigger operates at the **company** scope. Company, account, and contact actions are available downstream.
+:::
+
+## How it works
+
+1. A company record is created for the first time, or a field on an existing company record is updated.
+2. The company and its associated account are brought into scope.
+3. Standard company fields — such as name, industry, and address — become available as dynamic content.
+4. Downstream steps execute using the full company and account context.
+
+## Available data
+
+Standard company and account fields are available to downstream steps via **Add dynamic content**.
+
+| Output | Description |
+|---|---|
+| **Company name** | The name of the company record |
+| **Industry** | Industry classification on the company record |
+| **Phone** | Primary phone number on the company record |
+| **Address** | Street, city, province/state, and country fields |
+| **Website** | Company website URL |
+| **Custom fields** | Any custom fields configured on the company object |
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-company-removed-from-list.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-company-removed-from-list.mdx
@@ -1,0 +1,39 @@
+---
+title: "Trigger: A company is removed from a list"
+description: Start an automation whenever a company is removed from a specified CRM list.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, company]
+keywords: [company removed from list trigger, CRM list trigger, list membership removed, company scope trigger, list exit trigger]
+---
+
+# A company is removed from a list
+
+The **A company is removed from a list** trigger starts an automation whenever a company is removed from a CRM list. Use this trigger to react to list exits — such as archiving records, changing ownership, or triggering a follow-up sequence when a company leaves a specific segment.
+
+:::info Trigger scope
+This trigger operates at the **company** scope. Company, account, and contact actions are available downstream.
+:::
+
+## How it works
+
+1. A company is removed from a CRM list, either manually, through a bulk action, or by another automation.
+2. The company and its associated account are brought into scope.
+3. The list name and removal event data become available as dynamic content.
+4. Downstream steps execute using the company, account, and list context.
+
+## Available data
+
+| Output | Description |
+|---|---|
+| **List name** | The name of the list the company was removed from |
+| **List ID** | The unique identifier of the list |
+| **Associated company** | Name, ID, and standard fields of the company removed from the list |
+
+Standard company and account fields are also available to downstream steps via **Add dynamic content**.
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-contact-added-to-list.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-contact-added-to-list.mdx
@@ -1,0 +1,39 @@
+---
+title: "Trigger: A contact is added to a list"
+description: Start an automation when a contact is added to a specified CRM list.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, contact]
+keywords: [contact added to list, list trigger, CRM list, contact list automation, segment trigger]
+---
+
+# A contact is added to a list
+
+**A contact is added to a list** starts a workflow the moment a contact is placed into a specified CRM list. Use this trigger to act immediately when contacts enter a segment — kicking off campaigns, assigning tasks, or updating records without manual intervention.
+
+You configure the trigger to watch one specific list, so you can build focused workflows for each audience segment you maintain.
+
+:::info Trigger scope
+This trigger operates at the **contact** scope. Contact, company, and account actions are available downstream.
+:::
+
+## How it works
+
+1. You select the target list when configuring the trigger — only additions to that list will fire the automation.
+2. A contact is added to the list, either manually, by another automation, or through a bulk action.
+3. The automation evaluates any trigger conditions you've configured before proceeding.
+4. The workflow starts with the contact, their associated company, and the account in context.
+
+## Available data
+
+All standard contact, company, and account fields are available downstream via **Add dynamic content**. This includes fields such as contact name, email, phone, lifecycle stage, company name, and account tags.
+
+:::info
+The trigger does not fire for contacts that were already on the list when the automation was created. Only additions that occur after the automation is active will start the workflow.
+:::
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx) — trigger types, scoping, and how to choose the right trigger
+- [Automation triggers reference](./automation-triggers-reference.mdx) — full reference for every available trigger
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx) — entry settings, conditions, and error handling
+- [Actions overview](./actions-overview.mdx) — what can happen after a trigger fires

--- a/docusaurus/docs/automations/my-automations/trigger-contact-created-or-modified.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-contact-created-or-modified.mdx
@@ -1,0 +1,39 @@
+---
+title: "Trigger: A contact is created or modified"
+description: Start an automation when a contact record is created or any field on it changes.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, contact]
+keywords: [contact created trigger, contact modified trigger, contact field changed, new contact automation, CRM contact trigger]
+---
+
+# A contact is created or modified
+
+**A contact is created or modified** starts a workflow whenever a contact record is created in the CRM or any field on an existing contact changes. Use this trigger to respond to new contacts entering your system or to keep records and downstream processes in sync as contact data evolves.
+
+Because this trigger fires on any field change, use trigger conditions to narrow down exactly which changes should start the workflow — for example, only when the lifecycle stage field changes to a specific value.
+
+:::info Trigger scope
+This trigger operates at the **contact** scope. Contact, company, and account actions are available downstream.
+:::
+
+## How it works
+
+1. A contact is created, or a field on an existing contact is updated — whether by a user, an integration, or another automation.
+2. The automation evaluates any trigger conditions you've configured (for example, filtering on a specific field name or value).
+3. If all conditions are met, the workflow starts with the contact, their associated company, and the account in context.
+4. Downstream steps can use **Add dynamic content** to reference the contact's current field values.
+
+## Available data
+
+All standard contact, company, and account fields are available downstream via **Add dynamic content**. This includes fields such as contact name, email, phone, lifecycle stage, assigned salesperson, company name, and account tags.
+
+:::info
+To react only to specific field changes, add a trigger condition filtering on the field you care about. Without conditions, the automation fires on every create or update event for any contact.
+:::
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx) — trigger types, scoping, and how to choose the right trigger
+- [Automation triggers reference](./automation-triggers-reference.mdx) — full reference for every available trigger
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx) — entry settings, conditions, and error handling
+- [Actions overview](./actions-overview.mdx) — what can happen after a trigger fires

--- a/docusaurus/docs/automations/my-automations/trigger-contact-removed-from-list.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-contact-removed-from-list.mdx
@@ -1,0 +1,39 @@
+---
+title: "Trigger: A contact is removed from a list"
+description: Start an automation when a contact is removed from a specified CRM list.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, contact]
+keywords: [contact removed from list, list removal trigger, CRM list, contact list automation, segment exit trigger]
+---
+
+# A contact is removed from a list
+
+**A contact is removed from a list** starts a workflow the moment a contact leaves a specified CRM list. Use this trigger to react when contacts exit a segment — for example, to update their record, notify a team member, or move them into a different workflow.
+
+You configure the trigger to watch one specific list, so removals from other lists will not start the automation.
+
+:::info Trigger scope
+This trigger operates at the **contact** scope. Contact, company, and account actions are available downstream.
+:::
+
+## How it works
+
+1. You select the target list when configuring the trigger — only removals from that list will fire the automation.
+2. A contact is removed from the list, either manually, by another automation, or through a bulk action.
+3. The automation evaluates any trigger conditions you've configured before proceeding.
+4. The workflow starts with the contact, their associated company, and the account in context.
+
+## Available data
+
+All standard contact, company, and account fields are available downstream via **Add dynamic content**. This includes fields such as contact name, email, phone, lifecycle stage, company name, and account tags.
+
+:::info
+This trigger fires at the moment of removal. If you need to capture why a contact was removed, add a **Condition** step or use trigger conditions to filter by the contact's current field values.
+:::
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx) — trigger types, scoping, and how to choose the right trigger
+- [Automation triggers reference](./automation-triggers-reference.mdx) — full reference for every available trigger
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx) — entry settings, conditions, and error handling
+- [Actions overview](./actions-overview.mdx) — what can happen after a trigger fires

--- a/docusaurus/docs/automations/my-automations/trigger-conversations-message.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-conversations-message.mdx
@@ -1,0 +1,43 @@
+---
+title: "Trigger: A Conversations message is sent or received"
+description: Start an automation when a message is sent or received on an account in Conversations.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, conversations]
+keywords: [conversations trigger, message received trigger, message sent trigger, inbox automation, conversations message trigger]
+---
+
+# A Conversations message is sent or received
+
+**A Conversations message is sent or received** fires whenever a message is sent or received on an account in the Conversations inbox. Use this trigger to automate responses, route messages to the right team member, or log communication activity when messages flow through your inbox.
+
+You can configure the trigger to respond to inbound messages, outbound messages, or both depending on your workflow needs.
+
+:::info Trigger scope
+This trigger operates at the **account** scope. Account and contact actions are available downstream.
+:::
+
+## How it works
+
+1. A message is sent or received on an account in the Conversations inbox.
+2. The automation evaluates any trigger conditions you've configured, such as message direction or channel.
+3. If conditions are met, the workflow starts with the account and message data in context.
+4. Downstream steps can use **Add dynamic content** to reference the message content, channel, and account fields.
+
+## Available data
+
+Standard account fields and message fields are available via **Add dynamic content**.
+
+| Output | Description |
+|---|---|
+| **Message content** | The body text of the message |
+| **Message direction** | Whether the message was inbound or outbound |
+| **Channel** | The channel the message was sent on (SMS, email, etc.) |
+| **Sender name** | The name of the message sender |
+| **Account name** | The account the Conversations inbox belongs to |
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-crm-task-company.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-crm-task-company.mdx
@@ -1,0 +1,42 @@
+---
+title: "Trigger: A CRM sales task is created or modified for a company"
+description: Start an automation whenever a CRM sales task is created or updated on a company record.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, company]
+keywords: [CRM task trigger, sales task created trigger, company sales task, automation trigger task, company scope trigger]
+---
+
+# A CRM sales task is created or modified for a company
+
+The **A CRM sales task is created or modified for a company** trigger starts an automation whenever a sales task is created on a company record or an existing task on that record is updated. Use this trigger to keep your team informed and your workflows moving whenever task activity occurs on a company.
+
+:::info Trigger scope
+This trigger operates at the **company** scope. Company, account, and contact actions are available downstream.
+:::
+
+## How it works
+
+1. A sales task is created on a company record, or an existing task on that record is modified (for example, its status, due date, or assignee changes).
+2. The company and its associated account are brought into scope.
+3. The task data — including title, due date, status, and assignee — becomes available as dynamic content.
+4. Downstream steps execute using the company, account, and task context.
+
+## Available data
+
+| Output | Description |
+|---|---|
+| **Task title** | The name or subject of the sales task |
+| **Task status** | The current status of the task (e.g., Open, Completed) |
+| **Due date** | The date the task is due |
+| **Assignee** | The user the task is assigned to |
+| **Task notes** | Any notes or description on the task |
+| **Associated company** | Name, ID, and standard fields of the company the task is linked to |
+
+Standard company and account fields are also available to downstream steps via **Add dynamic content**.
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Trigger: A CRM sales task is overdue for a company](./trigger-crm-task-overdue-company.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-crm-task-contact.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-crm-task-contact.mdx
@@ -1,0 +1,39 @@
+---
+title: "Trigger: A CRM sales task is created or modified for a contact"
+description: Start an automation when a sales task is created or updated on a contact record.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, contact]
+keywords: [CRM task trigger, sales task created, sales task modified, contact task automation, CRM sales task trigger]
+---
+
+# A CRM sales task is created or modified for a contact
+
+**A CRM sales task is created or modified for a contact** starts a workflow whenever a sales task is created — or an existing task is updated — on a contact record. Use this trigger to chain tasks together, notify assignees, or update contact records automatically as your sales process moves forward.
+
+This trigger fires for both new tasks and edits to existing ones, so you can react to status changes, reassignments, or completion events.
+
+:::info Trigger scope
+This trigger operates at the **contact** scope. Contact, company, and account actions are available downstream.
+:::
+
+## How it works
+
+1. A sales task is created on a contact, or an existing task on a contact is updated — whether by a user or another automation.
+2. The automation evaluates any trigger conditions you've configured (for example, filtering on task status or task name).
+3. If all conditions are met, the workflow starts with the contact, their associated company, and the account in context.
+4. Downstream steps can use **Add dynamic content** to reference task details, contact fields, and company fields.
+
+## Available data
+
+All standard contact, company, and account fields are available downstream via **Add dynamic content**. This includes fields such as contact name, email, phone, assigned salesperson, company name, and account tags.
+
+:::info
+Sales task fields (such as task name, status, due date, and assignee) are available as dynamic data in steps that follow this trigger.
+:::
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx) — trigger types, scoping, and how to choose the right trigger
+- [Automation triggers reference](./automation-triggers-reference.mdx) — full reference for every available trigger
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx) — entry settings, conditions, and error handling
+- [Actions overview](./actions-overview.mdx) — what can happen after a trigger fires

--- a/docusaurus/docs/automations/my-automations/trigger-crm-task-overdue-company.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-crm-task-overdue-company.mdx
@@ -1,0 +1,42 @@
+---
+title: "Trigger: A CRM sales task is overdue for a company"
+description: Start an automation whenever a sales task on a company record passes its due date without being completed.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, company]
+keywords: [CRM task overdue trigger, sales task overdue company, overdue task automation, company scope trigger, task past due trigger]
+---
+
+# A CRM sales task is overdue for a company
+
+The **A CRM sales task is overdue for a company** trigger starts an automation whenever a sales task linked to a company passes its due date without being marked complete. Use this trigger to send reminders, escalate to a manager, or create a follow-up task automatically when deadlines are missed.
+
+:::info Trigger scope
+This trigger operates at the **company** scope. Company, account, and contact actions are available downstream.
+:::
+
+## How it works
+
+1. A sales task on a company record reaches its due date and remains incomplete.
+2. The company and its associated account are brought into scope.
+3. The overdue task data — including title, original due date, assignee, and status — becomes available as dynamic content.
+4. Downstream steps execute using the company, account, and overdue task context.
+
+## Available data
+
+| Output | Description |
+|---|---|
+| **Task title** | The name or subject of the overdue sales task |
+| **Task status** | The current status of the task at the time it became overdue |
+| **Due date** | The date the task was due |
+| **Assignee** | The user the task is assigned to |
+| **Task notes** | Any notes or description on the task |
+| **Associated company** | Name, ID, and standard fields of the company the task is linked to |
+
+Standard company and account fields are also available to downstream steps via **Add dynamic content**.
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Trigger: A CRM sales task is created or modified for a company](./trigger-crm-task-company.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-crm-task-overdue-contact.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-crm-task-overdue-contact.mdx
@@ -1,0 +1,39 @@
+---
+title: "Trigger: A CRM sales task is overdue for a contact"
+description: Start an automation when a sales task on a contact passes its due date without being completed.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, contact]
+keywords: [overdue task trigger, CRM task overdue, sales task past due, contact task overdue, automation trigger]
+---
+
+# A CRM sales task is overdue for a contact
+
+**A CRM sales task is overdue for a contact** starts a workflow the moment a sales task on a contact passes its due date without being marked complete. Use this trigger to escalate missed tasks, alert managers, or create follow-up tasks automatically so nothing falls through the cracks.
+
+This trigger is time-sensitive — it fires as soon as the task's due date passes and the task is still open.
+
+:::info Trigger scope
+This trigger operates at the **contact** scope. Contact, company, and account actions are available downstream.
+:::
+
+## How it works
+
+1. A sales task on a contact reaches its due date without being completed.
+2. The automation evaluates any trigger conditions you've configured (for example, filtering on task name or assignee).
+3. If all conditions are met, the workflow starts with the contact, their associated company, and the account in context.
+4. Downstream steps can use **Add dynamic content** to reference the overdue task details, contact fields, and company fields.
+
+## Available data
+
+All standard contact, company, and account fields are available downstream via **Add dynamic content**. This includes fields such as contact name, email, phone, assigned salesperson, company name, and account tags.
+
+:::info
+Sales task fields (such as task name, due date, and assignee) are available as dynamic data in steps that follow this trigger, so you can include task details in escalation notifications or replacement tasks.
+:::
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx) — trigger types, scoping, and how to choose the right trigger
+- [Automation triggers reference](./automation-triggers-reference.mdx) — full reference for every available trigger
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx) — entry settings, conditions, and error handling
+- [Actions overview](./actions-overview.mdx) — what can happen after a trigger fires

--- a/docusaurus/docs/automations/my-automations/trigger-custom-object-added-to-list.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-custom-object-added-to-list.mdx
@@ -1,0 +1,42 @@
+---
+title: "Trigger: Custom object added to a list"
+description: Start an automation whenever a custom object record is added to a list.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, custom-objects]
+keywords: [custom object trigger, added to list, custom object list, automation trigger, custom object scope]
+---
+
+# Custom object added to a list
+
+The **Custom object added to a list** trigger starts an automation whenever a custom object record is placed into a list. Use this trigger to kick off workflows scoped to that record the moment it's categorized or grouped.
+
+This trigger operates at the custom object scope, making all fields on the record available to downstream steps.
+
+:::info Trigger scope
+This trigger operates at the **custom object** scope. Custom object record fields are available downstream. Use lookup steps to bring account or company context into the workflow if needed.
+:::
+
+## How it works
+
+1. A custom object record is added to a list, either manually or via another automation step.
+2. The custom object record is brought into scope.
+3. All fields on the record become available as dynamic content.
+4. Downstream steps execute using the record data.
+
+## Available data
+
+| Output | Description |
+|---|---|
+| **Record ID** | Unique identifier for the custom object record |
+| **Record fields** | All custom fields defined on the object type |
+| **List name** | The name of the list the record was added to |
+| **Added at** | Timestamp when the record was added to the list |
+
+Additional fields depend on how the custom object type is configured in your account.
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-custom-object-created-or-modified.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-custom-object-created-or-modified.mdx
@@ -1,0 +1,42 @@
+---
+title: "Trigger: Custom object created or modified"
+description: Start an automation whenever a custom object record is created or any of its fields are updated.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, custom-objects]
+keywords: [custom object trigger, custom object created, custom object modified, record updated, automation trigger]
+---
+
+# Custom object created or modified
+
+The **Custom object created or modified** trigger starts an automation whenever a custom object record is first created or any field on an existing record is updated. Use this trigger to respond to data changes on your custom object types in real time.
+
+This trigger operates at the custom object scope, so all fields on the record are available to downstream steps.
+
+:::info Trigger scope
+This trigger operates at the **custom object** scope. Custom object record fields are available downstream. Use lookup steps to bring account or company context into the workflow if needed.
+:::
+
+## How it works
+
+1. A custom object record is created, or any field on an existing record is changed.
+2. The record is brought into scope.
+3. All current field values — including the field that changed — become available as dynamic content.
+4. Downstream steps execute using the record data.
+
+## Available data
+
+| Output | Description |
+|---|---|
+| **Record ID** | Unique identifier for the custom object record |
+| **Record fields** | All custom fields defined on the object type, reflecting current values |
+| **Created at** | Timestamp when the record was first created |
+| **Modified at** | Timestamp of the most recent update |
+
+All field values reflect the state of the record at the moment the trigger fired.
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-custom-object-removed-from-list.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-custom-object-removed-from-list.mdx
@@ -1,0 +1,42 @@
+---
+title: "Trigger: Custom object removed from a list"
+description: Start an automation whenever a custom object record is removed from a list.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, custom-objects]
+keywords: [custom object trigger, removed from list, custom object list, automation trigger, custom object scope]
+---
+
+# Custom object removed from a list
+
+The **Custom object removed from a list** trigger starts an automation whenever a custom object record is taken off a list. Use this trigger to react to records being uncategorized or moved out of a group.
+
+This trigger operates at the custom object scope, making all fields on the record available to downstream steps.
+
+:::info Trigger scope
+This trigger operates at the **custom object** scope. Custom object record fields are available downstream. Use lookup steps to bring account or company context into the workflow if needed.
+:::
+
+## How it works
+
+1. A custom object record is removed from a list, either manually or via another automation step.
+2. The custom object record is brought into scope.
+3. All fields on the record become available as dynamic content.
+4. Downstream steps execute using the record data.
+
+## Available data
+
+| Output | Description |
+|---|---|
+| **Record ID** | Unique identifier for the custom object record |
+| **Record fields** | All custom fields defined on the object type |
+| **List name** | The name of the list the record was removed from |
+| **Removed at** | Timestamp when the record was removed from the list |
+
+Additional fields depend on how the custom object type is configured in your account.
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-email-activity-company.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-email-activity-company.mdx
@@ -1,0 +1,41 @@
+---
+title: "Trigger: An email activity is created or modified for a company"
+description: Start an automation whenever an email activity is logged or updated on a company record in the CRM.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, company]
+keywords: [email activity trigger, company email logged, CRM email activity, automation trigger email, company scope trigger]
+---
+
+# An email activity is created or modified for a company
+
+The **An email activity is created or modified for a company** trigger starts an automation whenever an email is logged on a company record or an existing email activity on that record is updated. Use this trigger to react to email correspondence at the company level — without any manual follow-up steps.
+
+:::info Trigger scope
+This trigger operates at the **company** scope. Company, account, and contact actions are available downstream.
+:::
+
+## How it works
+
+1. An email activity is created on a company record, or an existing email activity on that record is modified.
+2. The company and its associated account are brought into scope.
+3. The email activity data — including subject, direction, and notes — becomes available as dynamic content.
+4. Downstream steps execute using the company, account, and email activity context.
+
+## Available data
+
+| Output | Description |
+|---|---|
+| **Email subject** | The subject line of the logged email activity |
+| **Email direction** | Whether the email was inbound or outbound |
+| **Activity notes** | Notes logged on the email activity |
+| **Activity date** | The date and time the email activity was created or last modified |
+| **Associated company** | Name, ID, and standard fields of the company the email is logged on |
+
+Standard company and account fields are also available to downstream steps via **Add dynamic content**.
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-email-activity-contact.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-email-activity-contact.mdx
@@ -1,0 +1,39 @@
+---
+title: "Trigger: An email activity is created or modified for a contact"
+description: Start an automation when an email activity is logged or updated on a contact record.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, contact]
+keywords: [email activity trigger, contact email logged, email updated, CRM email activity, automation trigger]
+---
+
+# An email activity is created or modified for a contact
+
+**An email activity is created or modified for a contact** starts a workflow whenever an email is logged — or an existing email activity is updated — on a contact record. Use this trigger to automate follow-up tasks, record updates, or notifications based on email interactions with your contacts.
+
+This trigger fires for both newly logged emails and edits to existing email activity records, so workflows stay current as details are added or corrected.
+
+:::info Trigger scope
+This trigger operates at the **contact** scope. Contact, company, and account actions are available downstream.
+:::
+
+## How it works
+
+1. A team member logs a new email activity — or edits an existing one — on a contact record in the CRM.
+2. The automation evaluates any trigger conditions you've configured (for example, filtering on email direction or subject).
+3. If all conditions are met, the workflow starts with the contact, their associated company, and the account in context.
+4. Downstream steps can use **Add dynamic content** to reference email activity details, contact fields, and company fields.
+
+## Available data
+
+All standard contact, company, and account fields are available downstream via **Add dynamic content**. This includes fields such as contact name, email address, phone, assigned salesperson, company name, and account tags.
+
+:::info
+Email activity fields (such as subject, direction, and notes) are available as dynamic data in steps that follow this trigger.
+:::
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx) — trigger types, scoping, and how to choose the right trigger
+- [Automation triggers reference](./automation-triggers-reference.mdx) — full reference for every available trigger
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx) — entry settings, conditions, and error handling
+- [Actions overview](./actions-overview.mdx) — what can happen after a trigger fires

--- a/docusaurus/docs/automations/my-automations/trigger-form-submitted-company.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-form-submitted-company.mdx
@@ -1,0 +1,40 @@
+---
+title: "Trigger: A form is submitted for a company"
+description: Start an automation whenever a form linked to a company is submitted.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, company]
+keywords: [form submitted trigger, company form trigger, form submission automation, company scope trigger, CRM form trigger]
+---
+
+# A form is submitted for a company
+
+The **A form is submitted for a company** trigger starts an automation whenever a form associated with a company record is submitted. Use this trigger to react immediately to inbound form submissions — routing data, notifying team members, or updating company fields automatically.
+
+:::info Trigger scope
+This trigger operates at the **company** scope. Company, account, and contact actions are available downstream.
+:::
+
+## How it works
+
+1. A form linked to a company is submitted by a visitor or CRM user.
+2. The company and its associated account are brought into scope.
+3. Form field responses become available as dynamic content for downstream steps.
+4. Downstream steps execute using the company, account, and form submission data.
+
+## Available data
+
+| Output | Description |
+|---|---|
+| **Form name** | The name of the form that was submitted |
+| **Form field responses** | Individual field values captured in the submission |
+| **Submission date** | The date and time the form was submitted |
+| **Associated company** | Name, ID, and standard fields of the company the form is linked to |
+
+Standard company and account fields are also available to downstream steps via **Add dynamic content**.
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-form-submitted-contact-company.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-form-submitted-contact-company.mdx
@@ -1,0 +1,41 @@
+---
+title: "Trigger: A form is submitted for a contact (company scope)"
+description: Start an automation whenever a form is submitted by a contact associated with a company. Runs at the company scope.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, company]
+keywords: [form submitted contact company trigger, contact form company scope, form submission automation, company scope trigger, contact form trigger]
+---
+
+# A form is submitted for a contact (company scope)
+
+The **A form is submitted for a contact (company scope)** trigger starts an automation whenever a form is submitted by a contact who is associated with a company. Unlike the contact-scoped form trigger, this version runs at the company scope — making company and account data the primary context for downstream steps.
+
+:::info Trigger scope
+This trigger operates at the **company** scope. Company, account, and contact actions are available downstream.
+:::
+
+## How it works
+
+1. A contact associated with a company submits a form.
+2. The company the contact belongs to, along with its associated account, are brought into scope.
+3. Form field responses and the submitting contact's data become available as dynamic content.
+4. Downstream steps execute using the company, account, and form submission context.
+
+## Available data
+
+| Output | Description |
+|---|---|
+| **Form name** | The name of the form that was submitted |
+| **Form field responses** | Individual field values captured in the submission |
+| **Submission date** | The date and time the form was submitted |
+| **Submitting contact** | Name, email, and standard fields of the contact who submitted the form |
+| **Associated company** | Name, ID, and standard fields of the company the contact belongs to |
+
+Standard company and account fields are also available to downstream steps via **Add dynamic content**.
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-form-submitted-contact.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-form-submitted-contact.mdx
@@ -1,0 +1,39 @@
+---
+title: "Trigger: A form is submitted for a contact"
+description: Start an automation when a form linked to a contact is submitted.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, contact]
+keywords: [form submitted trigger, contact form submission, form trigger, CRM form automation, contact form trigger]
+---
+
+# A form is submitted for a contact
+
+**A form is submitted for a contact** starts a workflow whenever a form associated with a contact is submitted. Use this trigger to act immediately on inbound form responses — routing leads, creating tasks, sending confirmations, or updating contact records without any manual steps.
+
+You can scope this trigger to a specific form or leave it open to fire on any form submission linked to a contact.
+
+:::info Trigger scope
+This trigger operates at the **contact** scope. Contact, company, and account actions are available downstream.
+:::
+
+## How it works
+
+1. A contact submits a form that is linked to their contact record.
+2. The automation evaluates any trigger conditions you've configured (for example, filtering on a specific form or a field value from the submission).
+3. If all conditions are met, the workflow starts with the contact, their associated company, and the account in context.
+4. Downstream steps can use **Add dynamic content** to reference form response data, contact fields, and company fields.
+
+## Available data
+
+All standard contact, company, and account fields are available downstream via **Add dynamic content**. This includes fields such as contact name, email, phone, lifecycle stage, company name, and account tags.
+
+:::info
+Form response fields are available as dynamic data in steps that follow this trigger, so you can use submission answers to personalize notifications, set field values, or route the workflow conditionally.
+:::
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx) — trigger types, scoping, and how to choose the right trigger
+- [Automation triggers reference](./automation-triggers-reference.mdx) — full reference for every available trigger
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx) — entry settings, conditions, and error handling
+- [Actions overview](./actions-overview.mdx) — what can happen after a trigger fires

--- a/docusaurus/docs/automations/my-automations/trigger-fulfillment-project-order-status.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-fulfillment-project-order-status.mdx
@@ -1,0 +1,44 @@
+---
+title: "Trigger: Fulfillment project for an order changes status"
+description: Start an automation whenever a fulfillment project linked to a sales order changes status.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, fulfillment]
+keywords: [fulfillment order trigger, order project status, Task Manager order, automation trigger, account scope]
+---
+
+# Fulfillment project for an order changes status
+
+The **Fulfillment project for an order changes status** trigger starts an automation whenever a **Task Manager** project that is linked to a sales order moves to a new status. Use this trigger to keep order-related workflows moving — such as notifying a customer when their order enters fulfillment or flagging delays for internal review.
+
+This trigger operates at the account scope, so account, order, and project data are all available to downstream steps.
+
+:::info Trigger scope
+This trigger operates at the **account** scope. Account fields, order data, and fulfillment project data are available downstream.
+:::
+
+## How it works
+
+1. A fulfillment project linked to a sales order changes status in **Task Manager**.
+2. The account associated with the order is brought into scope.
+3. Project status, order details, and account data become available as dynamic content.
+4. Downstream steps execute using that combined context.
+
+## Available data
+
+| Output | Description |
+|---|---|
+| **Project name** | Name of the fulfillment project |
+| **Project status** | The new status the project moved to |
+| **Previous status** | The status the project was in before the change |
+| **Order ID** | Identifier of the linked sales order |
+| **Account name** | The account associated with the order and project |
+| **Status changed at** | Timestamp of the status change |
+
+Use trigger conditions to target a specific status if you only want the automation to run at a particular point in the fulfillment lifecycle.
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-fulfillment-project-status.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-fulfillment-project-status.mdx
@@ -1,0 +1,43 @@
+---
+title: "Trigger: Fulfillment project status changed"
+description: Start an automation whenever a Task Manager fulfillment project changes status.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, fulfillment]
+keywords: [fulfillment project trigger, project status changed, Task Manager, automation trigger, account scope]
+---
+
+# Fulfillment project status changed
+
+The **Fulfillment project status changed** trigger starts an automation whenever a project in **Task Manager** moves to a new status. Use this trigger to notify stakeholders, update records, or kick off the next stage of work the moment a project progresses.
+
+This trigger operates at the account scope, so account and project data are available to downstream steps.
+
+:::info Trigger scope
+This trigger operates at the **account** scope. Account fields and fulfillment project data are available downstream.
+:::
+
+## How it works
+
+1. A fulfillment project in **Task Manager** changes from one status to another.
+2. The account associated with the project is brought into scope.
+3. Project details — including the new status — become available as dynamic content.
+4. Downstream steps execute using the account and project context.
+
+## Available data
+
+| Output | Description |
+|---|---|
+| **Project name** | Name of the fulfillment project |
+| **Project status** | The new status the project moved to |
+| **Previous status** | The status the project was in before the change |
+| **Account name** | The account associated with the project |
+| **Status changed at** | Timestamp of the status change |
+
+Use trigger conditions to filter for a specific status transition if you only want the automation to run when a project reaches a particular stage.
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-fulfillment-task-status.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-fulfillment-task-status.mdx
@@ -1,0 +1,44 @@
+---
+title: "Trigger: Fulfillment task status changed"
+description: Start an automation whenever a Task Manager task changes status.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, fulfillment]
+keywords: [fulfillment task trigger, task status changed, Task Manager task, automation trigger, account scope]
+---
+
+# Fulfillment task status changed
+
+The **Fulfillment task status changed** trigger starts an automation whenever an individual task in **Task Manager** moves to a new status. Use this trigger to react to task-level progress — such as sending a notification when a task is marked complete or escalating tasks that are blocked.
+
+This trigger operates at the account scope, so account and task data are available to downstream steps.
+
+:::info Trigger scope
+This trigger operates at the **account** scope. Account fields and fulfillment task data are available downstream.
+:::
+
+## How it works
+
+1. A task in **Task Manager** changes from one status to another.
+2. The account associated with the task's project is brought into scope.
+3. Task details — including the new status — become available as dynamic content.
+4. Downstream steps execute using the account and task context.
+
+## Available data
+
+| Output | Description |
+|---|---|
+| **Task name** | Name of the fulfillment task |
+| **Task status** | The new status the task moved to |
+| **Previous status** | The status the task was in before the change |
+| **Project name** | The project the task belongs to |
+| **Account name** | The account associated with the project |
+| **Status changed at** | Timestamp of the status change |
+
+Use trigger conditions to filter for a specific status or task name if you only want the automation to run for certain tasks.
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-invoice-past-due.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-invoice-past-due.mdx
@@ -1,0 +1,43 @@
+---
+title: "Trigger: An invoice is past due"
+description: Start an automation when an invoice status changes to past due on an account.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, billing]
+keywords: [invoice past due trigger, overdue invoice, billing trigger, invoice status changed, collections automation]
+---
+
+# An invoice is past due
+
+**An invoice is past due** fires when an invoice's status transitions to past due on an account. Use this trigger to automate payment reminders, notify account managers, or escalate collections workflows the moment a payment deadline is missed.
+
+This trigger fires on the status transition to past due — not on a recurring schedule — so it fires once per invoice when that threshold is crossed.
+
+:::info Trigger scope
+This trigger operates at the **account** scope. Account and contact actions are available downstream.
+:::
+
+## How it works
+
+1. An invoice on an account transitions to a past due status.
+2. The automation evaluates any trigger conditions you've configured.
+3. If conditions are met, the workflow starts with the account and invoice data in context.
+4. Downstream steps can use **Add dynamic content** to reference the invoice amount, due date, and account fields.
+
+## Available data
+
+Standard account fields and invoice fields are available via **Add dynamic content**.
+
+| Output | Description |
+|---|---|
+| **Invoice number** | The unique identifier for the invoice |
+| **Invoice amount** | The total amount due on the invoice |
+| **Due date** | The original payment due date |
+| **Account name** | The name of the account associated with the invoice |
+| **Contact email** | The primary contact email for billing correspondence |
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-manual-account.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-manual-account.mdx
@@ -1,0 +1,39 @@
+---
+title: "Trigger: Run manually on an account"
+description: Run an automation on demand from an account detail page.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, manual]
+keywords: [manual trigger, run manually, account trigger, on demand automation, manual account automation]
+---
+
+# Run manually on an account
+
+**Run manually on an account** allows you to start an automation on demand directly from an account detail page. Use this trigger for workflows that should only run when a team member explicitly initiates them — such as one-off outreach sequences, account audits, or processes that require human judgment before starting.
+
+This trigger does not fire automatically. A team member must navigate to the account and trigger the run manually.
+
+:::info Trigger scope
+This trigger operates at the **account** scope. Account and contact actions are available downstream.
+:::
+
+## How it works
+
+1. A team member opens an account detail page in Partner Center.
+2. They locate the automation in the account's automation panel and click **Run**.
+3. The workflow starts immediately with the account in context.
+4. Downstream steps can use **Add dynamic content** to reference account fields and contact details.
+
+## Available data
+
+Standard account and contact fields are available via **Add dynamic content** once the automation starts.
+
+:::info
+Because this trigger is manual, no event-specific data (such as a triggering message or payment) is passed in. All available data comes from the account and its associated records at the time of the run.
+:::
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-manual-company.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-manual-company.mdx
@@ -1,0 +1,39 @@
+---
+title: "Trigger: Run manually on a company"
+description: Run an automation on demand from a company detail page.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, manual]
+keywords: [manual trigger, run manually, company trigger, on demand automation, manual company automation]
+---
+
+# Run manually on a company
+
+**Run manually on a company** allows you to start an automation on demand directly from a company detail page in the CRM. Use this trigger for workflows that require intentional initiation — such as enriching a company record, sending a targeted outreach, or running a one-off data sync.
+
+This trigger does not fire automatically. A team member must navigate to the company and trigger the run manually.
+
+:::info Trigger scope
+This trigger operates at the **company** scope. Company, account, and contact actions are available downstream.
+:::
+
+## How it works
+
+1. A team member opens a company detail page in the CRM.
+2. They locate the automation and click **Run**.
+3. The workflow starts immediately with the company in context.
+4. Downstream steps can use **Add dynamic content** to reference company fields, associated account fields, and contact details.
+
+## Available data
+
+Standard company, account, and contact fields are available via **Add dynamic content** once the automation starts.
+
+:::info
+Because this trigger is manual, no event-specific data is passed in. All available data comes from the company record and its associated records at the time of the run.
+:::
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-manual-contact.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-manual-contact.mdx
@@ -1,0 +1,39 @@
+---
+title: "Trigger: Run manually on a contact"
+description: Run an automation on demand from a contact detail page.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, manual]
+keywords: [manual trigger, run manually, contact trigger, on demand automation, manual contact automation]
+---
+
+# Run manually on a contact
+
+**Run manually on a contact** allows you to start an automation on demand directly from a contact detail page in the CRM. Use this trigger for workflows that should only run when explicitly initiated — such as sending a personalized sequence, updating contact fields, or running a one-off enrichment for a specific person.
+
+This trigger does not fire automatically. A team member must navigate to the contact and trigger the run manually.
+
+:::info Trigger scope
+This trigger operates at the **contact** scope. Contact, company, and account actions are available downstream.
+:::
+
+## How it works
+
+1. A team member opens a contact detail page in the CRM.
+2. They locate the automation and click **Run**.
+3. The workflow starts immediately with the contact in context.
+4. Downstream steps can use **Add dynamic content** to reference contact fields, company fields, and account details.
+
+## Available data
+
+Standard contact, company, and account fields are available via **Add dynamic content** once the automation starts.
+
+:::info
+Because this trigger is manual, no event-specific data is passed in. All available data comes from the contact record and its associated records at the time of the run.
+:::
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-manual-order.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-manual-order.mdx
@@ -1,0 +1,39 @@
+---
+title: "Trigger: Run manually on an order"
+description: Run an automation on demand from an order detail page.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, manual]
+keywords: [manual trigger, run manually, order trigger, on demand automation, manual order automation]
+---
+
+# Run manually on an order
+
+**Run manually on an order** allows you to start an automation on demand directly from an order detail page. Use this trigger for workflows that should only run when a team member explicitly initiates them against a specific order — such as custom fulfillment steps, escalation workflows, or order-specific communications.
+
+This trigger does not fire automatically. A team member must navigate to the order and trigger the run manually.
+
+:::info Trigger scope
+This trigger operates at the **order** scope. Order and account actions are available downstream.
+:::
+
+## How it works
+
+1. A team member opens an order detail page in Partner Center.
+2. They locate the automation and click **Run**.
+3. The workflow starts immediately with the order in context.
+4. Downstream steps can use **Add dynamic content** to reference order fields and associated account details.
+
+## Available data
+
+Standard order and account fields are available via **Add dynamic content** once the automation starts.
+
+:::info
+Because this trigger is manual, no event-specific data is passed in. All available data comes from the order record and its associated account at the time of the run.
+:::
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-meeting-activity-company.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-meeting-activity-company.mdx
@@ -1,0 +1,41 @@
+---
+title: "Trigger: A meeting activity is created or modified for a company"
+description: Start an automation whenever a meeting activity is logged or updated on a company record in the CRM.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, company]
+keywords: [meeting activity trigger, company meeting logged, CRM meeting activity, automation trigger meeting, company scope trigger]
+---
+
+# A meeting activity is created or modified for a company
+
+The **A meeting activity is created or modified for a company** trigger starts an automation whenever a meeting is logged on a company record or an existing meeting activity on that record is updated. Use this trigger to automate post-meeting follow-ups or internal notifications at the company level.
+
+:::info Trigger scope
+This trigger operates at the **company** scope. Company, account, and contact actions are available downstream.
+:::
+
+## How it works
+
+1. A meeting activity is created on a company record, or an existing meeting activity on that record is modified.
+2. The company and its associated account are brought into scope.
+3. The meeting activity data — including meeting title, date, and notes — becomes available as dynamic content.
+4. Downstream steps execute using the company, account, and meeting activity context.
+
+## Available data
+
+| Output | Description |
+|---|---|
+| **Meeting title** | The title or subject of the logged meeting activity |
+| **Meeting date** | The date and time the meeting took place or was scheduled |
+| **Activity notes** | Notes logged on the meeting activity |
+| **Activity date** | The date and time the activity was created or last modified |
+| **Associated company** | Name, ID, and standard fields of the company the meeting is logged on |
+
+Standard company and account fields are also available to downstream steps via **Add dynamic content**.
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-meeting-activity-contact.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-meeting-activity-contact.mdx
@@ -1,0 +1,39 @@
+---
+title: "Trigger: A meeting activity is created or modified for a contact"
+description: Start an automation when a meeting activity is logged or updated on a contact record.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, contact]
+keywords: [meeting activity trigger, contact meeting logged, meeting updated, CRM meeting activity, automation trigger]
+---
+
+# A meeting activity is created or modified for a contact
+
+**A meeting activity is created or modified for a contact** starts a workflow whenever a meeting is logged — or an existing meeting activity is updated — on a contact record. Use this trigger to automate post-meeting tasks, advance pipeline stages, or notify team members whenever a contact interaction is recorded.
+
+This trigger fires for both new meeting logs and edits to existing ones, keeping downstream records accurate as meeting details are filled in or corrected.
+
+:::info Trigger scope
+This trigger operates at the **contact** scope. Contact, company, and account actions are available downstream.
+:::
+
+## How it works
+
+1. A team member logs a new meeting activity — or edits an existing one — on a contact record in the CRM.
+2. The automation evaluates any trigger conditions you've configured (for example, filtering on meeting outcome or attendees).
+3. If all conditions are met, the workflow starts with the contact, their associated company, and the account in context.
+4. Downstream steps can use **Add dynamic content** to reference meeting details, contact fields, and company fields.
+
+## Available data
+
+All standard contact, company, and account fields are available downstream via **Add dynamic content**. This includes fields such as contact name, email, phone, assigned salesperson, company name, and account tags.
+
+:::info
+Meeting activity fields (such as meeting notes, date, and outcome) are available as dynamic data in steps that follow this trigger.
+:::
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx) — trigger types, scoping, and how to choose the right trigger
+- [Automation triggers reference](./automation-triggers-reference.mdx) — full reference for every available trigger
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx) — entry settings, conditions, and error handling
+- [Actions overview](./actions-overview.mdx) — what can happen after a trigger fires

--- a/docusaurus/docs/automations/my-automations/trigger-note-activity-company.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-note-activity-company.mdx
@@ -1,0 +1,39 @@
+---
+title: "Trigger: A note activity is created or modified for a company"
+description: Start an automation whenever a note is added or modified on a company record in the CRM.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, company]
+keywords: [note activity trigger, company note trigger, CRM note activity, automation trigger note, company scope trigger]
+---
+
+# A note activity is created or modified for a company
+
+The **A note activity is created or modified for a company** trigger starts an automation whenever a note is added to a company record or an existing note on that record is modified. Use this trigger to act on important context captured by your team — routing notes, alerting colleagues, or updating fields based on note content.
+
+:::info Trigger scope
+This trigger operates at the **company** scope. Company, account, and contact actions are available downstream.
+:::
+
+## How it works
+
+1. A note is added to a company record, or an existing note on that record is modified.
+2. The company and its associated account are brought into scope.
+3. The note content and activity metadata become available as dynamic content.
+4. Downstream steps execute using the company, account, and note context.
+
+## Available data
+
+| Output | Description |
+|---|---|
+| **Note content** | The body text of the note |
+| **Activity date** | The date and time the note was created or last modified |
+| **Associated company** | Name, ID, and standard fields of the company the note is logged on |
+
+Standard company and account fields are also available to downstream steps via **Add dynamic content**.
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-note-activity-contact.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-note-activity-contact.mdx
@@ -1,0 +1,39 @@
+---
+title: "Trigger: A note activity is created or modified for a contact"
+description: Start an automation when a note is added or modified on a contact record.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, contact]
+keywords: [note activity trigger, contact note added, note modified, CRM note activity, automation trigger]
+---
+
+# A note activity is created or modified for a contact
+
+**A note activity is created or modified for a contact** starts a workflow whenever a note is added — or an existing note is edited — on a contact record. Use this trigger to capture important context added by your team and route it to the right place automatically, such as updating a task, notifying a colleague, or tagging the contact.
+
+This trigger fires for both new notes and edits to existing ones, so workflows can respond to evolving context as your team refines their notes.
+
+:::info Trigger scope
+This trigger operates at the **contact** scope. Contact, company, and account actions are available downstream.
+:::
+
+## How it works
+
+1. A team member adds a new note — or edits an existing note — on a contact record in the CRM.
+2. The automation evaluates any trigger conditions you've configured (for example, filtering on note content or author).
+3. If all conditions are met, the workflow starts with the contact, their associated company, and the account in context.
+4. Downstream steps can use **Add dynamic content** to reference the note content, contact fields, and company fields.
+
+## Available data
+
+All standard contact, company, and account fields are available downstream via **Add dynamic content**. This includes fields such as contact name, email, phone, assigned salesperson, company name, and account tags.
+
+:::info
+Note content is available as dynamic data in steps that follow this trigger, so you can include note text in notifications, task descriptions, or other downstream actions.
+:::
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx) — trigger types, scoping, and how to choose the right trigger
+- [Automation triggers reference](./automation-triggers-reference.mdx) — full reference for every available trigger
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx) — entry settings, conditions, and error handling
+- [Actions overview](./actions-overview.mdx) — what can happen after a trigger fires

--- a/docusaurus/docs/automations/my-automations/trigger-opportunity-created-or-changed.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-opportunity-created-or-changed.mdx
@@ -1,0 +1,49 @@
+---
+title: "Trigger: An opportunity is created or changes stage"
+description: Start an automation when an opportunity is created, moves to a new stage, or is marked won or lost.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, sales]
+keywords: [opportunity trigger, opportunity stage changed, deal won, deal lost, CRM opportunity, sales pipeline trigger]
+---
+
+# An opportunity is created or changes stage
+
+**An opportunity is created or changes stage** fires whenever a new opportunity is created in the CRM, an existing opportunity moves to a different pipeline stage, or an opportunity is marked as won or lost. Use this trigger to automate follow-ups, notifications, and handoff tasks as deals progress through your pipeline.
+
+You can configure the trigger to respond to a specific stage transition, all stage changes, or only won/lost outcomes — giving you precise control over when the workflow starts.
+
+:::info Trigger scope
+This trigger operates at the **account** scope. Account and contact actions are available downstream.
+:::
+
+## How it works
+
+1. An opportunity is created, its stage is updated, or it is closed as won or lost in the CRM.
+2. The automation evaluates any trigger conditions you've set, such as a specific stage name or pipeline.
+3. If conditions are met, the workflow starts with the account and opportunity data in context.
+4. Downstream steps can use **Add dynamic content** to reference opportunity fields, account fields, and contact details.
+
+## Available data
+
+Standard account and opportunity fields are available via **Add dynamic content**.
+
+| Output | Description |
+|---|---|
+| **Opportunity name** | The name of the opportunity record |
+| **Stage** | The current pipeline stage |
+| **Pipeline** | The pipeline the opportunity belongs to |
+| **Close date** | Expected or actual close date |
+| **Value** | Monetary value of the opportunity |
+| **Assigned salesperson** | The rep assigned to the opportunity |
+
+:::warning
+This trigger will not fire if the opportunity is created or updated in a stage that is already the stage specified in your trigger condition. Configure your stage filter accordingly to avoid missed firings.
+:::
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)
+- [Logic and flow control](./logic-and-flow-control.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-product-activated.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-product-activated.mdx
@@ -1,0 +1,46 @@
+---
+title: "Trigger: Product activated"
+description: Start an automation whenever a product is activated on an account.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, products]
+keywords: [product activated trigger, product activation, account product, automation trigger, account scope]
+---
+
+# Product activated
+
+The **Product activated** trigger starts an automation whenever a product is activated on an account. Use this trigger to kick off onboarding sequences, send confirmation messages, or provision resources the moment a product goes live.
+
+This trigger operates at the account scope, so account and product data are available to downstream steps.
+
+:::info Trigger scope
+This trigger operates at the **account** scope. Account fields and activated product data are available downstream.
+:::
+
+## How it works
+
+1. A product is activated on an account — either manually by an admin or through an order.
+2. The account is brought into scope along with the product details.
+3. Account and product data become available as dynamic content.
+4. Downstream steps execute using that context.
+
+## Available data
+
+| Output | Description |
+|---|---|
+| **Product name** | Name of the product that was activated |
+| **Product ID** | Unique identifier for the activated product |
+| **Account name** | The account the product was activated on |
+| **Activated at** | Timestamp when the product was activated |
+
+## Tips
+
+:::tip Run once per account
+Enable the **Run only once per account** option if you want the automation to fire just the first time a product is activated — for example, to send a one-time onboarding email rather than triggering again on reactivation.
+:::
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-product-deactivated.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-product-deactivated.mdx
@@ -1,0 +1,46 @@
+---
+title: "Trigger: Product deactivated"
+description: Start an automation whenever a product is deactivated on an account.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, products]
+keywords: [product deactivated trigger, product deactivation, account product, automation trigger, account scope]
+---
+
+# Product deactivated
+
+The **Product deactivated** trigger starts an automation whenever a product is deactivated on an account. Use this trigger to send offboarding communications, revoke access, or flag churned products for follow-up.
+
+This trigger operates at the account scope, so account and product data are available to downstream steps.
+
+:::info Trigger scope
+This trigger operates at the **account** scope. Account fields and deactivated product data are available downstream.
+:::
+
+## How it works
+
+1. A product is deactivated on an account — either manually by an admin or through a billing event.
+2. The account is brought into scope along with the product details.
+3. Account and product data become available as dynamic content.
+4. Downstream steps execute using that context.
+
+## Available data
+
+| Output | Description |
+|---|---|
+| **Product name** | Name of the product that was deactivated |
+| **Product ID** | Unique identifier for the deactivated product |
+| **Account name** | The account the product was deactivated on |
+| **Deactivated at** | Timestamp when the product was deactivated |
+
+## Tips
+
+:::tip Run once per account
+Enable the **Run only once per account** option if you want the automation to fire just the first time a product is deactivated — for example, to send a single save-the-relationship email rather than triggering again if the product is later reactivated and deactivated again.
+:::
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-quickbooks-invoice.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-quickbooks-invoice.mdx
@@ -1,0 +1,43 @@
+---
+title: "Trigger: A QuickBooks invoice event occurs"
+description: Start an automation when a QuickBooks invoice event is detected for a contact.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, integrations]
+keywords: [QuickBooks trigger, QuickBooks invoice trigger, QuickBooks integration, invoice event trigger, accounting automation]
+---
+
+# A QuickBooks invoice event occurs
+
+**A QuickBooks invoice event occurs** fires when a QuickBooks invoice event is detected for a contact — such as an invoice being created, sent, paid, or voided. Use this trigger to automate follow-ups, update CRM records, or notify team members based on invoice activity synced from QuickBooks.
+
+This trigger requires an active QuickBooks integration connected to your Partner Center account.
+
+:::info Trigger scope
+This trigger operates at the **contact** scope. Contact, company, and account actions are available downstream.
+:::
+
+## How it works
+
+1. A QuickBooks invoice event occurs and is synced to Partner Center via the QuickBooks integration.
+2. The automation evaluates any trigger conditions you've configured, such as filtering on a specific event type.
+3. If conditions are met, the workflow starts with the associated contact in context.
+4. Downstream steps can use **Add dynamic content** to reference invoice fields, contact fields, and company fields.
+
+## Available data
+
+QuickBooks invoice fields and standard contact, company, and account fields are available via **Add dynamic content**.
+
+| Output | Description |
+|---|---|
+| **Invoice number** | The QuickBooks invoice number |
+| **Invoice amount** | The total amount on the invoice |
+| **Invoice status** | The current status of the invoice (e.g., paid, overdue) |
+| **Due date** | The payment due date on the invoice |
+| **Contact name** | The contact the invoice is associated with |
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-quickbooks-payment.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-quickbooks-payment.mdx
@@ -1,0 +1,43 @@
+---
+title: "Trigger: A QuickBooks payment event occurs"
+description: Start an automation when a QuickBooks payment event is detected for a contact.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, integrations]
+keywords: [QuickBooks trigger, QuickBooks payment trigger, QuickBooks integration, payment event trigger, accounting automation]
+---
+
+# A QuickBooks payment event occurs
+
+**A QuickBooks payment event occurs** fires when a QuickBooks payment event is detected for a contact — such as a payment being received or applied to an invoice. Use this trigger to automate thank-you messages, update contact records, or kick off fulfillment workflows when a payment is confirmed in QuickBooks.
+
+This trigger requires an active QuickBooks integration connected to your Partner Center account.
+
+:::info Trigger scope
+This trigger operates at the **contact** scope. Contact, company, and account actions are available downstream.
+:::
+
+## How it works
+
+1. A QuickBooks payment event occurs and is synced to Partner Center via the QuickBooks integration.
+2. The automation evaluates any trigger conditions you've configured, such as filtering on payment amount or status.
+3. If conditions are met, the workflow starts with the associated contact in context.
+4. Downstream steps can use **Add dynamic content** to reference payment fields, contact fields, and company fields.
+
+## Available data
+
+QuickBooks payment fields and standard contact, company, and account fields are available via **Add dynamic content**.
+
+| Output | Description |
+|---|---|
+| **Payment amount** | The total amount of the payment |
+| **Payment date** | The date the payment was received |
+| **Payment method** | How the payment was made (e.g., check, credit card) |
+| **Applied to invoice** | The invoice number the payment was applied to |
+| **Contact name** | The contact the payment is associated with |
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-quickbooks-sales-receipt.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-quickbooks-sales-receipt.mdx
@@ -1,0 +1,43 @@
+---
+title: "Trigger: A QuickBooks sales receipt event occurs"
+description: Start an automation when a QuickBooks sales receipt event is detected for a contact.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, integrations]
+keywords: [QuickBooks trigger, QuickBooks sales receipt, sales receipt trigger, QuickBooks integration, accounting automation]
+---
+
+# A QuickBooks sales receipt event occurs
+
+**A QuickBooks sales receipt event occurs** fires when a QuickBooks sales receipt event is detected for a contact — such as a sales receipt being created or voided. Use this trigger to automate post-purchase workflows, send confirmations, or update CRM records when a sale is recorded in QuickBooks.
+
+This trigger requires an active QuickBooks integration connected to your Partner Center account.
+
+:::info Trigger scope
+This trigger operates at the **contact** scope. Contact, company, and account actions are available downstream.
+:::
+
+## How it works
+
+1. A QuickBooks sales receipt event occurs and is synced to Partner Center via the QuickBooks integration.
+2. The automation evaluates any trigger conditions you've configured, such as filtering on a specific product or amount.
+3. If conditions are met, the workflow starts with the associated contact in context.
+4. Downstream steps can use **Add dynamic content** to reference sales receipt fields, contact fields, and company fields.
+
+## Available data
+
+QuickBooks sales receipt fields and standard contact, company, and account fields are available via **Add dynamic content**.
+
+| Output | Description |
+|---|---|
+| **Receipt number** | The QuickBooks sales receipt number |
+| **Receipt amount** | The total amount on the sales receipt |
+| **Receipt date** | The date the sales receipt was created |
+| **Product or service** | The item(s) listed on the sales receipt |
+| **Contact name** | The contact the receipt is associated with |
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-sales-activity-created.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-sales-activity-created.mdx
@@ -1,0 +1,43 @@
+---
+title: "Trigger: A sales activity is created"
+description: Start an automation when a sales activity is logged on an account.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, sales]
+keywords: [sales activity trigger, activity logged, CRM activity, sales activity created, automation trigger]
+---
+
+# A sales activity is created
+
+**A sales activity is created** fires whenever a new sales activity — such as a meeting, email, or note — is logged on an account record. Use this trigger to automate follow-up tasks, notify team members, or update downstream systems the moment activity is recorded.
+
+This trigger captures all activity types by default. Add trigger conditions to filter by activity type or assigned user if you only want the workflow to run for specific activity events.
+
+:::info Trigger scope
+This trigger operates at the **account** scope. Account and contact actions are available downstream.
+:::
+
+## How it works
+
+1. A team member logs a new sales activity on an account in the CRM.
+2. The automation evaluates any trigger conditions you've configured, such as activity type or salesperson.
+3. If all conditions are met, the workflow starts with the account and activity data in context.
+4. Downstream steps can use **Add dynamic content** to reference activity details and account fields.
+
+## Available data
+
+Standard account fields and sales activity fields are available via **Add dynamic content**.
+
+| Output | Description |
+|---|---|
+| **Activity type** | The type of activity logged (meeting, email, note, etc.) |
+| **Activity date** | The date and time the activity was recorded |
+| **Assigned user** | The team member who logged the activity |
+| **Notes** | Any notes attached to the activity record |
+| **Account name** | The name of the associated account |
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-sales-order-expiring.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-sales-order-expiring.mdx
@@ -1,0 +1,48 @@
+---
+title: "Trigger: A sales order is approaching expiration"
+description: Start an automation when a sales order is nearing its expiration date.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, sales-orders]
+keywords: [sales order expiring trigger, order expiration trigger, expiring order automation, sales order reminder, order deadline trigger]
+---
+
+# A sales order is approaching expiration
+
+**A sales order is approaching expiration** fires when a sales order is within a configured number of days of its expiration date. Use this trigger to automate expiration reminders, prompt a sales rep to follow up, or send the customer a nudge to review and accept the order before it lapses.
+
+Configure the number of days before expiration that should trigger the workflow to match your sales cadence.
+
+:::info Trigger scope
+This trigger operates at the **account** scope. Account and contact actions are available downstream.
+:::
+
+## How it works
+
+1. A sales order has an expiration date set and is approaching that date within the configured window.
+2. The automation evaluates any trigger conditions you've configured.
+3. If conditions are met, the workflow starts with the account and order data in context.
+4. Downstream steps can use **Add dynamic content** to reference order fields, expiration date, and account details.
+
+## Available data
+
+Standard account fields and sales order fields are available via **Add dynamic content**.
+
+| Output | Description |
+|---|---|
+| **Order name** | The name or title of the sales order |
+| **Expiration date** | The date the order is set to expire |
+| **Order value** | The total value of the sales order |
+| **Order status** | The current status of the order |
+| **Account name** | The account the order is associated with |
+
+## Tips
+
+- Set the expiration window to 3–7 days before the deadline to give customers enough time to respond before the order lapses.
+- Chain multiple automations with different windows (e.g., 7 days and 1 day) for a two-touch reminder sequence.
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-sales-order-status-changed.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-sales-order-status-changed.mdx
@@ -1,0 +1,47 @@
+---
+title: "Trigger: A sales order status changes"
+description: Start an automation when the status of a sales order changes on an account.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, sales-orders]
+keywords: [sales order trigger, order status changed, order status trigger, sales order automation, order workflow trigger]
+---
+
+# A sales order status changes
+
+**A sales order status changes** fires whenever a sales order on an account transitions to a new status. Use this trigger to automate fulfillment steps, customer notifications, or internal handoffs as orders move through their lifecycle — from draft to sent, accepted, or declined.
+
+You can configure the trigger to respond to a specific target status, or to any status change.
+
+:::info Trigger scope
+This trigger operates at the **account** scope. Account and contact actions are available downstream.
+:::
+
+## How it works
+
+1. A sales order on an account transitions to a new status.
+2. The automation evaluates any trigger conditions you've configured, such as a specific target status.
+3. If conditions are met, the workflow starts with the account and order data in context.
+4. Downstream steps can use **Add dynamic content** to reference order fields and account details.
+
+## Available data
+
+Standard account fields and sales order fields are available via **Add dynamic content**.
+
+| Output | Description |
+|---|---|
+| **Order name** | The name or title of the sales order |
+| **Order status** | The new status the order transitioned to |
+| **Order value** | The total value of the sales order |
+| **Account name** | The account the order is associated with |
+| **Expiration date** | The expiration date on the order (if set) |
+
+:::warning
+This trigger will not fire if the sales order is created or updated with a status that is already the status specified in your trigger condition. Ensure the order transitions into the target status rather than starting in it.
+:::
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-sales-task-status-changed.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-sales-task-status-changed.mdx
@@ -1,0 +1,45 @@
+---
+title: "Trigger: A sales task status is changed (legacy)"
+description: Start an automation when the status of a legacy sales task changes.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, sales]
+keywords: [sales task trigger, legacy task trigger, task status changed, CRM task, sales task automation]
+---
+
+# A sales task status is changed (legacy)
+
+**A sales task status is changed** fires whenever the status of a legacy sales task is updated on an account. This trigger applies to tasks created in the legacy sales task system — not to CRM activities or newer task management features.
+
+If your team is still using legacy sales tasks, use this trigger to automate notifications or follow-up actions when a task is marked complete, in progress, or changes to any other status.
+
+:::info Trigger scope
+This trigger operates at the **account** scope. Account and contact actions are available downstream.
+:::
+
+## How it works
+
+1. A legacy sales task on an account has its status updated.
+2. The automation evaluates any trigger conditions you've configured, such as filtering on the target status.
+3. If conditions are met, the workflow starts with the account in context.
+4. Downstream steps can use **Add dynamic content** to reference account fields.
+
+## Available data
+
+Standard account fields are available via **Add dynamic content**. Legacy task fields (task name, status, and due date) may be available depending on your account configuration.
+
+:::warning Legacy trigger limitations
+The **Delay until event** step does not support filtering by assignee or task name for this trigger. If your workflow uses a **Delay until event** step, those filter options will not apply — the step will wait for any matching task status change regardless of assignee or task name.
+:::
+
+## Tips
+
+- If you are building new automations, consider using CRM activities and the [A sales activity is created](./trigger-sales-activity-created.mdx) trigger instead of legacy tasks.
+- Use **Condition** steps downstream to branch logic based on task status if your workflow handles multiple status transitions.
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Logic and flow control](./logic-and-flow-control.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-salesperson-assigned.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-salesperson-assigned.mdx
@@ -1,0 +1,43 @@
+---
+title: "Trigger: A salesperson is assigned to an account"
+description: Start an automation when a salesperson is assigned to an account record.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, sales]
+keywords: [salesperson assigned trigger, account assignment, sales rep assigned, CRM trigger, account scope trigger]
+---
+
+# A salesperson is assigned to an account
+
+**A salesperson is assigned to an account** fires whenever a salesperson is assigned — or reassigned — to an account record. Use this trigger to automate onboarding tasks, send introductory messages, or notify the new rep with relevant account context the moment an assignment is made.
+
+This trigger fires on both initial assignments and reassignments, so it covers account handoffs as well as new account creation.
+
+:::info Trigger scope
+This trigger operates at the **account** scope. Account and contact actions are available downstream.
+:::
+
+## How it works
+
+1. A salesperson is assigned to an account in Partner Center or the CRM.
+2. The automation evaluates any trigger conditions you've configured, such as filtering on a specific salesperson.
+3. If conditions are met, the workflow starts with the account and newly assigned salesperson in context.
+4. Downstream steps can use **Add dynamic content** to reference account fields and the assigned salesperson's details.
+
+## Available data
+
+Standard account and salesperson fields are available via **Add dynamic content**.
+
+| Output | Description |
+|---|---|
+| **Account name** | The name of the account |
+| **Assigned salesperson** | The name of the salesperson assigned to the account |
+| **Salesperson email** | The email address of the assigned salesperson |
+| **Account tags** | Any tags applied to the account record |
+| **Account ID** | The unique identifier for the account |
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-servicemonster-invoice.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-servicemonster-invoice.mdx
@@ -1,0 +1,43 @@
+---
+title: "Trigger: A ServiceMonster invoice event occurs"
+description: Start an automation when a ServiceMonster invoice event is detected for a contact.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, integrations]
+keywords: [ServiceMonster trigger, ServiceMonster invoice, field service automation, ServiceMonster integration, invoice event trigger]
+---
+
+# A ServiceMonster invoice event occurs
+
+**A ServiceMonster invoice event occurs** fires when a ServiceMonster invoice event is detected for a contact — such as an invoice being created, updated, or completed. Use this trigger to automate post-service follow-ups, send review requests, or update CRM records when service jobs are invoiced in ServiceMonster.
+
+This trigger requires an active ServiceMonster integration connected to your Partner Center account.
+
+:::info Trigger scope
+This trigger operates at the **contact** scope. Contact, company, and account actions are available downstream.
+:::
+
+## How it works
+
+1. A ServiceMonster invoice event occurs and is synced to Partner Center via the ServiceMonster integration.
+2. The automation evaluates any trigger conditions you've configured, such as filtering on a specific event type or invoice status.
+3. If conditions are met, the workflow starts with the associated contact in context.
+4. Downstream steps can use **Add dynamic content** to reference invoice fields, contact fields, and company fields.
+
+## Available data
+
+ServiceMonster invoice fields and standard contact, company, and account fields are available via **Add dynamic content**.
+
+| Output | Description |
+|---|---|
+| **Invoice number** | The ServiceMonster invoice number |
+| **Invoice amount** | The total amount on the invoice |
+| **Invoice status** | The current status of the invoice |
+| **Service date** | The date the service was performed |
+| **Contact name** | The contact the invoice is associated with |
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-shopping-cart-updated.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-shopping-cart-updated.mdx
@@ -1,0 +1,40 @@
+---
+title: "Trigger: Shopping cart updated"
+description: Start an automation whenever items are added to or removed from a shopping cart.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, products]
+keywords: [shopping cart trigger, cart updated, cart abandoned, automation trigger, account scope]
+---
+
+# Shopping cart updated
+
+The **Shopping cart updated** trigger starts an automation whenever items are added to or removed from a shopping cart in **Business App**. Use this trigger to send timely cart reminders, surface relevant offers, or track purchasing intent as it happens.
+
+This trigger operates at the account scope, so account and cart data are available to downstream steps.
+
+:::info Trigger scope
+This trigger operates at the **account** scope. Account fields and shopping cart data are available downstream.
+:::
+
+## How it works
+
+1. A user adds or removes an item from their shopping cart in **Business App**.
+2. The cart update event fires and the account is brought into scope.
+3. Cart contents and account data become available as dynamic content.
+4. Downstream steps execute using that context.
+
+## Available data
+
+| Output | Description |
+|---|---|
+| **Cart items** | The products currently in the cart at the time of the update |
+| **Update type** | Whether an item was added or removed |
+| **Account name** | The account associated with the cart |
+| **Updated at** | Timestamp when the cart was updated |
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-snapshot-report-created.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-snapshot-report-created.mdx
@@ -1,0 +1,45 @@
+---
+title: "Trigger: A Snapshot Report is created or refreshed"
+description: Start an automation when a Snapshot Report is generated or refreshed for an account.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, sales]
+keywords: [snapshot report trigger, snapshot created, snapshot refreshed, business report trigger, account snapshot automation]
+---
+
+# A Snapshot Report is created or refreshed
+
+**A Snapshot Report is created or refreshed** fires whenever a new Snapshot Report is generated for an account, or an existing report is refreshed with updated data. Use this trigger to automate outreach, assign tasks, or notify sales reps the moment fresh prospect intelligence is available.
+
+This trigger fires on both first-time report creation and subsequent refreshes, so any update to a Snapshot generates a new run.
+
+:::info Trigger scope
+This trigger operates at the **account** scope. Account and contact actions are available downstream.
+:::
+
+## How it works
+
+1. A Snapshot Report is generated or refreshed for an account.
+2. The automation evaluates any trigger conditions you've configured.
+3. If conditions are met, the workflow starts with the account and Snapshot data in context.
+4. Downstream steps can use **Add dynamic content** to reference Snapshot scores, grades, and account fields.
+
+## Available data
+
+Snapshot Report fields and standard account fields are available via **Add dynamic content**. This includes overall grade, category scores, and the account's contact and location details.
+
+:::warning Snapshot data may start as F ratings
+When a Snapshot Report is first created, many category grades default to **F** until the system has collected and scored the account's data. If your automation uses Snapshot data in conditions or actions, add a **Delay** step of several minutes after the trigger fires before reading Snapshot field values — this gives the report time to populate with real scores.
+:::
+
+## Tips
+
+- Use a **Delay** step (5–10 minutes) immediately after this trigger before branching on Snapshot grades to avoid acting on incomplete data.
+- Combine with a **Condition** step to route accounts differently based on their overall Snapshot grade.
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Logic and flow control](./logic-and-flow-control.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-social-comment-received.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-social-comment-received.mdx
@@ -1,0 +1,41 @@
+---
+title: "Trigger: Social comment received"
+description: Start an automation whenever a comment is received on a connected social network post.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, social]
+keywords: [social comment trigger, social media comment, connected network, automation trigger, account scope]
+---
+
+# Social comment received
+
+The **Social comment received** trigger starts an automation whenever a comment arrives on a post from a connected social network. Use this trigger to acknowledge comments quickly, route them for review, or log social engagement activity automatically.
+
+This trigger operates at the account scope, so account data and comment details are available to downstream steps.
+
+:::info Trigger scope
+This trigger operates at the **account** scope. Account fields and social comment data are available downstream. The social network must be connected to the account for this trigger to fire.
+:::
+
+## How it works
+
+1. A post on a connected social network receives a new comment.
+2. The comment event is detected and the account is brought into scope.
+3. Comment content and network details become available as dynamic content.
+4. Downstream steps execute using the account and comment context.
+
+## Available data
+
+| Output | Description |
+|---|---|
+| **Comment text** | The content of the comment received |
+| **Network** | The social network where the comment was posted (e.g., Facebook, Instagram) |
+| **Post content** | A reference to the post that received the comment |
+| **Commenter name** | Display name of the person who left the comment, if available |
+| **Received at** | Timestamp when the comment was received |
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-user-active-in-business-app.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-user-active-in-business-app.mdx
@@ -1,0 +1,42 @@
+---
+title: "Trigger: User active in Business App"
+description: Start an automation whenever a user logs into or becomes active in Business App.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, users]
+keywords: [user active trigger, Business App login, user engagement, automation trigger, account scope]
+---
+
+# User active in Business App
+
+The **User active in Business App** trigger starts an automation whenever a user logs into **Business App**. Use this trigger to surface timely tips, prompt next steps, or record engagement events based on user activity.
+
+This trigger operates at the account scope, so account and user data are available to downstream steps.
+
+:::info Trigger scope
+This trigger operates at the **account** scope. Account fields and user details are available downstream.
+:::
+
+## How it works
+
+1. A user logs into **Business App** and their session becomes active.
+2. The account associated with that user is brought into scope.
+3. User and account data become available as dynamic content.
+4. Downstream steps execute using the account and user context.
+
+## Available data
+
+| Output | Description |
+|---|---|
+| **User name** | First and last name of the active user |
+| **User email** | Email address of the user |
+| **Account name** | The account the user belongs to |
+| **Active at** | Timestamp of the login or activity event |
+
+To avoid running too frequently, enable the **Run once per contact per period** setting or add conditions that limit when downstream actions execute.
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-user-added-to-account.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-user-added-to-account.mdx
@@ -1,0 +1,46 @@
+---
+title: "Trigger: User added to account"
+description: Start an automation whenever a user is added to an account in Partner Center.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, users]
+keywords: [user added to account trigger, new user, account user, automation trigger, account scope]
+---
+
+# User added to account
+
+The **User added to account** trigger starts an automation whenever a user is associated with an account in Partner Center. Use this trigger to send onboarding communications, assign tasks, or log the event the moment a new team member gains access.
+
+This trigger operates at the account scope, so account and user data are available to downstream steps.
+
+:::info Trigger scope
+This trigger operates at the **account** scope. Account fields and user details are available downstream.
+:::
+
+## How it works
+
+1. A user is added to an account — either by an admin, via invitation, or through an integration.
+2. The account is brought into scope along with the user's details.
+3. Account and user data become available as dynamic content.
+4. Downstream steps execute using that context.
+
+## Available data
+
+| Output | Description |
+|---|---|
+| **User name** | First and last name of the user added |
+| **User email** | Email address of the user |
+| **Account name** | The account the user was added to |
+| **Added at** | Timestamp when the user was added |
+
+## Tips
+
+:::warning Re-added users
+If a user is removed from an account and then added again, this trigger will fire a second time. Use trigger conditions or a downstream check to handle users who have been through onboarding before.
+:::
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-user-asked-question.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-user-asked-question.mdx
@@ -1,0 +1,41 @@
+---
+title: "Trigger: User asked a question"
+description: Start an automation whenever a user sends a message or question through Business App.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, users]
+keywords: [user question trigger, Business App message, user inquiry, automation trigger, account scope]
+---
+
+# User asked a question
+
+The **User asked a question** trigger starts an automation whenever a user submits a message or question through the **Business App**. Use this trigger to route inquiries, acknowledge questions instantly, or escalate messages that need attention.
+
+This trigger operates at the account scope, so account and user data are available to downstream steps.
+
+:::info Trigger scope
+This trigger operates at the **account** scope. Account fields and user details are available downstream.
+:::
+
+## How it works
+
+1. A user sends a message or submits a question through **Business App**.
+2. The account associated with that user is brought into scope.
+3. The message content and user details become available as dynamic content.
+4. Downstream steps execute using the account and message context.
+
+## Available data
+
+| Output | Description |
+|---|---|
+| **Message content** | The text of the question or message the user submitted |
+| **User name** | First and last name of the user who asked the question |
+| **User email** | Email address of the user |
+| **Account name** | The account the user belongs to |
+| **Asked at** | Timestamp when the question was submitted |
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-user-makes-payment.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-user-makes-payment.mdx
@@ -1,0 +1,48 @@
+---
+title: "Trigger: A user makes a payment"
+description: Start an automation when a customer makes a payment, with options to filter on success, failure, or both.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, billing]
+keywords: [payment trigger, user payment, payment success, payment failure, billing automation, payment received trigger]
+---
+
+# A user makes a payment
+
+**A user makes a payment** fires whenever a customer submits a payment on an account. You can configure the trigger to respond to successful payments, failed payments, or both — giving you control over how the workflow responds to each payment outcome.
+
+Use this trigger to send payment confirmations, alert staff to failed transactions, or kick off fulfillment workflows after a successful charge.
+
+:::info Trigger scope
+This trigger operates at the **account** scope. Account and contact actions are available downstream.
+:::
+
+## How it works
+
+1. A customer submits a payment on an account.
+2. The trigger evaluates the payment outcome (success, failure, or both) against your configured filter.
+3. If the outcome matches, the workflow starts with the account and payment event data in context.
+4. Downstream steps can use **Add dynamic content** to reference payment amount, status, and account fields.
+
+## Available data
+
+Standard account fields and payment event fields are available via **Add dynamic content**.
+
+| Output | Description |
+|---|---|
+| **Payment amount** | The amount submitted by the customer |
+| **Payment status** | Whether the payment succeeded or failed |
+| **Payment date** | The date and time the payment was submitted |
+| **Account name** | The name of the account associated with the payment |
+| **Contact email** | The email of the customer who made the payment |
+
+## Tips
+
+- Use the **success/failure** filter on the trigger to create separate automations for each outcome rather than using condition steps — this keeps workflows simpler.
+- For failed payment workflows, add a delay before retrying outreach to give customers time to resolve payment issues.
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-user-shows-interest.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-user-shows-interest.mdx
@@ -1,0 +1,41 @@
+---
+title: "Trigger: User shows interest"
+description: Start an automation whenever a user views a package in Business App.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, products]
+keywords: [user shows interest trigger, package viewed, product interest, automation trigger, account scope]
+---
+
+# User shows interest
+
+The **User shows interest** trigger starts an automation whenever a user views a package in **Business App**. Use this trigger to follow up with interested prospects immediately — without waiting for them to reach out.
+
+This trigger operates at the account scope, so account and package data are available to downstream steps.
+
+:::info Trigger scope
+This trigger operates at the **account** scope. Account fields and package details are available downstream.
+:::
+
+## How it works
+
+1. A user views a package listing in **Business App**.
+2. The interest event fires and the account is brought into scope.
+3. Package and account data become available as dynamic content.
+4. Downstream steps execute using that context.
+
+## Available data
+
+| Output | Description |
+|---|---|
+| **Package name** | The name of the package the user viewed |
+| **User name** | First and last name of the user who viewed the package |
+| **User email** | Email address of the user |
+| **Account name** | The account associated with the user |
+| **Viewed at** | Timestamp of the view event |
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-user-verifies-email.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-user-verifies-email.mdx
@@ -1,0 +1,40 @@
+---
+title: "Trigger: User verifies email"
+description: Start an automation whenever a user completes email verification for their Business App account.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, users]
+keywords: [user email verification trigger, email verified, Business App user, automation trigger, account scope]
+---
+
+# User verifies email
+
+The **User verifies email** trigger starts an automation the moment a user confirms their email address for **Business App**. Use this trigger to send a tailored welcome, unlock next steps, or record the verification event in your CRM.
+
+This trigger operates at the account scope, so account and user data are available to downstream steps.
+
+:::info Trigger scope
+This trigger operates at the **account** scope. Account fields and user details are available downstream.
+:::
+
+## How it works
+
+1. A user clicks the verification link sent to their email address.
+2. The email is confirmed and the verification event fires.
+3. The account and user are brought into scope.
+4. Downstream steps execute using the account and user context.
+
+## Available data
+
+| Output | Description |
+|---|---|
+| **User name** | First and last name of the user who verified their email |
+| **User email** | The email address that was verified |
+| **Account name** | The account the user belongs to |
+| **Verified at** | Timestamp when the email verification was completed |
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-webchat-captures-lead.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-webchat-captures-lead.mdx
@@ -1,0 +1,43 @@
+---
+title: "Trigger: Web Chat captures a lead"
+description: Start an automation when Web Chat captures a new lead from a website visitor.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, conversations]
+keywords: [web chat trigger, lead captured trigger, webchat lead, website visitor lead, chat automation trigger]
+---
+
+# Web Chat captures a lead
+
+**Web Chat captures a lead** fires whenever the Web Chat widget on a website captures a new lead — typically when a visitor submits their contact information during a chat session. Use this trigger to automate immediate follow-up, create CRM records, or assign the lead to a sales rep the moment it arrives.
+
+Speed of response matters for inbound leads. Pair this trigger with fast follow-up actions to maximize conversion.
+
+:::info Trigger scope
+This trigger operates at the **contact** scope. Contact, company, and account actions are available downstream.
+:::
+
+## How it works
+
+1. A website visitor interacts with the Web Chat widget and submits their contact information.
+2. Web Chat captures the lead and creates or matches a contact record.
+3. The automation evaluates any trigger conditions you've configured.
+4. If conditions are met, the workflow starts with the new contact in context, and downstream steps can use **Add dynamic content** to reference contact fields and chat details.
+
+## Available data
+
+Standard contact and account fields are available via **Add dynamic content**, along with any information collected during the chat session.
+
+| Output | Description |
+|---|---|
+| **Contact name** | Name provided by the visitor during chat |
+| **Contact email** | Email address captured from the chat session |
+| **Contact phone** | Phone number captured from the chat session (if provided) |
+| **Chat transcript** | The conversation content from the chat session |
+| **Account name** | The account the Web Chat widget is associated with |
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)

--- a/docusaurus/docs/automations/my-automations/trigger-webhook-received.mdx
+++ b/docusaurus/docs/automations/my-automations/trigger-webhook-received.mdx
@@ -1,0 +1,46 @@
+---
+title: "Trigger: A webhook is received"
+description: Start an automation when an HTTP POST request arrives at the trigger's unique webhook URL.
+sidebar_class_name: hidden-sidebar-item
+tags: [automations, triggers, advanced]
+keywords: [webhook trigger, webhook received, HTTP POST trigger, inbound webhook, webhook automation]
+---
+
+# A webhook is received
+
+**A webhook is received** fires when an HTTP POST request is sent to the unique URL generated for this trigger. Use this trigger to connect any external system that supports outgoing webhooks — such as a third-party CRM, e-commerce platform, or custom application — to an automation workflow in Partner Center.
+
+Each automation using this trigger gets its own unique URL. Share that URL with the external system to start the workflow whenever that system sends a POST request.
+
+:::info Trigger scope
+This trigger has **no entity scope**. No account, contact, or company is automatically in context. Use the data from the webhook payload and lookup steps to bring entities into scope downstream.
+:::
+
+## How it works
+
+1. An external system sends an HTTP POST request to the automation's unique webhook URL.
+2. The automation receives the request and makes the request body available as dynamic data.
+3. The workflow starts and downstream steps can parse and use the webhook payload.
+4. Use lookup steps (such as **Find company** or **Find contact**) to bring CRM entities into scope based on data in the payload.
+
+## Available data
+
+The full JSON body of the incoming POST request is available as dynamic data via **Add dynamic content**. No CRM entity data is available automatically — you must use lookup steps to retrieve it.
+
+:::tip
+Use a **Find company** or **Find contact** step early in your workflow to locate the relevant CRM record based on an identifier in the webhook payload, then use that entity in subsequent steps.
+:::
+
+## Tips
+
+- Copy the unique webhook URL from the trigger settings panel and paste it into your external system's webhook configuration.
+- The external system must send a valid HTTP POST with a JSON body. The automation does not respond to GET requests.
+- Validate webhook payloads using a **Condition** step before taking action to guard against unexpected data shapes.
+
+## Related resources
+
+- [Triggers overview](./triggers-overview.mdx)
+- [Creating and configuring automations](./creating-and-configuring-automations.mdx)
+- [Automation triggers reference](./automation-triggers-reference.mdx)
+- [Actions overview](./actions-overview.mdx)
+- [Logic and flow control](./logic-and-flow-control.mdx)

--- a/docusaurus/docs/automations/my-automations/triggers-overview.mdx
+++ b/docusaurus/docs/automations/my-automations/triggers-overview.mdx
@@ -51,37 +51,37 @@ Add conditions to filter which events qualify:
 ### Companies
 
 <Cards cols={3}>
-  <Card href="/automations/my-automations/automation-triggers-reference#companies" title="Call activity created">
+  <Card href="/automations/my-automations/trigger-call-activity-company" title="Call activity created">
     Fires when a call is logged on a company record
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#companies" title="Company added to a list">
+  <Card href="/automations/my-automations/trigger-company-added-to-list" title="Company added to a list">
     Fires when a company is added to a CRM list
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#companies" title="Company created or modified">
+  <Card href="/automations/my-automations/trigger-company-created-or-modified" title="Company created or modified">
     Fires when a company record is created or any field changes
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#companies" title="Form submitted (company)">
+  <Card href="/automations/my-automations/trigger-form-submitted-company" title="Form submitted (company)">
     Fires when a form linked to a company is submitted
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#companies" title="Company removed from a list">
+  <Card href="/automations/my-automations/trigger-company-removed-from-list" title="Company removed from a list">
     Fires when a company is removed from a CRM list
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#companies" title="Form submitted (contact)">
+  <Card href="/automations/my-automations/trigger-form-submitted-contact-company" title="Form submitted (contact)">
     Fires when a form linked to a contact on a company is submitted
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#companies" title="Email activity created">
+  <Card href="/automations/my-automations/trigger-email-activity-company" title="Email activity created">
     Fires when an email is logged on a company record
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#companies" title="Meeting activity created">
+  <Card href="/automations/my-automations/trigger-meeting-activity-company" title="Meeting activity created">
     Fires when a meeting is logged on a company record
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#companies" title="Note activity created">
+  <Card href="/automations/my-automations/trigger-note-activity-company" title="Note activity created">
     Fires when a note is added to a company record
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#companies" title="Sales task created">
+  <Card href="/automations/my-automations/trigger-crm-task-company" title="Sales task created">
     Fires when a sales task is created on a company
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#companies" title="Sales task overdue">
+  <Card href="/automations/my-automations/trigger-crm-task-overdue-company" title="Sales task overdue">
     Fires when a sales task on a company passes its due date
   </Card>
 </Cards>
@@ -89,34 +89,34 @@ Add conditions to filter which events qualify:
 ### Contacts
 
 <Cards cols={3}>
-  <Card href="/automations/my-automations/automation-triggers-reference#contacts" title="Form submitted (contact)">
+  <Card href="/automations/my-automations/trigger-form-submitted-contact" title="Form submitted (contact)">
     Fires when a form linked to a contact is submitted
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#contacts" title="Call activity created">
+  <Card href="/automations/my-automations/trigger-call-activity-contact" title="Call activity created">
     Fires when a call is logged on a contact record
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#contacts" title="Contact added to a list">
+  <Card href="/automations/my-automations/trigger-contact-added-to-list" title="Contact added to a list">
     Fires when a contact is added to a CRM list
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#contacts" title="Contact created or modified">
+  <Card href="/automations/my-automations/trigger-contact-created-or-modified" title="Contact created or modified">
     Fires when a contact record is created or any field changes
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#contacts" title="Contact removed from a list">
+  <Card href="/automations/my-automations/trigger-contact-removed-from-list" title="Contact removed from a list">
     Fires when a contact is removed from a CRM list
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#contacts" title="Email activity created">
+  <Card href="/automations/my-automations/trigger-email-activity-contact" title="Email activity created">
     Fires when an email is logged on a contact record
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#contacts" title="Meeting activity created">
+  <Card href="/automations/my-automations/trigger-meeting-activity-contact" title="Meeting activity created">
     Fires when a meeting is logged on a contact record
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#contacts" title="Note activity created">
+  <Card href="/automations/my-automations/trigger-note-activity-contact" title="Note activity created">
     Fires when a note is added to a contact record
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#contacts" title="Sales task created">
+  <Card href="/automations/my-automations/trigger-crm-task-contact" title="Sales task created">
     Fires when a sales task is created on a contact
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#contacts" title="Sales task overdue">
+  <Card href="/automations/my-automations/trigger-crm-task-overdue-contact" title="Sales task overdue">
     Fires when a sales task on a contact passes its due date
   </Card>
 </Cards>
@@ -124,13 +124,13 @@ Add conditions to filter which events qualify:
 ### Custom objects
 
 <Cards cols={3}>
-  <Card href="/automations/my-automations/automation-triggers-reference#custom-objects" title="Custom object added to a list">
+  <Card href="/automations/my-automations/trigger-custom-object-added-to-list" title="Custom object added to a list">
     Fires when a custom object record is added to a list
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#custom-objects" title="Custom object created or modified">
+  <Card href="/automations/my-automations/trigger-custom-object-created-or-modified" title="Custom object created or modified">
     Fires when a custom object record is created or updated
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#custom-objects" title="Custom object removed from a list">
+  <Card href="/automations/my-automations/trigger-custom-object-removed-from-list" title="Custom object removed from a list">
     Fires when a custom object record is removed from a list
   </Card>
 </Cards>
@@ -138,16 +138,16 @@ Add conditions to filter which events qualify:
 ### Accounts
 
 <Cards cols={3}>
-  <Card href="/automations/my-automations/automation-triggers-reference#accounts" title="Account created">
+  <Card href="/automations/my-automations/trigger-account-created" title="Account created">
     Fires when a new account is created
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#accounts" title="Account updated">
+  <Card href="/automations/my-automations/trigger-account-updated" title="Account updated">
     Fires when an account record is modified
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#accounts" title="Account added to a list">
+  <Card href="/automations/my-automations/trigger-account-added-to-list" title="Account added to a list">
     Fires when an account is added to a list
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#accounts" title="Custom data fields updated">
+  <Card href="/automations/my-automations/trigger-account-custom-data-updated" title="Custom data fields updated">
     Fires when custom data fields on an account change
   </Card>
 </Cards>
@@ -155,16 +155,16 @@ Add conditions to filter which events qualify:
 ### Users
 
 <Cards cols={3}>
-  <Card href="/automations/my-automations/automation-triggers-reference#users" title="User asked a question">
+  <Card href="/automations/my-automations/trigger-user-asked-question" title="User asked a question">
     Fires when a user submits a question through Business App
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#users" title="User verifies email">
+  <Card href="/automations/my-automations/trigger-user-verifies-email" title="User verifies email">
     Fires when a user completes email verification
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#users" title="User added to account">
+  <Card href="/automations/my-automations/trigger-user-added-to-account" title="User added to account">
     Fires when a user is added to an account
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#users" title="User active in Business App">
+  <Card href="/automations/my-automations/trigger-user-active-in-business-app" title="User active in Business App">
     Fires when a user logs into or interacts with Business App
   </Card>
 </Cards>
@@ -172,7 +172,7 @@ Add conditions to filter which events qualify:
 ### Campaigns and emails
 
 <Cards cols={3}>
-  <Card href="/automations/my-automations/automation-triggers-reference#campaigns-and-emails" title="Activity on a campaign email">
+  <Card href="/automations/my-automations/trigger-campaign-email-activity" title="Activity on a campaign email">
     Fires when a campaign email is opened, clicked, or bounced
   </Card>
 </Cards>
@@ -180,13 +180,13 @@ Add conditions to filter which events qualify:
 ### Fulfillment
 
 <Cards cols={3}>
-  <Card href="/automations/my-automations/automation-triggers-reference#fulfillment" title="Project status changed">
+  <Card href="/automations/my-automations/trigger-fulfillment-project-status" title="Project status changed">
     Fires when a Task Manager project changes status
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#fulfillment" title="Project for order changes status">
+  <Card href="/automations/my-automations/trigger-fulfillment-project-order-status" title="Project for order changes status">
     Fires when a fulfillment project linked to an order changes status
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#fulfillment" title="Task status changed">
+  <Card href="/automations/my-automations/trigger-fulfillment-task-status" title="Task status changed">
     Fires when a Task Manager task changes status
   </Card>
 </Cards>
@@ -194,16 +194,16 @@ Add conditions to filter which events qualify:
 ### Products
 
 <Cards cols={3}>
-  <Card href="/automations/my-automations/automation-triggers-reference#products" title="User shows interest">
+  <Card href="/automations/my-automations/trigger-user-shows-interest" title="User shows interest">
     Fires when a customer views or clicks on a package
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#products" title="Product activated">
+  <Card href="/automations/my-automations/trigger-product-activated" title="Product activated">
     Fires when a product is activated on an account
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#products" title="Product deactivated">
+  <Card href="/automations/my-automations/trigger-product-deactivated" title="Product deactivated">
     Fires when a product is deactivated on an account
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#products" title="Shopping cart updated">
+  <Card href="/automations/my-automations/trigger-shopping-cart-updated" title="Shopping cart updated">
     Fires when items are added to or removed from a shopping cart
   </Card>
 </Cards>
@@ -211,19 +211,19 @@ Add conditions to filter which events qualify:
 ### Sales
 
 <Cards cols={3}>
-  <Card href="/automations/my-automations/automation-triggers-reference#sales" title="Opportunity created or changed">
+  <Card href="/automations/my-automations/trigger-opportunity-created-or-changed" title="Opportunity created or changed">
     Fires when an opportunity is created or its stage/fields change
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#sales" title="Sales activity created">
+  <Card href="/automations/my-automations/trigger-sales-activity-created" title="Sales activity created">
     Fires when a sales activity (call, email, meeting) is logged
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#sales" title="Salesperson assigned">
+  <Card href="/automations/my-automations/trigger-salesperson-assigned" title="Salesperson assigned">
     Fires when a salesperson is assigned to an account
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#sales" title="Sales task status changed">
+  <Card href="/automations/my-automations/trigger-sales-task-status-changed" title="Sales task status changed">
     Legacy trigger — fires when a sales task changes status
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#sales" title="Snapshot Report created">
+  <Card href="/automations/my-automations/trigger-snapshot-report-created" title="Snapshot Report created">
     Fires when a Snapshot Report is generated or refreshed
   </Card>
 </Cards>
@@ -231,13 +231,13 @@ Add conditions to filter which events qualify:
 ### Billing
 
 <Cards cols={3}>
-  <Card href="/automations/my-automations/automation-triggers-reference#billing" title="Billed wholesale for a product">
+  <Card href="/automations/my-automations/trigger-billed-wholesale" title="Billed wholesale for a product">
     Fires when a wholesale billing event occurs
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#billing" title="Invoice past due">
+  <Card href="/automations/my-automations/trigger-invoice-past-due" title="Invoice past due">
     Fires when an invoice goes past its due date
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#billing" title="User makes a payment">
+  <Card href="/automations/my-automations/trigger-user-makes-payment" title="User makes a payment">
     Fires when a customer makes a payment
   </Card>
 </Cards>
@@ -245,13 +245,13 @@ Add conditions to filter which events qualify:
 ### Conversations
 
 <Cards cols={3}>
-  <Card href="/automations/my-automations/automation-triggers-reference#conversations" title="Communication summary created">
+  <Card href="/automations/my-automations/trigger-communication-summary-created" title="Communication summary created">
     Fires when an AI conversation summary is generated for a contact
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#conversations" title="Web Chat captures a lead">
+  <Card href="/automations/my-automations/trigger-webchat-captures-lead" title="Web Chat captures a lead">
     Fires when a visitor submits their info through Web Chat
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#conversations" title="Message sent or received">
+  <Card href="/automations/my-automations/trigger-conversations-message" title="Message sent or received">
     Fires when a message is sent or received in Conversations
   </Card>
 </Cards>
@@ -259,16 +259,16 @@ Add conditions to filter which events qualify:
 ### Manual
 
 <Cards cols={3}>
-  <Card href="/automations/my-automations/automation-triggers-reference#manual" title="Manual for account">
+  <Card href="/automations/my-automations/trigger-manual-account" title="Manual for account">
     Run on demand for a selected account
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#manual" title="Manual for company">
+  <Card href="/automations/my-automations/trigger-manual-company" title="Manual for company">
     Run on demand for a selected company
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#manual" title="Manual for contact">
+  <Card href="/automations/my-automations/trigger-manual-contact" title="Manual for contact">
     Run on demand for a selected contact
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#manual" title="Manual for order">
+  <Card href="/automations/my-automations/trigger-manual-order" title="Manual for order">
     Run on demand for a selected order
   </Card>
 </Cards>
@@ -276,10 +276,10 @@ Add conditions to filter which events qualify:
 ### Sales orders
 
 <Cards cols={3}>
-  <Card href="/automations/my-automations/automation-triggers-reference#sales-orders" title="Sales order status changed">
+  <Card href="/automations/my-automations/trigger-sales-order-status-changed" title="Sales order status changed">
     Fires when a sales order moves to a new status
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#sales-orders" title="Sales order expiring">
+  <Card href="/automations/my-automations/trigger-sales-order-expiring" title="Sales order expiring">
     Fires when a sales order approaches its expiration date
   </Card>
 </Cards>
@@ -287,13 +287,13 @@ Add conditions to filter which events qualify:
 ### Advanced
 
 <Cards cols={3}>
-  <Card href="/automations/my-automations/automation-triggers-reference#advanced" title="API trigger (account)">
+  <Card href="/automations/my-automations/trigger-api-account" title="API trigger (account)">
     Fires when an external system calls the automation API for an account
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#advanced" title="Webhook received">
+  <Card href="/automations/my-automations/trigger-webhook-received" title="Webhook received">
     Fires when an external system sends a POST request to the webhook URL
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#advanced" title="API trigger (order)">
+  <Card href="/automations/my-automations/trigger-api-order" title="API trigger (order)">
     Fires when an external system calls the automation API for an order
   </Card>
   <Card href="/automations/my-automations/trigger-automation-using-zapier" title="Triggered via Zapier">
@@ -304,16 +304,16 @@ Add conditions to filter which events qualify:
 ### Integrations
 
 <Cards cols={3}>
-  <Card href="/automations/my-automations/automation-triggers-reference#integrations" title="QuickBooks invoice">
+  <Card href="/automations/my-automations/trigger-quickbooks-invoice" title="QuickBooks invoice">
     Fires on QuickBooks Online invoice events for a contact
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#integrations" title="QuickBooks payment">
+  <Card href="/automations/my-automations/trigger-quickbooks-payment" title="QuickBooks payment">
     Fires on QuickBooks Online payment events for a contact
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#integrations" title="QuickBooks sales receipt">
+  <Card href="/automations/my-automations/trigger-quickbooks-sales-receipt" title="QuickBooks sales receipt">
     Fires on QuickBooks Online sales receipt events for a contact
   </Card>
-  <Card href="/automations/my-automations/automation-triggers-reference#integrations" title="ServiceMonster invoice">
+  <Card href="/automations/my-automations/trigger-servicemonster-invoice" title="ServiceMonster invoice">
     Fires on ServiceMonster invoice events for a contact
   </Card>
 </Cards>


### PR DESCRIPTION
## Summary

- **65 new trigger detail pages** in docs/automations/my-automations/, one for every published automation trigger
- **Updated triggers-overview.mdx** — all card href links now point to individual pages instead of automation-triggers-reference#section anchors

## What changed

Every automation trigger that was previously only documented as a row in the monolithic automation-triggers-reference.mdx table now has its own dedicated page following the standardized template:

- Frontmatter with hidden-sidebar-item (no sidebar clutter)
- Intro paragraph with bolded trigger name
- Trigger scope callout (:::info box)
- How it works (numbered steps)
- Available data section
- Tips section where special cases exist (e.g. won't-fire-if-already-in-stage, duplicate detection gaps)
- Related resources

### Categories covered

| Category | Pages |
|---|---|
| Companies | 11 |
| Contacts | 10 |
| Custom Objects | 3 |
| Accounts | 4 |
| Users | 4 |
| Campaigns | 1 |
| Social | 1 |
| Fulfillment | 3 |
| Products | 4 |
| Sales | 5 |
| Billing | 3 |
| Conversations | 3 |
| Manual | 4 |
| Sales Orders | 2 |
| Advanced | 3 |
| Integrations | 4 |

### Not included

- Draft/unpublished triggers
- Triggers that already had dedicated pages (time-based-triggers, trigger-automation-using-zapier)
- Social comment trigger card not added to overview (was not present before)

## Test plan

- [ ] Verify triggers-overview card links navigate to individual pages
- [ ] Spot-check pages across categories (trigger-account-created, trigger-webhook-received, trigger-webchat-captures-lead)
- [ ] Confirm hidden pages don't appear in sidebar
- [ ] Run npm run build to verify no MDX compilation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)