### PR TITLE
Docs: bulk import notes for name field split and value matching (CRMAAS-3091)

### DIFF
--- a/docusaurus/docs/crm/contacts/index.mdx
+++ b/docusaurus/docs/crm/contacts/index.mdx
@@ -65,6 +65,7 @@ Before initiating an import:
 - **Company name (first-row rule)**: In Partner Center imports, company name must be populated on the **first** contact row. It does not need to appear on every subsequent row — but the first row requires it or the import will fail with "Company name is required."
 - **Business categories**: If your CSV includes a business category, select it from the dropdown during field mapping — do not type it as free text. Free-text categories do not map to the CRM's category list and will silently break downstream syncing.
 - **No blank rows**: Blank rows in your CSV cause "No company or contact found" errors. Remove all empty rows before importing.
+- **Name columns**: Contact names are stored as separate **First name** and **Last name** fields, not a single combined name field. A CSV with one "Name" column can't be mapped — split it into two columns before importing.
 - **Import limits**: Maximum file size is 5 MB, which typically allows for up to 35,000 contacts per import
 - Prepare your data with unique identifiers for bulk updates (Contact ID, External ID, or email)
 
@@ -132,6 +133,10 @@ Users will only see the imports their user has actioned.
 - For each column, choose whether it relates to a contact or company, then select the specific CRM field to map it to. Once you've completed the mapping, click `Next`
 
 ![Field Mapping Interface](./img/crm/contacts/field-mapping.jpg)
+
+:::info
+Values mapped to a field with predefined options (like Lifecycle stage) or to Tags are automatically matched to the closest defined option regardless of case, so a CSV value like "lead" matches a "Lead" option.
+:::
 
 **Step 3: Review import**
 


### PR DESCRIPTION
## JIRA

[CRMAAS-3091](https://vendasta.jira.com/browse/CRMAAS-3091)

## Classification

- **Type:** UI / UX change (bulk import flow adds explanatory copy) + feature behavior change (field option/tag matching)
- **Product impacted:** Partner Center (this PR) — the same underlying CRM import behavior also affects Business App, so a companion PR is being opened there

## Summary of documentation updates

Updated the existing **CRM → Contacts** article's import section (`docusaurus/docs/crm/contacts/index.mdx`) with two additions:

1. A new bullet under "Before you begin" explaining that contact names are stored as separate **First name** and **Last name** fields, so a CSV with a single "Name" column can't be mapped and needs to be split into two columns first.
2. A new `:::info` callout after the field-mapping step explaining that values mapped to fields with predefined options (e.g. Lifecycle stage) or to Tags are automatically matched to the closest defined option regardless of case.

## Existing docs updated vs. new docs created

Updated existing documentation only — no new pages created. The Contacts article already documents the full CSV import flow ("Before you begin" and "Step 2: Map fields"), so the new guidance fits directly into those existing sections.

## Placement reasoning

The Contacts article (`docs/crm/contacts/index.mdx`) is the canonical page for the CRM bulk import flow used from Partner Center. The name-field note was added to "Before you begin" alongside the other pre-import requirements (company name rule, blank rows, business categories); the value-matching note was added right after the field-mapping step where a user would map Lifecycle stage/Tags columns.

## Acceptance criteria coverage

- ✅ "The bulk import flow shows a note that contact names are stored as two fields... and that the CSV needs them as separate columns" → covered by the new "Before you begin" bullet.
- ✅ "We will auto convert the import value to match with the field options defined" → covered by the new `:::info` callout describing case-insensitive matching for field options and tags.

## Figma / images

None provided or used. This ticket's Loom link documents behavior, not new UI, so no visual assets were needed for the text-only additions.

## Skills used

None of the repo's authoring skills apply directly to a small existing-page edit; changes were made by hand following the repo's existing markdown/callout conventions (`CLAUDE.md`).

## Assumptions and limitations

- This story has no linked epic in JIRA and no gating/rollout tickets to check. The story's own status is Done with 4 merged PRs and 3/3 successful builds, so it was treated as shipped.
- The reviewer was selected as the ticket's assignee (Anshika Saini), matched to a GitHub collaborator on this repo via naming convention (`asaini-lang`), since no GitHub PRs were linked directly on the JIRA issue.

@ahnikakuse @haleyserrano @maryam6samadi

---
_Generated by [Claude Code](https://claude.ai/code/session_016HLXF7RJgS6nVNvPngpQFc)_

[CRMAAS-3091]: https://vendasta.jira.com/browse/CRMAAS-3091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ