### PR TITLE
docs(DOC-767): fix SEO Standard blog spec and review-call cadence

### DIFF
--- a/docusaurus/training/products/attract/local-seo-listings/product-knowledge-seo-standard.mdx
+++ b/docusaurus/training/products/attract/local-seo-listings/product-knowledge-seo-standard.mdx
@@ -34,7 +34,7 @@ In this course, you will learn about Marketing and Professional Services' SEO St
 | Service | SEO Standard | SEO Plus Add-On |
 |---------|:------------:|:---------------:|
 | Keywords Research | Up to 10 keywords | +10 (total 20) |
-| Monthly SEO Blog | Up to 500 words | +1 extra 500-word blog |
+| Monthly SEO Blog | Up to 1,500 words | +1 extra 1,500-word blog |
 | On-Page Optimization | 5 pages | +5 (total 10 pages) |
 | Google Business Profile | Complete management | ✓ |
 | Monthly SEO Reports | ✓ | ✓ |
@@ -79,13 +79,13 @@ In this course, you will learn about Marketing and Professional Services' SEO St
 
 - Optimize on-page content and technical SEO elements
 - Write and perform quality assurance checks on monthly blogs
-- Quarterly SEO review calls occur in months 4, 7, and 10
+- Join review calls with the client on a cadence set by their needs—some clients meet bi-weekly, others monthly or quarterly—and the SEO team joins any call where the client wants clarification on the SEO process
 
 <div className="in-practice">
   <span className="in-practice__icon">💬</span>
   <div className="in-practice__body">
     <span className="in-practice__label">In Practice</span>
-    <p>A partner orders SEO Standard for a client. Task Manager project is created. Client Engagement sends confirmation. Consultation is scheduled for day 5. The SEO Specialist and Client Solutions Specialist discuss keywords, pages, and goals. Post-consultation email goes out. At 30 days, the first report is generated—audit, competitive analysis, keyword re-eval, backlinks. Client Engagement distributes. Quarterly review in month 4.</p>
+    <p>A partner orders SEO Standard for a client. Task Manager project is created. Client Engagement sends confirmation. Consultation is scheduled for day 5. The SEO Specialist and Client Solutions Specialist discuss keywords, pages, and goals. Post-consultation email goes out. At 30 days, the first report is generated—audit, competitive analysis, keyword re-eval, backlinks. Client Engagement distributes. Review calls continue on a cadence set by the client's needs.</p>
   </div>
 </div>
 
@@ -96,7 +96,7 @@ In this course, you will learn about Marketing and Professional Services' SEO St
 ## Key Resources
 
 <FlipCardGrid>
-  <FlipCard front="SEO Standard" back="10 keywords, 500-word blog, 5 pages, GBP, reports." subtext="Core" />
+  <FlipCard front="SEO Standard" back="10 keywords, 1,500-word blog, 5 pages, GBP, reports." subtext="Core" />
   <FlipCard front="Consultation" back="5–6 business days from order." subtext="Timeline" />
   <FlipCard front="First Report" back="30 days. Audit, competitive, keywords, backlinks." subtext="Reporting" />
 </FlipCardGrid>
@@ -110,10 +110,10 @@ In this course, you will learn about Marketing and Professional Services' SEO St
   site="vendasta_learn"
   sessionSize={5}
   questions={[
-    { type: "mcq", question: "Which bundle matches SEO Standard as described in this product page?", options: ["Ten pages of on-page work and twenty keywords only", "Keyword research only with no reporting or GBP work", "Keyword research (up to 10), monthly blog (up to 500 words), on-page work on five pages, GBP management, monthly reports", "Technical fixes only with no content or reporting"], correctIndex: 2, explanation: "SEO Standard lists keyword research (up to 10), monthly SEO blog (up to 500 words), on-page optimization for five pages, complete GBP management, and monthly SEO reports." },
+    { type: "mcq", question: "Which bundle matches SEO Standard as described in this product page?", options: ["Ten pages of on-page work and twenty keywords only", "Keyword research only with no reporting or GBP work", "Keyword research (up to 10), monthly blog (up to 1,500 words), on-page work on five pages, GBP management, monthly reports", "Technical fixes only with no content or reporting"], correctIndex: 2, explanation: "SEO Standard lists keyword research (up to 10), monthly SEO blog (up to 1,500 words), on-page optimization for five pages, complete GBP management, and monthly SEO reports." },
     { type: "truefalse", statement: "A consultation call is scheduled 5–6 business days from the order date.", correct: true, explanation: "The consultation call is scheduled 5–6 business days from the order date." },
     { type: "mcq", question: "When does the SEO team generate the first report?", options: ["Immediately", "After 7 days", "After 30 days", "After 90 days"], correctIndex: 2, explanation: "After 30 days, the SEO team generates a report." },
-    { type: "mcq", question: "What does the SEO Plus add-on include?", options: ["Only more keywords", "On-Page Optimization of 5 additional pages (total 10), 10 additional keywords (total 20), an additional monthly 500-word blog", "Only an extra blog", "Only GBP management"], correctIndex: 1, explanation: "SEO Plus adds 5 more pages (total 10), 10 more keywords (total 20), and an additional monthly blog." },
+    { type: "mcq", question: "What does the SEO Plus add-on include?", options: ["Only more keywords", "On-Page Optimization of 5 additional pages (total 10), 10 additional keywords (total 20), an additional monthly 1,500-word blog", "Only an extra blog", "Only GBP management"], correctIndex: 1, explanation: "SEO Plus adds 5 more pages (total 10), 10 more keywords (total 20), and an additional monthly blog." },
     { type: "whicharea", principle: "Where would you learn about order receipt and Task Manager assignment?", correctArea: "📋 SEO Standard Process", explanation: "That section covers the full process from order to reporting." }
   ]}
 />


### PR DESCRIPTION
## Summary
- **Blog spec:** Monthly SEO Blog corrected from 500 words to 1,500 words (table, flip card, both quiz questions). Every other blog spec in the repo already said 1,500 words - this page was the outlier.
- **Review-call cadence:** replaced the flat "quarterly, months 4/7/10" claim with the actual flexible cadence, per direct confirmation from Swaminathan B. (SEO Team Lead): calls are not mandatory or fixed-quarterly - partners run bi-weekly, monthly, or quarterly depending on need, and the SEO team joins ad hoc when a client wants clarification.
- Contact emails (marketingservices@yourdigitalagents.com, onboarding@vendasta.com) and the GTM playbook/upsell deck accessibility claim were also verified this pass and found still accurate - no doc changes needed for those.

This closes out the last open items on DOC-767, clearing the way to close DOC-760.

## Test plan
- [x] `npm run build` succeeds from `docusaurus/`
- [x] No new broken links/anchors introduced (same pre-existing backlog as before)
- [x] Manually reviewed the rendered diff for the table, flip card, and both knowledge-check questions

Refs DOC-767, DOC-760

🤖 Generated with [Claude Code](https://claude.com/claude-code)