### PR TITLE
docs: article verifications 2026-08-20

### DIFF
--- a/.claude/skills/article-verifications/SKILL.md
+++ b/.claude/skills/article-verifications/SKILL.md
@@ -78,13 +78,23 @@ grep -n "^#" docusaurus/docs/accounts/connect-profile.md
 
 ### Step 4b: Check inbound anchors
 
-A link pointing *into* one of today's flagged articles can go stale the moment you rename or remove a heading in it during this verification — and nothing else will ever check that. For each flagged article, search the rest of the repo for anything that links to it:
+A link pointing *into* one of today's flagged articles can go stale the moment you rename or remove a heading in it during this verification — and nothing else will ever check that. This step only exists to catch damage from *today's own edits*, so scope it accordingly:
+
+**Skip this step entirely for any flagged article whose headings you did not add, rename, or remove in Step 5/7.** No heading change means no inbound anchor could have broken today — re-scanning the repo for it is redundant work with no new information. Note in the Link check section that inbound anchors were not re-checked because no headings changed.
+
+For articles that did have heading changes, batch the repo scan into a single pass instead of one grep per article — search for all such articles' filenames at once:
 
 ```bash
-grep -rln "article-filename-without-extension" docusaurus/docs
+grep -rlE "article-one-filename|article-two-filename" docusaurus/docs
 ```
 
-For every hit found outside today's batch, open it and check any `#anchor` fragment on that inbound link against the flagged article's current headings (after your Step 5/7 edits are applied), using the same slugify check as Step 4. Flag any inbound link whose anchor no longer resolves — this is a broken link on a page you weren't otherwise going to touch, so it needs its own **Pending approval** item (propose fixing the anchor or the surrounding text on the linking page, scoped narrowly to that link).
+Then, for each hit found outside today's batch, filter to only the lines that actually contain a `#anchor` fragment on the link before opening anything — a plain file-level link with no fragment cannot be broken by a heading rename:
+
+```bash
+grep -n "article-filename-without-extension#" path/to/hit.mdx
+```
+
+For each remaining hit, open it and check the `#anchor` fragment against the affected article's current headings, using the same slugify check as Step 4. Flag any inbound link whose anchor no longer resolves — this is a broken link on a page you weren't otherwise going to touch, so it needs its own **Pending approval** item (propose fixing the anchor or the surrounding text on the linking page, scoped narrowly to that link).
 
 This is how a self-referential loop gets caught: Page A defers to Page B for a topic's details ("see Page B for details") while Page B has no content on that topic and defers back to Page A. Anchor resolution surfaces the symptom (a dead fragment) even when the underlying cause (missing content, circular deferral) needs a human judgment call — flag it as a **Needs SME Review** item rather than guessing where the content should live.
 
@@ -104,52 +114,52 @@ After outputting the report, apply all auto-fixable issues using the Edit tool. 
 
 After auto-fixes are applied, check whether any articles have items listed under **Pending approval**. If none, skip this step.
 
-Work through pending items **one article at a time**, in the order they appeared in the report.
+**Collapse duplicates first.** If the exact same issue (e.g. the same prohibited term, the same tone problem) appears at multiple locations in the same article with the same proposed fix, treat it as **one** pending item covering every location, not one item per occurrence. List all affected lines in that single item's **Location** field. This is what keeps a repeated issue from turning into repeated near-identical prompts.
 
-**Opening:** Announce how many articles have pending items and that you're starting the review:
+**Batch into groups of up to 4.** `AskUserQuestion` accepts up to 4 questions per call. Collect all pending items across all articles into a single ordered queue (article order, then report order within each article), then work through the queue in batches of up to 4 items per `AskUserQuestion` call — never one call per item. A typical day's batch (5 articles, a handful of pending items each) usually fits in 1-3 calls total, not one per item.
 
-> "Auto-fixes are applied. Now let's go through the [N] items that need your input — I'll take them one at a time."
+**Opening:** Announce how many total items need input and roughly how many rounds that will take:
+
+> "Auto-fixes are applied. [N] items need your input across [M] articles — I'll go through them in [K] batch(es)."
 
 ---
 
-**For each article with pending items**, announce the article first, including a clickable markdown link to the file so the user can open it if they want to see the full context:
-
-> "**[Article title]** ([path/to/file.mdx](path/to/file.mdx)) — [N] item(s) need your input."
-
-**For each individual pending item**, output the context block as plain text first — before calling AskUserQuestion. Do not put this content inside the option descriptions. Always include the filename as a clickable link so the user can jump to the file:
+**For each batch**, output the context block for every item in that batch as plain text first — before calling AskUserQuestion. Do not put this content inside the option descriptions. Group the text blocks by article with the article name and a clickable link as a sub-heading, so the user can see which file each item belongs to:
 
 ```
+**[Article title]** ([path/to/file.mdx](path/to/file.mdx))
+
 **Issue:** [One plain sentence — no jargon — describing what was found and why it matters]
 **Location:** Line [N] in [filename](path/to/file.mdx)
 **Current:** "[exact text as it appears in the file]"
 **Proposed:** "[exact replacement text]"
 ```
 
-Output that block as text, then immediately call AskUserQuestion with:
-- Question: `Apply this change?`
+Then make **one** AskUserQuestion call containing one question entry per item in the batch (up to 4). Make each item's `question` text unique (e.g. include the file and line, like `Apply this change? [file.mdx:24]`) so answers don't collide when matched back up — the tool returns answers keyed by question text. For the standard case, each entry uses:
+- Question: `Apply this change? [file.mdx:line]`
 - Option 1: `Yes — apply it`
 - Option 2: `No — skip it`
 
-Keep the option descriptions brief (one short sentence max) — all the detail the user needs is in the text block above. Do not repeat the Issue/Current/Proposed content inside the option descriptions.
+Keep the option descriptions brief (one short sentence max) — all the detail the user needs is in the text blocks above. Do not repeat the Issue/Current/Proposed content inside the option descriptions.
 
-The question automatically includes an "Other" free-text field. If the user types their own version there, apply their text instead of the proposed change — do not apply the original proposed text.
+Each question automatically includes an "Other" free-text field. If the user types their own version there, apply their text instead of the proposed change — do not apply the original proposed text.
 
-Apply, apply-custom, or skip based on the response, then immediately move to the next item.
+Apply, apply-custom, or skip each item based on its answer, then move to the next batch. If a collapsed duplicate item is approved, apply the fix at every location it covers.
 
 ---
 
-**Special cases — use these instead of the standard format when the item doesn't have an obvious proposed change. As with the standard format, output the context block as text first, then call AskUserQuestion:**
+**Special cases — mix these into the same batches as standard items (still up to 4 questions per call total). As with the standard format, output every item's context block as text first, then call AskUserQuestion once for the whole batch:**
 
 **Prohibited term with no obvious replacement:**
 
 ```
 **Issue:** "[term]" is a prohibited term — it should not appear in partner-facing documentation.
-**Location:** Line [N]
+**Location:** Line [N] (and any other lines with the same term/fix — see Collapse duplicates above)
 **Current:** "[exact sentence]"
 **Question:** What should this say instead?
 ```
 
-Use AskUserQuestion with options tailored to the context, e.g.:
+Use an AskUserQuestion entry with options tailored to the context, e.g.:
 - `Remove the sentence entirely`
 - `Replace "[term]" with "[suggested alternative]"`
 - `Leave it for now — I'll handle this manually`
@@ -163,7 +173,7 @@ Use AskUserQuestion with options tailored to the context, e.g.:
 **Note:** This changes the article's URL. Check for any existing inbound links to the old URL before confirming.
 ```
 
-Use AskUserQuestion:
+Use an AskUserQuestion entry with:
 - `Yes — rename the file`
 - `No — leave the filename as-is`
 
@@ -176,15 +186,13 @@ Use AskUserQuestion:
 **This needs an SME to verify** — I can't propose a safe change here without product confirmation.
 ```
 
-Use AskUserQuestion:
+Use an AskUserQuestion entry with:
 - `Flag it with an inline comment for SME follow-up`
 - `Leave it as-is — I'll handle it separately`
 
 ---
 
-**After all items for an article are complete**, move straight to the next article without a summary — keep momentum going.
-
-**After all articles are complete**, if any articles had items in their **Needs verification** section, print a compact checklist before the closing summary:
+**After all batches are complete**, if any articles had items in their **Needs verification** section, print a compact checklist before the closing summary:
 
 > **Before creating your PR, verify these manually in the live product:**
 > - [Article title]: [the specific thing to check]

--- a/docusaurus/docs/administration/commerce/default-billing-settings/index.mdx
+++ b/docusaurus/docs/administration/commerce/default-billing-settings/index.mdx
@@ -7,19 +7,17 @@ tags: [billing, automation, subscriptions, configuration]
 keywords: [billing-automation, default-settings, recurring-billing, invoice-automation, collection-methods]
 ---
 
-# Default Billing Settings
-
 Default billing automation applies your chosen billing settings to every new account you create. You set collection method and timing once; new accounts get those settings automatically. Existing accounts are unchanged.
 
 ## What it is
 
-Billing automation creates and sends invoices or charges saved payment methods for recurring subscriptions. Default settings in **Administration** → **Default Billing Settings** apply to all new accounts so you don’t configure billing for each account manually.
+Billing automation creates and sends invoices or charges saved payment methods for recurring subscriptions. Default settings in `Administration` → `Default Billing Settings` apply to all new accounts so you don’t configure billing for each account manually.
 
 ## Why it matters
 
 - **Less manual work** – New accounts get your preferred billing method and schedule automatically
 - **Consistency** – Same billing practices across new customers
-- **Flexibility** – Override any account’s billing under **Accounts** → **Manage Accounts** → account → **Products**
+- **Flexibility** – Override any account's billing under `Accounts` → `Manage Accounts` → account → `Products`
 
 ## What you can configure
 
@@ -31,15 +29,15 @@ Defaults apply only to accounts created **after** you save. Existing accounts ke
 
 ## How to configure default billing
 
-1. Go to **Partner Center** → **Administration** → **Default Billing Settings**
-2. Select a **Market** if you use multiple markets
-3. Turn the toggle **On** (default is Off)
-4. Set **Collection method** (how you collect: auto charge vs invoice) and **Collect on** (day or days)
-5. Review the summary and click **Save**
+1. Go to `Partner Center` → `Administration` → `Default Billing Settings`
+2. Select a `Market` if you use multiple markets
+3. Turn the toggle `On` (default is `Off`)
+4. Set `Collection method` (how you collect: auto charge vs invoice) and `Collect on` (day or days)
+5. Review the summary and click `Save`
 
 ![Default billing settings configuration page](./img/administration/default-billing-settings/default-billing-settings.png)
 
-New accounts will get these settings in their **Billing** configuration automatically.
+New accounts will get these settings in their `Billing` configuration automatically.
 
 :::warning
 Default billing settings do not change existing accounts. Only accounts created after you save will use these defaults.
@@ -49,9 +47,9 @@ Default billing settings do not change existing accounts. Only accounts created 
 
 You can change billing for any account at any time:
 
-1. Go to **Partner Center** → **Accounts** → **Manage Accounts**
+1. Go to `Partner Center` → `Accounts` → `Manage Accounts`
 2. Open the account
-3. Open the **Products** section and adjust **Billing** settings for that account
+3. Open the `Products` section and adjust `Billing` settings for that account
 
 For more on per-account billing, see [Subscription management](/commerce/subscriptions/subscription-management).
 
@@ -81,7 +79,7 @@ No. They apply only to accounts created after you save. Existing accounts keep t
 <details>
 <summary>Can I change billing for one account after applying defaults?</summary>
 
-Yes. Go to **Accounts** → **Manage Accounts** → account → **Products** and change that account’s billing settings.
+Yes. Go to `Accounts` → `Manage Accounts` → account → `Products` and change that account's billing settings.
 </details>
 
 <details>
@@ -105,18 +103,18 @@ You can use automatic credit card charging, invoice generation for manual paymen
 <details>
 <summary>Can I turn off default billing automation later?</summary>
 
-Yes. Go to **Default Billing Settings**, set the toggle to **Off**, and save. New accounts will no longer get defaults; existing accounts are unchanged.
+Yes. Go to `Default Billing Settings`, set the toggle to `Off`, and save. New accounts will no longer get defaults; existing accounts are unchanged.
 </details>
 
 <details>
-<summary>My customers are receiving unexpected invoice emails — how do I stop this?</summary>
+<summary>My customers are receiving unexpected invoice emails: how do I stop this?</summary>
 
 This happens when billing automation is enabled and set to email invoices to customers. To stop invoice emails from being sent:
 
-1. Go to **Partner Center** → **Administration** → **Default Billing Settings** and check whether billing automation is turned **On**
-2. If it is On, also check the Account Level Setting for the affected account — account-level settings override the default
-3. Change the collection method to **Don't bill, just track revenue** to stop invoices from being sent to customers
+1. Go to `Partner Center` → `Administration` → `Default Billing Settings` and check whether billing automation is turned `On`
+2. If it is On, also check the Account Level Setting for the affected account, since account-level settings override the default
+3. Change the collection method to `Don't bill, just track revenue` to stop invoices from being sent to customers
 
-Account-level settings can be found under **Partner Center** → **Accounts** → **Manage Accounts** → select the account → **Products** → **Billing Settings**.
+Account-level settings can be found under `Partner Center` → `Accounts` → `Manage Accounts` → select the account → `Products` → `Billing Settings`.
 
 </details>

--- a/docusaurus/docs/administration/platform-settings/customize/market-settings.md
+++ b/docusaurus/docs/administration/platform-settings/customize/market-settings.md
@@ -6,15 +6,13 @@ tags: [markets, early-access, business-priorities, advanced-configuration]
 keywords: [market-configuration, market-management, early-access-program, business-priorities, marketplace-vendor-control]
 ---
 
-# Markets and Advanced Configuration
-
 This comprehensive guide covers market configuration, advanced platform settings, and specialized features including Early Access Program enrollment, business priorities customization, and marketplace vendor controls.
 
-## What are Markets and Advanced Configuration Settings?
+## What are Markets and advanced configuration settings?
 
 Markets and advanced configuration settings help you organize your business structure, customize market-specific branding and settings, access new features early, and configure specialized business workflows. These settings include market segmentation, branding customization, feature preview programs, and business priority management.
 
-## Why are Markets and Advanced Configuration Important?
+## Why are Markets and advanced configuration important?
 
 - **Business Organization**: Segment your business by region, brand, industry, or custom criteria
 - **Market-Specific Branding**: Customize logos, colors, and experiences for different markets
@@ -22,21 +20,21 @@ Markets and advanced configuration settings help you organize your business stru
 - **Business Alignment**: Configure settings to match your business priorities and workflows
 - **Scalability**: Set up systems that grow with your business and maintain centralized oversight
 
-## What's Included with Markets and Advanced Configuration?
+## What's included with Markets and advanced configuration?
 
-### Market Organization and Structure
+### Market organization and structure
 - **Account assignment**: All new accounts must be assigned to a specific market
 - **Market segmentation**: Organize by brand, region, industry, or custom criteria
 - **Centralized management**: Maintain oversight across all markets from one platform
 - **Scalable structure**: Add new markets as your business grows
 
-### Market-Specific Branding
+### Market-specific branding
 - **Custom logos**: Upload different logos for each market
 - **Color schemes**: Set unique color palettes per market
 - **Product naming**: Customize product names for different markets
 - **Login portals**: Branded experiences for market-specific users
 
-### Market-Level Configuration
+### Market-level configuration
 - **Individual settings**: Configure features and restrictions per market
 - **Permission inheritance**: Markets inherit default settings but can be customized
 - **Sales order settings**: Market-specific sales processes and configurations
@@ -46,18 +44,18 @@ Markets and advanced configuration settings help you organize your business stru
 Markets are only available on certain subscription tiers. Contact your account representative or support to activate Markets for your platform or add additional markets.
 :::
 
-## How to Understand Market Structure
+## How to understand market structure
 
-### Market Organization Principles
+### Market organization principles
 
-#### Account Assignment Process
+#### Account assignment process
 When Markets are activated on your platform:
 - **Required assignment**: Each new account must be assigned to a market during creation
 - **Dropdown selection**: A market dropdown appears in the Account Create form
 - **Default market**: One market represents your company as a whole
 - **Additional markets**: Used for segmentation by region, brand, or other criteria
 
-#### User Access and Permissions
+#### User access and permissions
 Different user types interact with markets differently:
 
 **Business App Users**:
@@ -72,22 +70,22 @@ Different user types interact with markets differently:
 - New accounts automatically created under their assigned market
 - Must be assigned to a market (required for salespeople created before Markets activation)
 
-### URL and Portal Management
+### URL and portal management
 - **Consistent URLs**: Portal URLs remain consistent with your original setup
 - **Custom domains**: Per-market custom domains are currently unavailable
 - **Login branding**: Pre-login portals display your white-label branding
 - **Market switching**: Branding updates dynamically based on selected accounts
 
-## How to Configure Market-Specific Branding
+## How to configure market-specific branding
 
-### Access Market Branding Settings
+### Access market branding settings
 
 To customize branding for individual markets:
 
-1. Navigate to `Administration` > `Partner Branding`
+1. Navigate to `Administration` → `Partner Branding`
 2. Use the dropdown in the top-right corner to select:
-   - **All Markets**: Apply branding to all markets
-   - **Individual Market**: Customize specific market branding
+   - `All Markets`: Apply branding to all markets
+   - `Individual Market`: Customize specific market branding
 3. Configure logos, colors, and visual elements
 4. Save changes for the selected market scope
 
@@ -95,72 +93,72 @@ To customize branding for individual markets:
 
 ![Market selection dropdown](./img/markets-overview/11939932669719.png)
 
-### Branding Inheritance and Customization
+### Branding inheritance and customization
 - **Default branding**: Branding created before Markets activation becomes the default for new markets
 - **Individual customization**: Each market can have unique visual identity
 - **Inheritance model**: New markets inherit default settings but can be modified
 - **Consistent elements**: Maintain brand consistency across markets while allowing differentiation
 
-## How to Manage Market Settings and Configuration
+## How to manage market settings and configuration
 
-### Configure Market-Specific Features
+### Configure market-specific features
 
 Each market can have its own configuration for various features:
 
-#### Sales Order Settings Configuration
+#### Sales order settings configuration
 Markets can have customized sales processes:
 - **Individual sales processes**: Configure unique workflows per market
 - **Order restrictions**: Set market-specific product and sales limitations
 - **Process customization**: Tailor sales workflows to market requirements
 - **Permission variations**: Different access levels and capabilities per market
 
-#### Beta Program and Feature Management
+#### Beta program and feature management
 - **Market-level beta access**: Enable or disable beta features per market
 - **Independent settings**: Beta program participation separate from partner-level settings
 - **Feature rollouts**: Test new features in specific markets before wider deployment
 - **Controlled access**: Manage feature availability based on market readiness
 
-### Restore Market Settings to Defaults
+### Restore market settings to defaults
 
 If you need to reset market-specific configurations:
 
-1. Go to `Administration` > `Customize`
-2. Click **Markets**
+1. Go to `Administration` → `Customize`
+2. Click `Markets`
 3. Click the edit icon next to the market you want to restore
-4. Navigate to **Sales** > **Configure Orders and Sales Processes**
-5. Scroll to the bottom and click **Restore Back to Partner Defaults**
+4. Navigate to `Sales` → `Configure Orders and Sales Processes`
+5. Scroll to the bottom and click `Restore Back to Partner Defaults`
 
 ![edit icon](./img/restore-market-settings/edit-icon.png)
 
 :::info
-The "Restore Back to Partner Defaults" option only appears if you've previously configured market-specific sales order settings. This ensures you don't accidentally reset markets that are using default configurations.
+The `Restore Back to Partner Defaults` option only appears if you've previously configured market-specific sales order settings. This ensures you don't accidentally reset markets that are using default configurations.
 :::
 
-## How to Configure Market-Based Reporting Limits
+## How to configure market-based reporting limits
 
-### Set Market-Specific Snapshot Report Limits
+### Set market-specific Snapshot Report limits
 
 While there's no direct market-wide snapshot limit, you can control reporting per market by configuring salesperson limits within each market:
 
-1. Navigate to `Administration` > `Customize` > `Sales`
+1. Navigate to `Administration` → `Customize` → `Sales`
 2. Switch to the specific market you want to configure
-3. Check the **Limit monthly Snapshot Reports** checkbox
-4. Set the **Snapshot creation limit** for salespeople in that market
+3. Check the `Limit monthly Snapshot Reports` checkbox
+4. Set the `Snapshot creation limit` for salespeople in that market
 5. Save the configuration
 
 ![Limit monthly snapshot report checkbox](./img/administration/customize/limit-snapshot-report-1.jpg)
 
 ![Snapshot creation limit setting](./img/administration/customize/limit-snapshot-report-2.jpg)
 
-### Understanding Market Report Limits
+### Understanding market report limits
 - **Combined limits**: If multiple salespeople work in a market, the limit is the total maximum all salespeople can create combined
 - **Market-specific**: Each market can have different reporting limits
 - **Individual tracking**: Each salesperson's usage is tracked separately within the market total
 - **Monthly reset**: All limits reset monthly regardless of market configuration
 
-## How to Add and Manage Markets
+## How to add and manage Markets
 
-### Adding New Markets
+### Adding new Markets
 To expand your market structure:
 - **Contact support**: Reach out to your account representative or Support On Demand
 - **Define purpose**: Clearly identify how the new market will be used
@@ -173,19 +171,19 @@ Disabling a market removes it from active use but does not delete it. Accounts a
 
 ### Reactivating a market
 
-A previously disabled or cancelled market can be reactivated. Before requesting reactivation, check with your Vendasta account manager — reactivating a cancelled market may incur an additional cost depending on your contract. To reactivate a market, contact [Vendasta Support](https://support.vendasta.com) with the market name and your account details.
+A previously disabled or cancelled market can be reactivated. Before requesting reactivation, check with your Vendasta account manager, since reactivating a cancelled market may incur an additional cost depending on your contract. To reactivate a market, contact [Vendasta Support](https://support.vendasta.com) with the market name and your account details.
 
 ### Renaming a market
 
 Market names can be changed at any time. Contact [Vendasta Support](https://support.vendasta.com) with the current name, the new name, and your account details.
 
-### Market Management Best Practices
+### Market management best practices
 - **Clear naming**: Use descriptive market names that reflect their purpose
 - **Consistent organization**: Establish clear criteria for account assignment
 - **Regular review**: Periodically assess market structure effectiveness
 - **User training**: Ensure team members understand market assignments and implications
 
-## How to Join the Early Access Program
+## How to join the Early Access Program
 
 ### What is the Early Access Program?
 
@@ -204,16 +202,16 @@ The Early Access Program provides access to features before they're released to 
 ### Joining Early Access
 
 **For Your Entire Platform:**
-1. Go to **Partner Center > Administration > Customize**
-2. Navigate to **General Product Settings > Others**
-3. Select **Join Early Access Program**
+1. Go to `Partner Center` → `Administration` → `Customize`
+2. Navigate to `General Product Settings` → `Others`
+3. Select `Join Early Access Program`
 
 **For Individual Markets:**
-1. Go to **Partner Center > Administration > Customize**
-2. Navigate to **Markets** and select your target market
-3. Go to **General Product Settings** section
-4. Locate **Early Access Program**
-5. Change selection to **Enable**
+1. Go to `Partner Center` → `Administration` → `Customize`
+2. Navigate to `Markets` and select your target market
+3. Go to `General Product Settings` section
+4. Locate `Early Access Program`
+5. Change selection to `Enable`
 
 :::info
 Market-specific settings override partner defaults unless explicitly defined.
@@ -223,70 +221,70 @@ Market-specific settings override partner defaults unless explicitly defined.
 
 If you leave the program, you'll no longer have access to Early Access features. Consider this carefully as some features may be removed from your platform.
 
-## How to Manage Business Priorities
+## How to manage Business Priorities
 
-### Customizing Business Priority Options
+### Customizing Business Priority options
 
 You can customize the business priority options available to your clients, allowing them to focus on the most relevant goals for their industry or business model.
 
-### Configuration Steps
+### Configuration steps
 
-1. Navigate to **Partner Center > Administration > Customize**
-2. Go to **Product Settings > Business Priorities**
+1. Navigate to `Partner Center` → `Administration` → `Customize`
+2. Go to `Product Settings` → `Business Priorities`
 3. Review available priority categories
 4. Enable/disable priorities based on your client base
 5. Customize priority descriptions if needed
 6. Save your configuration
 
-### Best Practices for Business Priorities
+### Best practices for Business Priorities
 
 - **Industry Relevance**: Enable priorities that align with your clients' industries
 - **Simplicity**: Don't overwhelm clients with too many options
 - **Regular Review**: Update priorities as your client base evolves
 - **Clear Descriptions**: Ensure priority descriptions are easily understood
 
-## How to Control Marketplace Vendor Contact
+## How to control Marketplace vendor contact
 
-### Preventing Direct Vendor Contact
+### Preventing direct vendor contact
 
 You can prevent Marketplace Vendors from directly contacting your partners, maintaining control over vendor relationships and communications.
 
-### Enabling Contact Protection
+### Enabling contact protection
 
 To prevent direct marketplace vendor contact:
 
-1. Navigate to **Partner Center > Administration > Customize**
-2. Go to **General Product Settings**
-3. Locate **Marketplace Vendor Contact** settings
-4. Select **Prevent Direct Contact**
+1. Navigate to `Partner Center` → `Administration` → `Customize`
+2. Go to `General Product Settings`
+3. Locate `Marketplace Vendor Contact` settings
+4. Select `Prevent Direct Contact`
 5. Save your changes
 
-### Benefits of Contact Control
+### Benefits of contact control
 
 - **Relationship Management**: Maintain control over vendor partnerships
 - **Quality Assurance**: Filter vendor communications for relevance
 - **Brand Protection**: Ensure consistent messaging from your organization
 - **Client Protection**: Shield clients from unsolicited vendor outreach
 
-## How to Restore Market Sales Order Settings
+## How to restore market sales order settings
 
-### Understanding Default vs Custom Settings
+### Understanding default vs custom settings
 
 Market sales order settings can be customized per market or inherit from partner-level defaults. Sometimes you may need to restore these settings to their original configuration.
 
-### Restoration Process
+### Restoration process
 
-1. Navigate to **Partner Center > Administration > Customize**
-2. Go to **Markets** and select your target market
-3. Locate **Sales Order Settings** section
-4. Click **Restore to Partner Defaults**
+1. Navigate to `Partner Center` → `Administration` → `Customize`
+2. Go to `Markets` and select your target market
+3. Locate `Sales Order Settings` section
+4. Click `Restore to Partner Defaults`
 5. Confirm the restoration when prompted
 
 :::warning
 Restoring market settings will override any custom configurations you've made for that specific market.
 :::
 
-## Frequently Asked Questions (FAQs)
+## Frequently asked questions (FAQs)
 
 <details>
 <summary>How do I activate Markets for my platform?</summary>

--- a/docusaurus/docs/commerce/subscriptions/subscription-management.mdx
+++ b/docusaurus/docs/commerce/subscriptions/subscription-management.mdx
@@ -9,91 +9,91 @@ keywords: [subscription billing, retail subscriptions, recurring billing, automa
 
 <iframe src="//www.loom.com/embed/76b0b4515c6b45b1a84d628ec8a0c9a0" width="560" height="315" frameborder="0" allowfullscreen></iframe>
 
-## What is Subscription Management?
+## What is subscription management?
 
-Subscription management in Vendasta's Commerce platform provides automated recurring billing for your customers. This replaces manual invoice creation with streamlined, automatic billing that generates customer invoices seamlessly from orders.
+Subscription management in Vendasta's Commerce platform provides automated recurring billing for your customers, generating customer invoices directly from orders.
 
 Subscription billing is a recurring billing model where customers are billed regularly (monthly, or yearly) to continue accessing products and services. Every activated product or service creates equivalent subscriptions for both partner-to-Vendasta transactions (wholesale subscriptions) and partner-to-client transactions (retail subscriptions).
 
-## Why Use Subscription Management?
+## Why use subscription management?
 
 Subscription billing offers significant advantages over traditional billing methods:
 
-### Key Benefits
+### Key benefits
 
-- **Streamlined Billing & Automated Invoicing**: Automated recurring billing generates customer invoices seamlessly from orders, saving time and effort
+- **Streamlined Billing & Automated Invoicing**: Automated recurring billing generates customer invoices from orders, saving time and effort
 - **Customizable Sale Prices**: Override default store prices and sell at negotiated customer-level prices with automatic recurring billing
 - **Personalized Invoice Scheduling**: Customize payment terms, due dates, payment methods, and memo notes for professional invoicing
 - **Enhanced Financial Transparency**: Comprehensive view of costs and retail revenue per client account in one consolidated interface
 - **Complete Control**: Full control over client subscriptions - view, update, or cancel subscriptions effortlessly
 - **Preview Next Invoice**: Unique preview feature lets you see upcoming client invoices before they're sent
 
-## How to Set Up Subscription Billing
+## How to set up subscription billing
 
-### Option 1: Default Settings for All New Accounts
+### Option 1: Default settings for all new accounts
 
 Configure default settings that apply to all accounts created after saving. Existing accounts can be configured individually.
 
-1. **Enable Retail Subscriptions**: Toggle the Retail Subscriptions button to ON to ensure a subscription is created every time you activate a product
-2. **Enable Subscription Billing**: Toggle the Subscription billing button to ON to turn on customer invoicing (optional)
-3. **Setup Payment Collection**:
-   - **Don't bill — just track revenue**: Creates subscriptions and tracks revenue without generating customer invoices
-   - **Create a draft invoice**: Creates the invoice and saves it as a draft for manual sending
-   - **Email payable invoice to billing recipient**: Generates and emails the invoice to the customer for payment
+1. `Enable Retail Subscriptions`: Toggle the `Retail Subscriptions` button to `ON` to ensure a subscription is created every time you activate a product
+2. `Enable Subscription Billing`: Toggle the `Subscription billing` button to `ON` to turn on customer invoicing (optional)
+3. `Setup Payment Collection`:
+   - `Don't bill, just track revenue`: Creates subscriptions and tracks revenue without generating customer invoices
+   - `Create a draft invoice`: Creates the invoice and saves it as a draft for manual sending
+   - `Email payable invoice to billing recipient`: Generates and emails the invoice to the customer for payment
 
-4. **Configure Subscription Renewal**: Invoices are sent at 3:00 PM UTC on renewal days. Subscriptions sharing a renewal day will be consolidated into one invoice
+4. `Configure Subscription Renewal`: Invoices are sent at 3:00 PM UTC on renewal days. Subscriptions sharing a renewal day will be consolidated into one invoice
 
-5. **Set Default Renewal Date**: Align all subscriptions to have the same renewal day so they appear on the same invoice
+5. `Set Default Renewal Date`: Align all subscriptions to have the same renewal day so they appear on the same invoice
 
-6. **Add Default Memo**: Enter a default note added to all invoices generated from subscriptions
+6. `Add Default Memo`: Enter a default note added to all invoices generated from subscriptions
 
-7. Click **Save** to apply settings to all newly created accounts
+7. Click `Save` to apply settings to all newly created accounts
 
-### Option 2: Account-Level Billing Settings
+### Option 2: Account-level billing settings
 
 Configure billing settings for individual customer accounts:
 
 ![Account-level billing settings](./img/commerce/commerce-subscriptions/account-billing-settings.png)
 
 1. Navigate to the customer account in Partner Center
-2. Click **Subscriptions** in the top panel
-3. Click **Billing Settings** in the top right corner
-4. **Enable Retail Subscriptions**: Toggle ON to create subscriptions when activating products
-5. **Enable Subscription Billing**: Toggle ON to turn on customer invoicing
-6. **Setup Payment Collection Options**:
-   - **Don't bill — just track revenue**: Tracks recurring revenue without generating customer invoices
-   - **Create a draft invoice**: Manual invoice sending
-   - **Email payable invoice to billing recipient**: Automatic email to customer
-   - **Automatically charge payment method on file**: Automatic credit card charging (requires a saved payment method — if none is on file, invoices default to email only)
+2. Click `Subscriptions` in the top panel
+3. Click `Billing Settings` in the top right corner
+4. `Enable Retail Subscriptions`: Toggle ON to create subscriptions when activating products
+5. `Enable Subscription Billing`: Toggle ON to turn on customer invoicing
+6. `Setup Payment Collection Options`:
+   - `Don't bill, just track revenue`: Tracks recurring revenue without generating customer invoices
+   - `Create a draft invoice`: Manual invoice sending
+   - `Email payable invoice to billing recipient`: Automatic email to customer
+   - `Automatically charge payment method on file`: Automatic credit card charging (requires a saved payment method, since if none is on file, invoices default to email only)
 
 :::note
 A payment method must be added to the account **before** enabling automatic charging. If no payment method is on file, invoices will default to email-only delivery.
 :::
 
-7. **Configure Collection Timing**:
-   - **Each subscription renewal**: Invoice on product renewal day
-   - **Same day of the month**: Consolidate all renewals into one monthly invoice
+7. `Configure Collection Timing`:
+   - `Each subscription renewal`: Invoice on product renewal day
+   - `Same day of the month`: Consolidate all renewals into one monthly invoice
 
-8. **Add Account Memo**: Custom note for this account's invoices
-9. Click **Save** to apply settings to this account only
+8. `Add Account Memo`: Custom note for this account's invoices
+9. Click `Save` to apply settings to this account only
 
-## Managing Existing Subscriptions
+## Managing existing subscriptions
 
-### Billing Settings Overview
+### Billing settings overview
 
 When viewing a subscription, billing information displays the configuration specified when creating the subscription. You may need to edit this information for updated credit cards or payment method changes.
 
-#### Default Settings
+#### Default settings
 By default, subscriptions are billed automatically using the pre-configured payment processor on the first day of the billing cycle.
 
 ![Default billing settings](./img/commerce/commerce-subscriptions/default-billing-settings.png)
 
-#### Account-Level Settings
+#### Account-level settings
 Configure specific settings for handling subscriptions at the account level.
 
 ![Account-level billing settings](./img/commerce/commerce-subscriptions/account-level-billing-settings.png)
 
-### How to Edit Subscription Prices
+### How to edit subscription prices
 
 You can edit subscription prices at any time. The platform displays when new prices take effect - changes do not apply to the current billing cycle.
 
@@ -103,11 +103,11 @@ Changing a product's price in your catalog does **not** automatically update exi
 
 **To edit a subscription price:**
 
-1. Find the subscription in **Commerce > Subscriptions**
+1. Find the subscription in `Commerce` → `Subscriptions`
 2. Click on the subscription you want to modify
-3. Click the **EDIT PRICE** button next to the current price
+3. Click the `EDIT PRICE` button next to the current price
 4. Enter the new subscription price in the relevant fields
-5. Click **SAVE**
+5. Click `SAVE`
 
 ![Editing subscription price](./img/commerce/commerce-subscriptions/edit-subscription-price.png)
 
@@ -119,16 +119,16 @@ A price change icon will appear next to the price, indicating that a price chang
 If a product can be activated more than once on an account, pricing changes to one retail subscription will be applied to the others.
 :::
 
-### How to Cancel Subscriptions
+### How to cancel subscriptions
 
 You can cancel subscriptions at any time with two options:
 
-#### Cancel at End of Period
+#### Cancel at end of period
 Allows the subscription to remain active until the end of the current billing cycle.
 
 ![Cancel subscription at end of period](./img/commerce/commerce-subscriptions/cancel-subscription-end-period.png)
 
-#### Cancel with Custom Date
+#### Cancel with custom date
 Specify a specific date when the subscription should end.
 
 ![Cancel subscription with custom date](./img/commerce/commerce-subscriptions/cancel-subscription-custom-date.png)
@@ -136,7 +136,7 @@ Specify a specific date when the subscription should end.
 **To cancel a subscription:**
 
 1. Go to the kebab menu (⋮) on the retail subscription you wish to cancel
-2. Select **Cancel Subscription**
+2. Select `Cancel Subscription`
 3. Choose cancellation timing (end of period or custom date)
 4. Select which products to cancel (allows partial cancellation)
 5. Confirm the cancellation
@@ -151,33 +151,33 @@ When cancelling a subscription, you can select which products to cancel, allowin
 
 ![Note about canceling products](./img/commerce/commerce-subscriptions/cancel-products-note.png)
 
-### How to Add Products to Subscriptions
+### How to add products to subscriptions
 
 **To add products to an existing subscription:**
 
-1. Navigate to the subscription in **Commerce > Subscriptions**
+1. Navigate to the subscription in `Commerce` → `Subscriptions`
 2. Click on the subscription you want to modify
-3. Click **ADD PRODUCTS**
+3. Click `ADD PRODUCTS`
 4. Select the additional products to add
 5. Configure the product settings as needed
-6. Click **SAVE**
+6. Click `SAVE`
 
 Newly added products will be prorated for the remaining time in the current billing cycle.
 
-### How to Remove Products from Subscriptions
+### How to remove products from subscriptions
 
 **To remove products without cancelling the entire subscription:**
 
-1. Navigate to the subscription in **Commerce > Subscriptions**
+1. Navigate to the subscription in `Commerce` → `Subscriptions`
 2. Click on the subscription you want to modify
 3. Find the product you wish to remove
 4. Click the menu icon (three dots) next to the product
-5. Select **Remove**
+5. Select `Remove`
 6. Confirm the removal
 
 Removing products follows the same cancellation rules as cancelling subscriptions - you can choose to remove the product at the end of the billing period or on a specific date.
 
-## Frequently Asked Questions
+## Frequently asked questions
 
 <details>
 <summary>Who can use subscription billing?</summary>
@@ -202,8 +202,8 @@ Retail subscriptions will generate invoices for your customers according to the 
 
 For custom products, add them to your store in the platform:
 
-1. In Partner Center, go to **Marketplace > Products**
-2. Click **Create Product** in the top right corner
+1. In Partner Center, go to `Marketplace` → `Products`
+2. Click `Create Product` in the top right corner
 3. After the product is created, add it to an order or activate it for your customer
 
 </details>
@@ -254,7 +254,7 @@ With subscription billing, make sure to stop billing your customer when you canc
 
 The unit price of a retail subscription is the amount the customer will be billed every billing period. The unit price can be edited while the subscription is active, and changes apply to all subsequent billing periods.
 
-1. Open the retail subscription you'd like to edit by clicking the row or selecting "View subscription" in the kebab menu
+1. Open the retail subscription you'd like to edit by clicking the row or selecting `View subscription` in the kebab menu
 2. Click the unit price of the retail subscription
 3. Enter the new price and click save
 
@@ -309,7 +309,7 @@ Subscriptions support quantities from 1 to 99 units per subscription. For larger
 
 Partners on the Free tier have limited access to subscription features:
 
-- **Pricing**: Retail pricing only — no wholesale discount pricing available
+- **Pricing**: Retail pricing only, no wholesale discount pricing available
 - **SMS messaging**: Businesses associated with a Free Partner account cannot claim an SMS number or send messages via Business App
 - **White-label customization**: You cannot apply or manage white-label settings on the Free tier. If you had white-labeled products active before a downgrade, they will remain as-is but cannot be modified until you upgrade
 
@@ -321,7 +321,7 @@ If your account has been suspended or sent to collections, it may have been auto
 
 </details>
 
-## Important Notes
+## Important notes
 
 - Subscription renewal invoices are sent at 3:00 PM UTC on renewal days
 - Subscriptions sharing a renewal day will be consolidated into one invoice
@@ -330,5 +330,5 @@ If your account has been suspended or sent to collections, it may have been auto
 - Product removals follow the same timing rules as subscription cancellation
 - Default settings apply only to newly created accounts after saving
 - Account-level settings override default settings for specific accounts
-- New subscriptions do not charge in the creation month — the first automatic charge occurs on the next renewal date
+- New subscriptions do not charge in the creation month: the first automatic charge occurs on the next renewal date
 - If no payment method is on file, invoices default to email-only delivery

--- a/docusaurus/docs/marketplace/discover-products-guide.mdx
+++ b/docusaurus/docs/marketplace/discover-products-guide.mdx
@@ -7,8 +7,6 @@ tags: [marketplace, discover-products, start-selling, product-information]
 keywords: [discover products, marketplace products, start selling, product filtering, product search, retail pricing, wholesale cost]
 ---
 
-# Discover Products
-
 ## What is Discover Products?
 
 Discover Products is the hub for finding, evaluating, and enabling products that fit your clients' needs and budgets. Browse 250+ curated solutions, compare pricing and profitability, and start selling with a single click.
@@ -22,28 +20,28 @@ Discover Products streamlines product research and enables faster business growt
 - Open detailed marketing pages with complete product information
 - Start selling instantly with one click
 
-## What's Included with Discover Products?
+## What's included with Discover Products?
 
-### Product Discovery
+### Product discovery
 - Browse 250+ curated marketplace products
 - Filter by category, country, pricing strategy, billing frequency, and vendor
 - Search for specific solutions
 - View curated collections (top, new, trending, best-sellers, seasonal)
 
-### Product Evaluation
+### Product evaluation
 - Detailed marketing pages with features and benefits
 - Screenshots and supporting files (brochures, case studies, documentation)
 - Edition comparisons and pricing per tier
 - FAQs and vendor contact information
 - Country availability information
 
-### Instant Enablement
+### Instant enablement
 - One-click product activation with `Start Selling` button
 - Automatic inclusion of all editions and add-ons
 - Immediate availability in your store's ALL category
 - Automatic currency conversion and multi-market distribution
 
-## How to Use Discover Products
+## How to use Discover Products
 
 ### Browse all products
 1. Open **Partner Center** → **Marketplace** → **Discover Products**
@@ -75,24 +73,24 @@ If you don't find what you need, use the "Suggest a product" feature to request 
 
 <img src={require('./img/marketplace/discover-products/suggest-product.jpg').default} alt="Suggest a product control on the Discover Products page" style={{width: '100%', border: '1px solid #e0e0e0', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.08)'}} />
 
-## Product Marketing Pages
+## Product marketing pages
 
 Each product has a detailed marketing page with comprehensive information:
 
-### Product Information
+### Product information
 - Features and benefits
 - Key selling points
 - Technical requirements
 - Integration capabilities
 - Real-world use cases
 
-### Editions & Pricing
+### Editions & pricing
 - Side-by-side edition comparisons
 - Pricing across all tiers
 - Feature differences
 - Upgrade/downgrade paths
 
-### Screenshots & Files
+### Screenshots & files
 - UI screenshots
 - Brochures and case studies
 - Documentation
@@ -103,13 +101,13 @@ Each product has a detailed marketing page with comprehensive information:
 - Billing clarifications
 - Support and troubleshooting
 
-### Contact Information
+### Contact information
 - Vendor sales and support details
 - Email addresses and phone numbers
 - Escalation paths
 - Regional availability
 
-## Starting to Sell Products
+## Starting to sell products
 
 ### Enable products with one click
 1. Browse or search in Discover Products
@@ -139,7 +137,7 @@ Use **Partner Center** → **Marketplace** → **Manage Store** to:
 - **Custom pricing**: Override suggested prices, set market-specific pricing, configure promotions
 - **Currency settings**: Set conversion rates in **Manage Store** → **Currency**
 
-## Customer Purchase Experience
+## Customer purchase experience
 
 ### Edition selection
 Product details pages include comprehensive info, an Editions & Pricing tab for comparison, and a Buy it Now path into the shopping cart.
@@ -149,29 +147,33 @@ Product details pages include comprehensive info, an Editions & Pricing tab for 
 - Contact Sales (lead form)
 - External URL (redirect)
 
-## Stopping Product Sales
+## Stopping product sales
 
 ### Stop selling a product
 1. Go to **Marketplace** → **Products** and open the product
 2. Click **Stop Selling** and confirm
 
-Impact: Packages containing it are archived; existing sales orders continue; it’s removed from new order creation and store display; existing activations continue.
+Impact:
+- Packages containing it are archived
+- Existing sales orders continue
+- It’s removed from new order creation and store display
+- Existing activations continue
 
-## Best Practices
+## Best practices
 
-### Product Selection
+### Product selection
 - Start with products that complement your existing services
 - Consider your target market's most common needs
 - Evaluate profit margins at your current subscription tier
 - Test products with small customer segments before full rollout
 
-### Store Organization
+### Store organization
 - Group related products into logical categories
 - Use clear, customer-friendly product descriptions
 - Maintain consistent pricing strategies across similar products
 - Regularly review and update product offerings
 
-### Customer Education
+### Customer education
 - Leverage product marketing materials for sales conversations
 - Share relevant case studies and documentation with prospects
 - Use FAQs to proactively address common concerns
@@ -225,13 +227,13 @@ Accounts with the product active will lose access to it.
 
 If you expect to see a product that isn't appearing, there are a few common reasons:
 
-- **Not enabled for your account** — Some products are only available on specific plans or account configurations.
-- **Product has been renamed** — Products can be renamed over time. Try searching by a different name or browsing by category.
-- **Product discontinued or replaced** — Some products are retired or superseded by newer offerings.
-- **Market or subscription restrictions** — Availability can vary by market and subscription tier.
+- **Not enabled for your account**: Some products are only available on specific plans or account configurations.
+- **Product has been renamed**: Products can be renamed over time. Try searching by a different name or browsing by category.
+- **Product discontinued or replaced**: Some products are retired or superseded by newer offerings.
+- **Market or subscription restrictions**: Availability can vary by market and subscription tier.
 
 If you still can't find the product, contact [Vendasta Support](https://support.vendasta.com) with the product name and your account details. A support agent can confirm whether the product is available for your account, has been renamed, or requires a different plan.
 
 ## Conclusion
 
-With Discover Products, you have access to a comprehensive ecosystem of vetted solutions that can immediately expand your service offerings and grow your revenue. The platform's intuitive interface and powerful filtering capabilities ensure you can quickly find and enable the right products for your business and customers.
+Discover Products gives you access to a catalog of vetted solutions you can add to your service offerings. Use the filtering and search tools to find and enable the right products for your business and customers.

--- a/docusaurus/docs/multi-location-business-app/reputation/review-response-suggestions.mdx
+++ b/docusaurus/docs/multi-location-business-app/reputation/review-response-suggestions.mdx
@@ -5,8 +5,6 @@ sidebar_position: 1
 description: Learn how to use suggested responses for reviews in the Multi-Location Business App
 ---
 
-# Review Response Suggestions
-
 Review response suggestions make it easy to quickly respond to customer reviews. There are several suggested responses for different star ratings, making it easy to find a response that matches your review.
 
 :::note


### PR DESCRIPTION
## Summary
- Verified 5 flagged articles: heading casing, UI/nav-path formatting, em dashes, duplicate H1s, and prohibited terms fixed across all five.
- discover-products-guide.mdx: removed a prohibited marketing term, rewrote a promotional closing paragraph, and converted a dense sentence into a bullet list.
- subscription-management.mdx: removed a prohibited term (2 instances) and reworded the intro; confirmed two potential evergreen concerns (legacy Loom embed, "Bill by active" FAQ language) are still accurate as-is.
- review-response-suggestions.mdx: removed a stray body H1 that didn't match the frontmatter title — flagged for a manual naming check (see below).
- Updated the `article-verifications` skill: Step 4b's inbound-anchor scan is now a single batched grep and is skipped entirely when no headings changed; Step 8 now batches approval prompts (up to 4 per `AskUserQuestion` call, duplicate occurrences of the same issue collapsed into one prompt) instead of asking one question per item.

## Issues resolved
Closes #1015
Closes #1013
Closes #1014
Closes #1011
Closes #1012

## Still needs follow-up
- Reputation AI (review-response-suggestions.mdx): confirm "Reputation AI" is still the correct current name for this feature — the frontmatter title and the removed body heading didn't match.

## Test plan
- [ ] Spot check rendered pages in local dev (`npm run start` in `docusaurus/`) for the 5 articles above
- [ ] Confirm no broken links/anchors post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)