### PR TITLE
docs(learn): cross-link Your growth engine course and Partner Center docs

### DIFF
--- a/docusaurus/docs/accounts/manage-accounts/create-accounts.mdx
+++ b/docusaurus/docs/accounts/manage-accounts/create-accounts.mdx
@@ -7,6 +7,8 @@ tags: [account-creation, business-profile, bulk-import]
 keywords: [create-account, add-business, account-setup, bulk-import]
 ---
 
+import { GraduationCapIcon } from '@site/src/components/Icons';
+
 # Create Accounts
 
 ## What is account creation?
@@ -333,3 +335,10 @@ While creating accounts, you can configure default user settings for bulk import
 
 The Google Locations API is used to gather the Name, Address, Phone Number, Website, geo-location, Business Category and Hours of Operation.  The social profile URLs are gathered from the business website.
 </details>
+
+<div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '12px', background: 'rgba(60, 154, 99, 0.08)', border: '1px solid rgba(60, 154, 99, 0.35)', borderRadius: '8px', padding: '14px 18px', margin: '16px auto', width: 'fit-content', maxWidth: '100%', textAlign: 'center'}}>
+  <span style={{flexShrink: 0}}><GraduationCapIcon size={26} /></span>
+  <span style={{fontSize: '14px', color: 'var(--ifm-font-color-base)', textAlign: 'center'}}>
+    New to running the full sales motion? Take the <a href="/learn/growth-engine" style={{color: '#3C9A63', fontWeight: 600}}>Your growth engine</a> course in Vendasta Learn — Beginner, 6 lessons.
+  </span>
+</div>

--- a/docusaurus/docs/ai/ai-capabilities/configuring-capabilities.md
+++ b/docusaurus/docs/ai/ai-capabilities/configuring-capabilities.md
@@ -231,9 +231,9 @@ Track key metrics to measure capability effectiveness:
 
 Need help with specific capability configurations? Check our [troubleshooting guide](#troubleshooting-common-issues) or contact support for personalized assistance.
 
-<div style={{display: 'flex', alignItems: 'center', gap: '12px', background: 'rgba(60, 154, 99, 0.08)', border: '1px solid rgba(60, 154, 99, 0.35)', borderRadius: '8px', padding: '14px 18px', margin: '16px 0'}}>
+<div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '12px', background: 'rgba(60, 154, 99, 0.08)', border: '1px solid rgba(60, 154, 99, 0.35)', borderRadius: '8px', padding: '14px 18px', margin: '16px auto', width: 'fit-content', maxWidth: '100%', textAlign: 'center'}}>
   <span style={{flexShrink: 0}}><GraduationCapIcon size={26} /></span>
-  <span style={{fontSize: '14px', color: 'var(--ifm-font-color-base)'}}>
+  <span style={{fontSize: '14px', color: 'var(--ifm-font-color-base)', textAlign: 'center'}}>
     New to how AI Employees work? Take the <a href="/learn/ai-foundations" style={{color: '#3C9A63', fontWeight: 600}}>AI foundations</a> course in Vendasta Learn — Beginner, 6 lessons.
   </span>
 </div>

--- a/docusaurus/docs/ai/ai-capabilities/creating-custom-capabilities.md
+++ b/docusaurus/docs/ai/ai-capabilities/creating-custom-capabilities.md
@@ -425,9 +425,9 @@ The value at the end of the path is the `product_id`.
 For the AI Chat Receptionist, see [Make responses page-aware with the visitor's URL](../ai-workforce/ai-chat-receptionist/index.md#make-responses-page-aware-with-the-visitors-url) for the broader feature overview.
 :::
 
-<div style={{display: 'flex', alignItems: 'center', gap: '12px', background: 'rgba(60, 154, 99, 0.08)', border: '1px solid rgba(60, 154, 99, 0.35)', borderRadius: '8px', padding: '14px 18px', margin: '16px 0'}}>
+<div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '12px', background: 'rgba(60, 154, 99, 0.08)', border: '1px solid rgba(60, 154, 99, 0.35)', borderRadius: '8px', padding: '14px 18px', margin: '16px auto', width: 'fit-content', maxWidth: '100%', textAlign: 'center'}}>
   <span style={{flexShrink: 0}}><GraduationCapIcon size={26} /></span>
-  <span style={{fontSize: '14px', color: 'var(--ifm-font-color-base)'}}>
+  <span style={{fontSize: '14px', color: 'var(--ifm-font-color-base)', textAlign: 'center'}}>
     New to how AI Employees work? Take the <a href="/learn/ai-foundations" style={{color: '#3C9A63', fontWeight: 600}}>AI foundations</a> course in Vendasta Learn — Beginner, 6 lessons.
   </span>
 </div>

--- a/docusaurus/docs/ai/ai-capabilities/index.md
+++ b/docusaurus/docs/ai/ai-capabilities/index.md
@@ -133,9 +133,9 @@ Use the Explanations feature in Conversations to understand:
 
 ---
 
-<div style={{display: 'flex', alignItems: 'center', gap: '12px', background: 'rgba(60, 154, 99, 0.08)', border: '1px solid rgba(60, 154, 99, 0.35)', borderRadius: '8px', padding: '14px 18px', margin: '16px 0'}}>
+<div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '12px', background: 'rgba(60, 154, 99, 0.08)', border: '1px solid rgba(60, 154, 99, 0.35)', borderRadius: '8px', padding: '14px 18px', margin: '16px auto', width: 'fit-content', maxWidth: '100%', textAlign: 'center'}}>
   <span style={{flexShrink: 0}}><GraduationCapIcon size={26} /></span>
-  <span style={{fontSize: '14px', color: 'var(--ifm-font-color-base)'}}>
+  <span style={{fontSize: '14px', color: 'var(--ifm-font-color-base)', textAlign: 'center'}}>
     New to how AI Employees work? Take the <a href="/learn/ai-foundations" style={{color: '#3C9A63', fontWeight: 600}}>AI foundations</a> course in Vendasta Learn — Beginner, 6 lessons.
   </span>
 </div>

--- a/docusaurus/docs/ai/ai-workforce/index.mdx
+++ b/docusaurus/docs/ai/ai-workforce/index.mdx
@@ -286,9 +286,9 @@ After initial setup, regularly test and optimize your AI Employees to ensure the
 - Be patient. Optimizing AI Employees is an iterative process that improves over time
 :::
 
-<div style={{display: 'flex', alignItems: 'center', gap: '12px', background: 'rgba(60, 154, 99, 0.08)', border: '1px solid rgba(60, 154, 99, 0.35)', borderRadius: '8px', padding: '14px 18px', margin: '16px 0'}}>
+<div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '12px', background: 'rgba(60, 154, 99, 0.08)', border: '1px solid rgba(60, 154, 99, 0.35)', borderRadius: '8px', padding: '14px 18px', margin: '16px auto', width: 'fit-content', maxWidth: '100%', textAlign: 'center'}}>
   <span style={{flexShrink: 0}}><GraduationCapIcon size={26} /></span>
-  <span style={{fontSize: '14px', color: 'var(--ifm-font-color-base)'}}>
+  <span style={{fontSize: '14px', color: 'var(--ifm-font-color-base)', textAlign: 'center'}}>
     New to how AI Employees work? Take the <a href="/learn/ai-foundations" style={{color: '#3C9A63', fontWeight: 600}}>AI foundations</a> course in Vendasta Learn (Beginner, 6 lessons).
   </span>
 </div>

--- a/docusaurus/docs/ai/index.mdx
+++ b/docusaurus/docs/ai/index.mdx
@@ -55,9 +55,9 @@ These three components can be mixed and matched to create AI employees that hand
 - **Tools** = Ability to take action in external systems (integration-based)
 :::
 
-<div style={{display: 'flex', alignItems: 'center', gap: '12px', background: 'rgba(60, 154, 99, 0.08)', border: '1px solid rgba(60, 154, 99, 0.35)', borderRadius: '8px', padding: '14px 18px', margin: '16px 0'}}>
+<div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '12px', background: 'rgba(60, 154, 99, 0.08)', border: '1px solid rgba(60, 154, 99, 0.35)', borderRadius: '8px', padding: '14px 18px', margin: '16px auto', width: 'fit-content', maxWidth: '100%', textAlign: 'center'}}>
   <span style={{flexShrink: 0}}><GraduationCapIcon size={26} /></span>
-  <span style={{fontSize: '14px', color: 'var(--ifm-font-color-base)'}}>
+  <span style={{fontSize: '14px', color: 'var(--ifm-font-color-base)', textAlign: 'center'}}>
     New to how AI Employees work? Take the <a href="/learn/ai-foundations" style={{color: '#3C9A63', fontWeight: 600}}>AI foundations</a> course in Vendasta Learn — Beginner, 6 lessons.
   </span>
 </div>

--- a/docusaurus/docs/automations/index.mdx
+++ b/docusaurus/docs/automations/index.mdx
@@ -109,9 +109,9 @@ The automation runs whenever the trigger conditions are met (if it's turned on).
 
 <a href="https://partners.vendasta.com/automations" target="_blank" rel="noopener">**Create an Automation**</a> (Partner Center)
 
-<div style={{display: 'flex', alignItems: 'center', gap: '12px', background: 'rgba(60, 154, 99, 0.08)', border: '1px solid rgba(60, 154, 99, 0.35)', borderRadius: '8px', padding: '14px 18px', margin: '16px 0'}}>
+<div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '12px', background: 'rgba(60, 154, 99, 0.08)', border: '1px solid rgba(60, 154, 99, 0.35)', borderRadius: '8px', padding: '14px 18px', margin: '16px auto', width: 'fit-content', maxWidth: '100%', textAlign: 'center'}}>
   <span style={{flexShrink: 0}}><GraduationCapIcon size={26} /></span>
-  <span style={{fontSize: '14px', color: 'var(--ifm-font-color-base)'}}>
+  <span style={{fontSize: '14px', color: 'var(--ifm-font-color-base)', textAlign: 'center'}}>
     New to how AI Employees work? Take the <a href="/learn/ai-foundations" style={{color: '#3C9A63', fontWeight: 600}}>AI foundations</a> course in Vendasta Learn — Beginner, 6 lessons.
   </span>
 </div>

--- a/docusaurus/docs/crm/companies/index.mdx
+++ b/docusaurus/docs/crm/companies/index.mdx
@@ -4,6 +4,8 @@ description: Comprehensive tools for managing business relationships, tracking c
 sidebar_position: 2
 ---
 
+import { GraduationCapIcon } from '@site/src/components/Icons';
+
 # Companies
 
 The Companies section in Vendasta's CRM provides comprehensive tools to manage your business relationships effectively. This centralized hub enables you to track company information, log activities, and monitor engagement throughout your sales process. With advanced features like lead scoring and activity logging, you can prioritize prospects and maintain detailed records of all interactions. The Companies section serves as your primary workspace for building and nurturing business relationships that drive revenue growth.
@@ -310,3 +312,10 @@ If a company was accidentally deleted, you can trigger the system to recreate it
 4. Save the account.
 
 Saving triggers a sync that recreates the Company record linked to that account. The recreated company will have a fresh activity timeline with no previous notes.
+
+<div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '12px', background: 'rgba(60, 154, 99, 0.08)', border: '1px solid rgba(60, 154, 99, 0.35)', borderRadius: '8px', padding: '14px 18px', margin: '16px auto', width: 'fit-content', maxWidth: '100%', textAlign: 'center'}}>
+  <span style={{flexShrink: 0}}><GraduationCapIcon size={26} /></span>
+  <span style={{fontSize: '14px', color: 'var(--ifm-font-color-base)', textAlign: 'center'}}>
+    New to running the full sales motion? Take the <a href="/learn/growth-engine" style={{color: '#3C9A63', fontWeight: 600}}>Your growth engine</a> course in Vendasta Learn — Beginner, 6 lessons.
+  </span>
+</div>

--- a/docusaurus/docs/snapshot-report/index.mdx
+++ b/docusaurus/docs/snapshot-report/index.mdx
@@ -5,6 +5,8 @@ tags: [snapshot-report, prospecting, digital-marketing, sales-tools]
 keywords: [snapshot-report, digital-presence, marketing-assessment, prospecting-tool, online-visibility]
 ---
 
+import { GraduationCapIcon } from '@site/src/components/Icons';
+
 # Snapshot Report – complete guide
 
 ## What is Snapshot Report?
@@ -354,5 +356,12 @@ The Quick View Scorecard provides a summarized view of digital presence with let
 - [Generate Revenue with the Snapshot Report PDF](/files/snapshot-report/Generate-Revenue-with-the-Snapshot-Report-v0122.pdf)
 - [Generate Revenue with the Snapshot Report PowerPoint](/files/snapshot-report/Generate-Revenue-with-the-Snapshot-Report-v0122.pptx)
 - [Google Drive Cheat Sheet](https://drive.google.com/file/d/1qPPOK_MTjw2BwT70FTLToLKzuw4wXx1u/view?usp=drive_link)
+
+<div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '12px', background: 'rgba(60, 154, 99, 0.08)', border: '1px solid rgba(60, 154, 99, 0.35)', borderRadius: '8px', padding: '14px 18px', margin: '16px auto', width: 'fit-content', maxWidth: '100%', textAlign: 'center'}}>
+  <span style={{flexShrink: 0}}><GraduationCapIcon size={26} /></span>
+  <span style={{fontSize: '14px', color: 'var(--ifm-font-color-base)', textAlign: 'center'}}>
+    New to running the full sales motion? Take the <a href="/learn/growth-engine" style={{color: '#3C9A63', fontWeight: 600}}>Your growth engine</a> course in Vendasta Learn — Beginner, 6 lessons.
+  </span>
+</div>
 
 ---

--- a/docusaurus/docs/snapshot-report/snapshot-report-ai-chat.mdx
+++ b/docusaurus/docs/snapshot-report/snapshot-report-ai-chat.mdx
@@ -6,6 +6,8 @@ tags: [snapshot-report, ai-chat, ai-receptionist]
 keywords: [snapshot-report, ai-widget, ai-chat, book appointments, lead capture]
 ---
 
+import { GraduationCapIcon } from '@site/src/components/Icons';
+
 ## What is AI Chat in Snapshot Report?
 ![AI Chat widget embedded in a Snapshot Report](./img/snapshot-report-ai-chat-1.png)
 AI Chat is a widget embedded in the Snapshot Report that responds to visitor questions in real time. It understands the contents of the Snapshot Report, captures leads, and can book appointments directly from the chat.
@@ -116,6 +118,13 @@ No. These customizations only apply to the Snapshot Report AI Chat widget.
 
 Yes. When enabling appointment booking, choose a team calendar link during setup.
 </details>
+
+<div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '12px', background: 'rgba(60, 154, 99, 0.08)', border: '1px solid rgba(60, 154, 99, 0.35)', borderRadius: '8px', padding: '14px 18px', margin: '16px auto', width: 'fit-content', maxWidth: '100%', textAlign: 'center'}}>
+  <span style={{flexShrink: 0}}><GraduationCapIcon size={26} /></span>
+  <span style={{fontSize: '14px', color: 'var(--ifm-font-color-base)', textAlign: 'center'}}>
+    New to running the full sales motion? Take the <a href="/learn/growth-engine" style={{color: '#3C9A63', fontWeight: 600}}>Your growth engine</a> course in Vendasta Learn — Beginner, 6 lessons.
+  </span>
+</div>
 
 
 

--- a/docusaurus/docs/snapshot-report/snapshot-report-ai-optimization.mdx
+++ b/docusaurus/docs/snapshot-report/snapshot-report-ai-optimization.mdx
@@ -6,6 +6,8 @@ tags: [ai-optimization, ai-search, chatgpt, google-ai, ai-visibility, prospectin
 keywords: [ai-optimization, ai-search-visibility, chatgpt-results, google-ai-mode, ai-readiness, ai-audit]
 ---
 
+import { GraduationCapIcon } from '@site/src/components/Icons';
+
 ## What is AI Optimization?
 
 The AI Optimization section helps you understand whether a business appears in AI-generated search results. As more customers use AI tools like Google AI Mode and ChatGPT to find businesses and get direct answers, businesses need to know if they're being discovered in these new search experiences.
@@ -338,6 +340,13 @@ The AI Optimization section provides a clear grade and overview of both AI Readi
 You can also find the response returned for each query for each persona on each AI engine.
 
 ![AI Readiness Audit](./img/snapshot-report/ai-optimization-details.jpg)
+
+<div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '12px', background: 'rgba(60, 154, 99, 0.08)', border: '1px solid rgba(60, 154, 99, 0.35)', borderRadius: '8px', padding: '14px 18px', margin: '16px auto', width: 'fit-content', maxWidth: '100%', textAlign: 'center'}}>
+  <span style={{flexShrink: 0}}><GraduationCapIcon size={26} /></span>
+  <span style={{fontSize: '14px', color: 'var(--ifm-font-color-base)', textAlign: 'center'}}>
+    New to running the full sales motion? Take the <a href="/learn/growth-engine" style={{color: '#3C9A63', fontWeight: 600}}>Your growth engine</a> course in Vendasta Learn — Beginner, 6 lessons.
+  </span>
+</div>
 
 ---
 

--- a/docusaurus/docs/snapshot-report/snapshot-report-customization.mdx
+++ b/docusaurus/docs/snapshot-report/snapshot-report-customization.mdx
@@ -6,6 +6,8 @@ tags: [customization, configuration, templates, branding, headers]
 keywords: [snapshot-customization, report-templates, custom-headers, banner-images, section-configuration]
 ---
 
+import { GraduationCapIcon } from '@site/src/components/Icons';
+
 # Snapshot Report Customization and Configuration
 
 ## What is Snapshot Report Customization?
@@ -344,5 +346,12 @@ Choose from pre-built templates or create custom configurations for different us
 Upload and manage banner images for professional report branding.
 
 ![Snapshot Report Banner Image Menu](./img/snapshot-report/banner-image-1.jpg)
+
+<div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '12px', background: 'rgba(60, 154, 99, 0.08)', border: '1px solid rgba(60, 154, 99, 0.35)', borderRadius: '8px', padding: '14px 18px', margin: '16px auto', width: 'fit-content', maxWidth: '100%', textAlign: 'center'}}>
+  <span style={{flexShrink: 0}}><GraduationCapIcon size={26} /></span>
+  <span style={{fontSize: '14px', color: 'var(--ifm-font-color-base)', textAlign: 'center'}}>
+    New to running the full sales motion? Take the <a href="/learn/growth-engine" style={{color: '#3C9A63', fontWeight: 600}}>Your growth engine</a> course in Vendasta Learn — Beginner, 6 lessons.
+  </span>
+</div>
 
 ---

--- a/docusaurus/docs/snapshot-report/snapshot-report-ecommerce-technology.mdx
+++ b/docusaurus/docs/snapshot-report/snapshot-report-ecommerce-technology.mdx
@@ -6,6 +6,8 @@ tags: [ecommerce, technology-stack, online-sales, website-technology, digital-co
 keywords: [ecommerce-analysis, technology-stack, online-storefront, payment-processing, lead-engagement]
 ---
 
+import { GraduationCapIcon } from '@site/src/components/Icons';
+
 ## What are Ecommerce and Technology assessments?
 
 The Ecommerce and Technology sections analyze critical components for online business success. Ecommerce assessment evaluates a business's ability to sell products and services online, while technology analysis reveals the tech stack and marketing tools powering their digital presence.
@@ -248,5 +250,12 @@ The Technology section displays comprehensive information about website platform
 Screenshots showing how to enable/disable ecommerce and technology sections in report customization.
 
 ![Disabling technology section](./img/snapshot-report/technology-disable-section.jpg)
+
+<div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '12px', background: 'rgba(60, 154, 99, 0.08)', border: '1px solid rgba(60, 154, 99, 0.35)', borderRadius: '8px', padding: '14px 18px', margin: '16px auto', width: 'fit-content', maxWidth: '100%', textAlign: 'center'}}>
+  <span style={{flexShrink: 0}}><GraduationCapIcon size={26} /></span>
+  <span style={{fontSize: '14px', color: 'var(--ifm-font-color-base)', textAlign: 'center'}}>
+    New to running the full sales motion? Take the <a href="/learn/growth-engine" style={{color: '#3C9A63', fontWeight: 600}}>Your growth engine</a> course in Vendasta Learn — Beginner, 6 lessons.
+  </span>
+</div>
 
 ---

--- a/docusaurus/docs/snapshot-report/snapshot-report-listings-reviews.mdx
+++ b/docusaurus/docs/snapshot-report/snapshot-report-listings-reviews.mdx
@@ -6,6 +6,8 @@ tags: [business-listings, online-reviews, digital-presence, directory-listings]
 keywords: [business-listings, online-reviews, listing-accuracy, review-management, directory-presence]
 ---
 
+import { GraduationCapIcon } from '@site/src/components/Icons';
+
 # Snapshot Report sections – Business Listings and Reviews
 
 ## What are Business Listings and Reviews?
@@ -175,5 +177,12 @@ The Listings section displays overall listing performance with detailed breakdow
 The Reviews section shows comprehensive review performance across multiple platforms and metrics.
 
 ![Reviews Section in Snapshot Report](./img/snapshot-report/grade-calculations/social-section.jpg)
+
+<div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '12px', background: 'rgba(60, 154, 99, 0.08)', border: '1px solid rgba(60, 154, 99, 0.35)', borderRadius: '8px', padding: '14px 18px', margin: '16px auto', width: 'fit-content', maxWidth: '100%', textAlign: 'center'}}>
+  <span style={{flexShrink: 0}}><GraduationCapIcon size={26} /></span>
+  <span style={{fontSize: '14px', color: 'var(--ifm-font-color-base)', textAlign: 'center'}}>
+    New to running the full sales motion? Take the <a href="/learn/growth-engine" style={{color: '#3C9A63', fontWeight: 600}}>Your growth engine</a> course in Vendasta Learn — Beginner, 6 lessons.
+  </span>
+</div>
 
 ---

--- a/docusaurus/docs/snapshot-report/snapshot-report-social-advertising.mdx
+++ b/docusaurus/docs/snapshot-report/snapshot-report-social-advertising.mdx
@@ -6,6 +6,8 @@ tags: [social-media, online-advertising, digital-marketing, facebook, instagram]
 keywords: [social-media-analysis, online-advertising, facebook-marketing, instagram-assessment, digital-advertising]
 ---
 
+import { GraduationCapIcon } from '@site/src/components/Icons';
+
 # Snapshot Report sections – Social Media and Advertising
 
 ## What are Social Media and Advertising assessments?
@@ -226,5 +228,12 @@ The Advertising section displays keyword analysis and competitive positioning in
 Screenshots showing how to update social media profiles for accurate reporting.
 
 ![Social tab with business pages](./img/snapshot-report/social-profiles-business-pages.jpg)
+
+<div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '12px', background: 'rgba(60, 154, 99, 0.08)', border: '1px solid rgba(60, 154, 99, 0.35)', borderRadius: '8px', padding: '14px 18px', margin: '16px auto', width: 'fit-content', maxWidth: '100%', textAlign: 'center'}}>
+  <span style={{flexShrink: 0}}><GraduationCapIcon size={26} /></span>
+  <span style={{fontSize: '14px', color: 'var(--ifm-font-color-base)', textAlign: 'center'}}>
+    New to running the full sales motion? Take the <a href="/learn/growth-engine" style={{color: '#3C9A63', fontWeight: 600}}>Your growth engine</a> course in Vendasta Learn — Beginner, 6 lessons.
+  </span>
+</div>
 
 ---

--- a/docusaurus/docs/snapshot-report/snapshot-report-website-seo.mdx
+++ b/docusaurus/docs/snapshot-report/snapshot-report-website-seo.mdx
@@ -6,6 +6,8 @@ tags: [website-performance, seo, core-web-vitals, search-optimization, pagespeed
 keywords: [website-performance, seo-analysis, core-web-vitals, pagespeed-insights, search-engine-optimization]
 ---
 
+import { GraduationCapIcon } from '@site/src/components/Icons';
+
 # Snapshot Report sections – Website Performance and SEO
 
 ## What are Website Performance and SEO?
@@ -310,5 +312,12 @@ Expanded view showing specific performance recommendations categorized by priori
 The SEO section displays organic keyword performance with search volume and ranking data.
 
 ![Organic Keyword Ranking](./img/snapshot-report/organic-keywords-12957990148887.png)
+
+<div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '12px', background: 'rgba(60, 154, 99, 0.08)', border: '1px solid rgba(60, 154, 99, 0.35)', borderRadius: '8px', padding: '14px 18px', margin: '16px auto', width: 'fit-content', maxWidth: '100%', textAlign: 'center'}}>
+  <span style={{flexShrink: 0}}><GraduationCapIcon size={26} /></span>
+  <span style={{fontSize: '14px', color: 'var(--ifm-font-color-base)', textAlign: 'center'}}>
+    New to running the full sales motion? Take the <a href="/learn/growth-engine" style={{color: '#3C9A63', fontWeight: 600}}>Your growth engine</a> course in Vendasta Learn — Beginner, 6 lessons.
+  </span>
+</div>
 
 ---

--- a/docusaurus/training/growth-engine/run-your-first-snapshot.mdx
+++ b/docusaurus/training/growth-engine/run-your-first-snapshot.mdx
@@ -103,14 +103,14 @@ You are going to **Partner Center** → **Administration** → **Client Notifica
 
 The report grades eight parts of the business's online presence, each with a letter grade from A to F, rolled into an overall Digital Score:
 
-- **Business listings**: how accurately the business appears across online directories
-- **Reviews**: volume, ratings, frequency, and where they land
-- **Social media**: presence, followers, and posting rhythm
-- **Website performance**: speed and mobile experience, measured with Google's Core Web Vitals
-- **SEO**: how visible the business is in organic search
-- **Advertising**: online advertising presence against its industry's top keywords
-- **Ecommerce**: whether the business can sell, schedule, and take payment online
-- **AI optimization**: whether the business shows up when customers ask AI tools instead of search engines
+- **[Business listings](/snapshot-report/snapshot-report-listings-reviews#whats-included-with-business-listings-assessment)**: how accurately the business appears across online directories
+- **[Reviews](/snapshot-report/snapshot-report-listings-reviews#whats-included-with-reviews-assessment)**: volume, ratings, frequency, and where they land
+- **[Social media](/snapshot-report/snapshot-report-social-advertising#whats-included-with-social-media-assessment)**: presence, followers, and posting rhythm
+- **[Website performance](/snapshot-report/snapshot-report-website-seo#whats-included-with-website-performance-assessment)**: speed and mobile experience, measured with Google's Core Web Vitals
+- **[SEO](/snapshot-report/snapshot-report-website-seo#whats-included-with-seo-assessment)**: how visible the business is in organic search
+- **[Advertising](/snapshot-report/snapshot-report-social-advertising#whats-included-with-advertising-assessment)**: online advertising presence against its industry's top keywords
+- **[Ecommerce](/snapshot-report/snapshot-report-ecommerce-technology#whats-included-with-ecommerce-assessment)**: whether the business can sell, schedule, and take payment online
+- **[AI optimization](/snapshot-report/snapshot-report-ai-optimization)**: whether the business shows up when customers ask AI tools instead of search engines
 
 Every grade is a comparison against the business's own industry, which is what the primary category feeds. Northside Dental came back a B in reviews and a D in listings: patients love the clinic, and the directories cannot find it. A gap like that is where a sale begins.
 


### PR DESCRIPTION
## Summary
- Link the two published "Your growth engine" lessons out to the Partner Center docs they cover (account creation, CRM companies, and each of the 8 Snapshot Report grade sections)
- Add a "take the course" callout back to those same docs pointing to the course overview, matching the pattern from the AI foundations cross-linking work
- Fix the shared callout box style (also used by the earlier AI foundations callouts) so the icon and text sit centered as a compact pill instead of a left-aligned full-width strip

Steps 3-6 of the growth engine path are still content stubs, so there's nothing to cross-link there yet.

## Test plan
- [x] `npm run build` passes with no new broken links or anchors
- [x] Verified locally in dev server: lesson page inline links resolve, and callout boxes render centered on snapshot-report and related pages