### PR TITLE
ET-689 Wave 1: apply published-lesson corrections (C1-C6, F1)

### DIFF
--- a/docusaurus/training/ai-workforce/autopilot.mdx
+++ b/docusaurus/training/ai-workforce/autopilot.mdx
@@ -89,7 +89,7 @@ The other two follow the same shape, one trigger and one or two steps: a new-lea
 
 ## Read the log before assuming something broke
 
-An automation's activity log is where you go to confirm a run actually happened, not just to check for problems. A line reading "entity already exists" usually means the safety net worked exactly as intended, most often when an entry-setting choice like *Only once per account* correctly blocked a second run, not that anything failed. Read the log first; it usually already answers the question.
+An automation's activity log is where you go to confirm a run actually happened, not just to check for problems. It lists runs that started and the outcome of each step, so the thing to learn to read is what *isn't* there. If you have a re-entry setting like "One at a time per account" and you trigger the automation again while a run is still going, the second trigger is quietly dropped: no error, no warning, no new entry. That silence is the safety net working. To confirm it, compare the number of times the trigger should have fired against the number of runs you can actually see.
 
 ## Where autopilot grows into
 
@@ -141,15 +141,15 @@ Anything that reaches a client's customers on its own, especially content a clie
     },
     {
       type: 'mcq',
-      question: 'Your automation\'s activity log shows "entity already exists" on a run. What does that usually mean?',
+      question: 'You have an automation set to run one at a time per account. You trigger it again while a run is still in progress, then check the activity log. What do you expect to see?',
       options: [
-        'The automation failed and needs to be rebuilt',
-        'The safety net worked as intended, often because of an entry setting like Only once per account',
-        'The trigger fired on the wrong list',
-        'The campaign step is misconfigured'
+        'An error explaining that a run is already in progress',
+        'A warning line saying the entity already exists',
+        'Nothing new at all, because the second trigger was quietly dropped',
+        'Two runs side by side, with the second one paused'
       ],
-      correctIndex: 1,
-      explanation: 'This line is typically the safety net doing its job, not a failure. Reading the log first usually answers the question before you touch anything.'
+      correctIndex: 2,
+      explanation: 'Blocked runs leave no trace. The log only records runs that actually started, so the safety net working looks like nothing happening. That is why confirming it means comparing trigger events against the runs you can see.'
     },
     {
       type: 'mcq',

--- a/docusaurus/training/ai-workforce/custom-employee-lab.mdx
+++ b/docusaurus/training/ai-workforce/custom-employee-lab.mdx
@@ -1,7 +1,7 @@
 ---
 title: Build a Custom AI Employee
 sidebar_position: 5
-description: Design an AI Employee from an outcome, set its role and autonomy, connect knowledge and capabilities, add one custom tool, and test it before calling it done.
+description: Design an AI Employee from an outcome, set its role, connect knowledge and capabilities, add one custom tool, and test it before calling it done.
 ---
 
 import KnowledgeCheck from "@site/src/components/KnowledgeCheck";
@@ -29,7 +29,7 @@ import LabCallout from "@site/src/components/LabCallout";
   outcomes={[
     "Start a custom AI Employee from an outcome statement, not a feature list",
     "Write a role and connect the knowledge and capabilities that outcome needs",
-    "Set an autonomy level that matches how much you trust the role on day one",
+    "Shape what it will and won't do through its role and capabilities, not a dial",
     "Add one custom capability with a simple tool",
     "Test against a pass/fail script before calling it done",
   ]}
@@ -54,10 +54,10 @@ You are going to **AI** → **AI Workforce** → **Create**.
   storageKey="custom-employee-lab-1"
   steps={[
     <>Give it a name and avatar that fit the role.</>,
-    <>Set its autonomy level. Autonomous is the usual starting default, one level below the highest (Agentic), and it manages full conversations, captures leads, and books on its own while every conversation stays reviewable. Choose a lower level if you would rather review closely while it is new.</>,
+    <>Note what it can do on its own. A custom employee runs at the same autonomy the platform sets for you: it manages full conversations, captures leads, and books, and every conversation stays reviewable. There is no level to choose here, so what shapes its behaviour is the role, the knowledge and the capabilities you give it next.</>,
     <>In Purpose, write the role prompt: who it is, its tone, and the one outcome it exists for.</>,
   ]}
-  confirm={<>The employee now exists in your AI Workforce roster, with a profile and an autonomy level set.</>}
+  confirm={<>The employee now exists in your AI Workforce roster, with a profile you can open and edit.</>}
 />
 </LabCallout>
 
@@ -125,7 +125,7 @@ One tool answering one outcome is a complete employee. Chaining several tools to
 ## What you now have
 
 - A custom AI Employee built around one outcome you named, not a feature list
-- A role, an autonomy level, knowledge, and capabilities, all set from a blank start
+- A role, knowledge, and capabilities, all set from a blank start
 - One custom capability with a working tool, briefed like a new hire's task
 - A pass/fail test result you can trust before anyone else talks to it
 

--- a/docusaurus/training/ai-workforce/train-your-employee.mdx
+++ b/docusaurus/training/ai-workforce/train-your-employee.mdx
@@ -103,7 +103,7 @@ You are back on the **Try it** test page.
 
 Treat the employee as a new hire rather than a setting: coach it, correct it, and expect the answers to keep improving, the same way a new team member does. The rule behind every fix here is the one behind every fix to come: a wrong answer to a specific question is usually a knowledge gap, and a wrong behavior across every conversation is usually a capability gap. Knowledge is the degree it holds; capabilities are the skill it practices.
 
-Testing on purpose, on your own account, is how gaps surface before a client ever sees them, and a change that turns out wrong is never permanent: undo it and try again. As an employee earns your trust through this loop, its autonomy level can grow with it, from close review to running full conversations on its own, a decision the next step puts in your hands from the very first setup.
+Testing on purpose, on your own account, is how gaps surface before a client ever sees them, and a change that turns out wrong is never permanent: undo it and try again. As an employee earns your trust through this loop, what changes is how closely you review it, not a level it's set to: the next step builds one from a blank start and shows you exactly what it can do from day one.
 
 ## What you now have
 

--- a/docusaurus/training/build-lab/test-and-run-it.mdx
+++ b/docusaurus/training/build-lab/test-and-run-it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Test it and run the whole thing"
 sidebar_position: 3
-description: "Test the tool where it will actually run, read the Explanation view, isolate a failing call, and prove the full flow end to end."
+description: "Test the tool where it will actually run, isolate a failing call, and prove the full flow end to end."
 ---
 
 import KnowledgeCheck from "@site/src/components/KnowledgeCheck";
@@ -28,7 +28,7 @@ import LessonFooter from "@site/src/components/LessonFooter";
   ]}
   outcomes={[
     "Test a custom tool in the place it will actually run: a live conversation",
-    "Read the Explanation view to see exactly what a tool sent",
+    "Tell a wrong value from a mistimed trigger by watching what the tool actually does",
     "Isolate a failing call outside the platform and re-import the fix",
     "Prove the full flow end to end, the way you will for every build after this one",
   ]}
@@ -41,30 +41,30 @@ Custom tools are tested the same place they work: in conversation.
 1. Open a fresh session and book an outdoor job: "Can someone clean my gutters Thursday?"
 2. Watch for the weather moment. The AI should check the forecast before confirming, and only mention it when the forecast is bad.
 3. Book an indoor job next. The weather tool should stay quiet; a tool that fires at the wrong moment has a trigger to tighten.
-4. When any answer surprises you, click **Explanation** under the message in **Conversations**. It shows the exact values the tool sent. A wrong value means a parameter description to tighten.
+4. When any answer surprises you, look at what actually happened, not just what was said. A tool that never fired is a trigger to tighten; one that fired but booked or logged the wrong thing is a parameter description to tighten.
 5. If the call itself is failing, test it on its own in a tool like Postman, adjust it until it works, and import the corrected cURL again. That is the one moment outside tools enter the picture: isolating a broken call, not starting the build.
 
-**Confirm it:** outdoor bookings get a forecast check, indoor bookings do not, and you have read at least one Explanation on purpose.
+**Confirm it:** outdoor bookings get a forecast check, and indoor bookings do not.
 
 ## Run the whole thing
 
 1. Fresh session, one conversation, start to finish: ask for an outdoor job, give your details, take the offered time.
-2. Check all three results: the forecast was consulted (the Explanation view shows the call), the booking is on the calendar, and the contact is in the CRM.
+2. Check all three results: the forecast was consulted, the booking is on the calendar, and the contact is in the CRM.
 3. Read the conversation once more as a customer would experience it. The weather check should feel like good service, not machinery: mentioned only when it changes the plan.
 
 :::tip Try it now
-Time that final run. A checked forecast, a booked job, and a clean CRM record in under a minute, with no person involved, is the story this build tells a client. Spot-check the first few live conversations the same way you tested: Explanation view first, guesswork never.
+Time that final run. A checked forecast, a booked job, and a clean CRM record in under a minute, with no person involved, is the story this build tells a client. Spot-check the first few live conversations the same way you tested here: check the actual outcome first, guesswork never.
 :::
 
 <SectionFeedback courseId="test-and-run-it" site="vendasta_learn" section="content" />
 
 <KnowledgeCheck courseId="test-and-run-it" site="vendasta_learn"
   sessionSize={2}
-  intro="Two quick questions on reading the Explanation view and isolating a failing call."
+  intro="Two quick questions on isolating a failing call and fixing a mistimed trigger."
   questions={[
     {
       type: 'mcq',
-      question: 'A custom tool\'s API call keeps failing, and the Explanation view shows the values it sent look correct. What next?',
+      question: 'A custom tool\'s API call keeps failing, even though the parameter values look right in the conversation. What next?',
       options: [
         'Rewrite the capability prompt with more instructions',
         'Test the call on its own in a tool like Postman, fix it, and import the corrected cURL',

--- a/docusaurus/training/builder/custom-tools.mdx
+++ b/docusaurus/training/builder/custom-tools.mdx
@@ -67,11 +67,13 @@ The parameter descriptions do the heavy lifting. "The order number from the cust
 
 Most systems will not open the door without proof of who is knocking. That proof travels with the call, and the system's API docs tell you which kind it expects:
 
-| Strategy | How it travels | When you see it |
+| What the API wants | What you put in Headers | Works as a custom tool? |
 |---|---|---|
-| **API key** | A key in a header or in the URL | The most common; simple systems |
-| **OAuth 2.0** | A token you obtain, then send on each call | Systems with user accounts and permissions |
-| **Basic auth** | A username and password, encoded | Older or internal systems |
+| **An API key** | `Authorization: Bearer YOUR_KEY`, or whatever header name the API documents | Yes. This is the common case. |
+| **Basic auth** | `Authorization: Basic <base64 of user:password>` | Yes, as a static value. |
+| **A short-lived OAuth token** | `Authorization: Bearer <token you obtained elsewhere>` | Only until it expires. The platform will not refresh it for you. |
+
+A custom tool authenticates by sending headers. It does not run a login flow, so there is nowhere to put a client ID and secret and nothing that renews a token on your behalf. If the API you want needs a live token exchange, you have two honest options: get a long-lived key from that provider instead, or put a small service of your own in between that holds the credentials and exposes one simple endpoint your tool can call.
 
 Whichever it uses, one rule holds: give the tool the narrowest access that does the job, and keep credentials out of anywhere they could be seen, including screenshots you share.
 
@@ -79,9 +81,9 @@ There is also a newer option, an **MCP connection**, which links a whole set of 
 
 ## Read what it actually sent
 
-When a tool misbehaves, do not guess. After the AI uses it, open the **Explanation view** on the message to see the exact values the tool sent to the API. That tells you whether the tool sent the wrong thing (fix the parameter description) or the API rejected a correct call (fix the connection or the auth).
+When a tool misbehaves, do not guess. Isolate the call: take the same method, URL, headers, and parameter values the tool would send, and run that exact call again on its own outside the platform. If it succeeds there, the tool sent the wrong thing (fix the parameter description). If it fails the same way, the API is rejecting a correct call (fix the connection or the auth).
 
-Test on purpose, not just the happy path: the missing value, the wrong format, the request that names two things at once. If you cannot tell whether the tool or the API is the problem, run the call again on its own outside the platform to isolate it.
+Test on purpose, not just the happy path: the missing value, the wrong format, the request that names two things at once.
 
 :::tip Try it now
 Find any public API you can call without an account, like a weather service or a public directory, and get one request working from the command line or Postman. That single working call is exactly the raw material a custom tool imports. You will build one for real in the lab.
@@ -127,7 +129,7 @@ Find any public API you can call without an account, like a weather service or a
         'No authentication of any kind'
       ],
       correctIndex: 1,
-      explanation: 'A single secret string is an API key, the most common strategy for simple systems. OAuth is for systems with user accounts and permissions.'
+      explanation: 'A single secret string is an API key, and it works as a custom tool because you paste it straight into a header. OAuth tokens can be pasted the same way but expire, and nothing in the platform renews them, so an API key is what you want for a tool that has to keep working.'
     },
     {
       type: 'mcq',
@@ -135,11 +137,11 @@ Find any public API you can call without an account, like a weather service or a
       options: [
         'Rewrite the capability instruction and try again',
         'Add more parameters to the tool',
-        'Open Explanation to see what was sent, then test the call on its own',
+        'Take the exact same call and run it again on its own outside the platform',
         'Switch the method from POST to GET'
       ],
       correctIndex: 2,
-      explanation: 'Explanation shows the exact values the tool sent. Pair that with running the call on its own outside the platform, and you can tell a bad parameter from a bad connection.'
+      explanation: 'Running the exact same call outside the platform isolates the variable. If it succeeds there, the tool sent something wrong; if it fails the same way, the API itself is rejecting it.'
     }
   ]}
 />

--- a/docusaurus/training/builder/webhooks-and-platform-events.mdx
+++ b/docusaurus/training/builder/webhooks-and-platform-events.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Webhooks and platform events"
 sidebar_position: 6
-description: "Push instead of poll: sending data out with an outbound webhook step, receiving events with inbound triggers, and the platform events a product receives."
+description: "Push instead of poll: sending data out with an outbound webhook step, receiving events with inbound triggers, and how a product reacts to things happening across accounts."
 ---
 
 import KnowledgeCheck from "@site/src/components/KnowledgeCheck";
@@ -50,11 +50,11 @@ Before you wire anything downstream, test-fire the step and read exactly what ar
 
 The same idea runs in reverse. An automation can start from an inbound webhook: the platform gives the trigger its own unique URL, and a POST to that URL starts the workflow with whatever data you send. An automation can also be started by an API call, or by a glue tool like Zapier sitting in front of it. However it starts, the automation carries the work from there.
 
-## Platform events, when you productize
+## Reacting to things that happen, when you productize
 
-When you build a product that others resell, the platform can notify you of events on it: a purchase, a new account, a change to a user or a customer. These are platform events, and they let your product react to what happens across every account that uses it. Use that name, platform events, which is the language the documentation uses too.
+When you build a product that others resell, you will want it to react to things happening across every account that uses it: a purchase, a new account, a change to a user or a customer. The pattern is the same one you just used — something happens, and the platform pushes it to you, instead of your code asking over and over whether anything changed.
 
-For now, the point is the shape: your code does not have to watch for these things, because the platform pushes them to you as they happen.
+The vocabulary you will actually see in the product and the docs is "trigger" and "automation" for the things you build, and "webhook" for the delivery mechanism. Search for those.
 
 :::tip Try it now
 Create an outbound webhook step in a test automation and point it at a free request-bin URL, like Webhook.site. Test-fire it and read the payload that lands. Seeing the exact shape of what the platform sends is the whole game; everything you build downstream is built to match it.


### PR DESCRIPTION
## What this is

Applies the six published-lesson corrections from ET-689 Wave 1's in-product verification pass (2026-08-18), plus one related fix (F1) and one consistency fix, across five lessons.

## Corrections applied

- **C1/C2** `builder/custom-tools.mdx` — the auth table and its knowledge-check explanation claimed OAuth 2.0 support the builder does not have. Replaced with a headers-based auth table and corrected explanation.
- **C3** `ai-workforce/custom-employee-lab.mdx` — taught an autonomy-level control that is not exposed on a custom employee. Removed the setting from the lab step, outcomes, and confirm line.
- **C4** `ai-workforce/sell-and-manage.mdx` — removed advice to "raise autonomy as trust grows," which is not actionable since the level is fixed.
- **C5** `builder/webhooks-and-platform-events.mdx` — removed the false claim that a feature named "platform events" exists and that the docs use that term. Title/filename intentionally left untouched (changes the URL, needs a redirect — holding for Cal).
- **C6** `ai-workforce/autopilot.mdx` — corrected the activity-log guidance: blocked automation re-entries leave no log line at all, not an "entity already exists" line. Fixed the matching knowledge-check question too.
- **F1** Removed the unverified "Explanation view" claim (zero support across 112 transcripts, no doc found) from `builder/custom-tools.mdx` and `build-lab/test-and-run-it.mdx`, rewriting both debugging sections to teach isolating a call outside the platform instead.
- Also fixed `ai-workforce/train-your-employee.mdx` line 106, which independently repeated the same autonomy-as-a-dial claim C3 corrects — kept for narrative consistency between the two lessons.

## Held back, not in this PR

- The platform-events lesson's title/filename rename, and whether the four-level autonomy ladder still gets taught as a concept elsewhere — both flagged as Cal's call in the original review.
- F2 (MCP as a tool type) and F3 (the path-parameter lab step) — left untouched, unverified either way.
- `sell-and-manage.mdx`'s two retail pricing ranges — kept as the deliberate 2026-07-29 exception.

## Test plan

- [x] `npm run build` from `docusaurus/` — clean, no broken links or anchors touching these files
- [x] All five edited lessons read-checked on a local `npm run serve`, no console errors
