### PR TITLE
Docs: Autotask sync error message for missing company (TLKM-2168)

### DIFF
--- a/docusaurus/docs/administration/advanced/integrations/integrate-autotask.mdx
+++ b/docusaurus/docs/administration/advanced/integrations/integrate-autotask.mdx
@@ -277,7 +277,7 @@ Roll the integration out gradually so you can confirm it behaves as expected bef
 |-------------|-------------------|--------------|
 | 500 error when connecting | API credentials are invalid or the user is disabled | Verify credentials in Autotask Admin. Re-enter. |
 | "Connected" but nothing syncs | Webhooks are not enabled on the security level | Open the security level in Autotask → Other Settings → enable webhooks with limit of 5+ |
-| Contacts not appearing | Contact is not linked to a company in Autotask | Link the contact to a company in Autotask. Unlinked contacts are skipped. |
+| Contacts not appearing | Contact is not linked to a company in Autotask | Link the contact to a company in Autotask. The Activity Feed logs "Unable to sync this contact. Company details are not associated. Please associate a company and try again." Unlinked contacts are skipped. |
 | Duplicate records after connecting | Records existed in both systems without Autotask IDs | Disconnect. Clean up duplicates. Bulk import with external_id. Reconnect. See [Recovery](#recovery--already-have-duplicates) section. |
 | "Broken" status on connection card | API credentials expired or revoked | Click **Re-authenticate**. Re-enter credentials. |
 | Sync back to Autotask not working | The record is missing its Autotask ID | Check the record in Vendasta. If autotask-company-id or autotask-contact-id is empty, use bulk import to add external IDs. |
@@ -311,7 +311,7 @@ Nothing is deleted. Records stay in both systems. Reconnecting later resumes syn
 <details>
 <summary>Can I create a contact in Vendasta without associating it to a company?</summary>
 
-Yes. Vendasta allows contacts to exist independently without a company association. However, standalone contacts will not sync to Autotask. Autotask enforces a mandatory company-contact relationship — every contact must belong to a company. If a contact exists in Vendasta without a company association, the integration will skip the sync and log an activity note indicating the contact was not synced.
+Yes. Vendasta allows contacts to exist independently without a company association. However, standalone contacts will not sync to Autotask. Autotask enforces a mandatory company-contact relationship — every contact must belong to a company. If a contact exists in Vendasta without a company association, the integration skips the sync and logs this message in the Activity Feed: "Unable to sync this contact. Company details are not associated. Please associate a company and try again."
 
 </details>
 


### PR DESCRIPTION
## Jira

[TLKM-2168 — Activity Feed - Error Message update](https://vendasta.jira.com/browse/TLKM-2168)

## Change classification

Feature behavior change — a specific, user-facing error message now appears in the Activity Feed when a Contact fails to sync via the Autotask integration because it has no associated company.

## Repo targeted

**Partner Center** (partner-facing docs). The Autotask integration is also configured from Partner Center on behalf of SMB clients, and this repo maintains a parallel copy of the same Autotask article for that audience.

## Summary of documentation updates

Updated `docusaurus/docs/administration/advanced/integrations/integrate-autotask.mdx`:
- Added the exact Activity Feed message text to the existing **Troubleshooting** table row for "Contacts not appearing" (cause: contact not linked to a company in Autotask).
- Updated the FAQ answer for "Can I create a contact in Vendasta without associating it to a company?" to quote the same message instead of the previous generic "log an activity note indicating the contact was not synced" wording.

## Existing docs updated vs. new docs created

Updated existing docs only. No new page was created.

## Placement reasoning

This file already had a troubleshooting row and FAQ entry covering the "contact not linked to a company" scenario — the exact case this error message targets. Naming the specific message in those two existing locations avoids duplication and matches the parallel structure already used in the Business App repo's copy of this article.

## Acceptance criteria coverage

- ✅ Contact Creation — when Company Name is missing, the article now states the Activity Feed displays: *"Unable to sync this contact. Company details are not associated. Please associate a company and try again."*

## Figma/images

Not used — the ticket's only visual was a broken/inaccessible attachment reference in the Jira description (no image loaded). Documentation is based on the acceptance criteria text only.

## Skills used

None of this repo's specific skills applied (no Wistia embed involved); changes were verified by direct diff review against this repo's markdown rules (no `>` characters, `<details>` structure preserved).

## Assumptions / limitations

- The parent epic (TLKM-2144) is a rolling, non-feature "operational tracking" epic explicitly labeled `Other` (not `Product-Roadmap`) with no single completion date; TLKM-2168 itself carries an independent "Done" resolution, and no sibling ticket under the epic showed feature-flag, eligibility, or region-gating signals. Proceeding was judged safe on that basis.
- No linked GitHub PR was found on the Jira ticket. The ticket assignee's GitHub account (`jbalasubramaniyan`) was identified as the likely reviewer but could not be requested — they are not a collaborator on this repo.

---

@ahnikakuse @haleyserrano @maryam6samadi

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVtWgaX3KFZriwwAQL7iDz)_