### PR TITLE
docs(learn): cross-link Hire your first AI Employee course and Partner Center docs

### DIFF
--- a/docusaurus/docs/ai/ai-capabilities/tools-overview/index.md
+++ b/docusaurus/docs/ai/ai-capabilities/tools-overview/index.md
@@ -14,6 +14,8 @@ tags:
   - Integrations
 ---
 
+import { GraduationCapIcon } from '@site/src/components/Icons';
+
 Tools enable your AI Employees to interact with external systems, retrieve real-time information, and automate workflows across different platforms. Understanding how Tools work is essential for building powerful AI capabilities that go beyond simple conversation.
 
 ## What are Tools?
@@ -175,4 +177,11 @@ Create custom Tools when AI Employees need to:
 :::tip Ready to Build?
 Now that you understand what Tools are and how they work, follow our step-by-step tutorial to build your first custom Tool: [Building Custom Tools](./building-custom-tools)
 :::
+
+<div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '12px', background: 'rgba(60, 154, 99, 0.08)', border: '1px solid rgba(60, 154, 99, 0.35)', borderRadius: '8px', padding: '14px 18px', margin: '16px auto', width: 'fit-content', maxWidth: '100%', textAlign: 'center'}}>
+  <span style={{flexShrink: 0}}><GraduationCapIcon size={26} /></span>
+  <span style={{fontSize: '14px', color: 'var(--ifm-font-color-base)', textAlign: 'center'}}>
+    New to hiring and running an AI Employee? Take the <a href="/learn/ai-workforce" style={{color: '#3C9A63', fontWeight: 600}}>Hire your first AI Employee</a> course in Vendasta Learn — Beginner to Intermediate, 7 lessons.
+  </span>
+</div>
 

--- a/docusaurus/docs/ai/ai-workforce/ai-chat-receptionist/index.md
+++ b/docusaurus/docs/ai/ai-workforce/ai-chat-receptionist/index.md
@@ -4,7 +4,7 @@ sidebar_position: 2
 description: Set up, train, and monitor the AI Chat Receptionist to capture leads and answer visitor questions across web chat and SMS.
 ---
 
-import { AISparkleIcon } from '@site/src/components/Icons';
+import { AISparkleIcon, GraduationCapIcon } from '@site/src/components/Icons';
 
 The AI Chat Receptionist helps you capture leads and respond to website visitors 24/7. In this guide, you'll learn how to set up, train, and monitor your AI assistant to work for your business.
 
@@ -422,3 +422,10 @@ This only applies to conversations where messages have been sent from Conversati
 :::
 
 </details>
+
+<div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '12px', background: 'rgba(60, 154, 99, 0.08)', border: '1px solid rgba(60, 154, 99, 0.35)', borderRadius: '8px', padding: '14px 18px', margin: '16px auto', width: 'fit-content', maxWidth: '100%', textAlign: 'center'}}>
+  <span style={{flexShrink: 0}}><GraduationCapIcon size={26} /></span>
+  <span style={{fontSize: '14px', color: 'var(--ifm-font-color-base)', textAlign: 'center'}}>
+    New to hiring and running an AI Employee? Take the <a href="/learn/ai-workforce" style={{color: '#3C9A63', fontWeight: 600}}>Hire your first AI Employee</a> course in Vendasta Learn — Beginner to Intermediate, 7 lessons.
+  </span>
+</div>

--- a/docusaurus/docs/ai/ai-workforce/ai-voice-receptionist.md
+++ b/docusaurus/docs/ai/ai-workforce/ai-voice-receptionist.md
@@ -5,7 +5,7 @@ sidebar_position: 3
 description: Learn how to set up, configure, test, and troubleshoot your AI Voice Receptionist, including call routing, capabilities, knowledge sources, and frequently asked questions.
 ---
 
-import { AISparkleIcon, SettingsIcon, CRMIcon } from '@site/src/components/Icons';
+import { AISparkleIcon, SettingsIcon, CRMIcon, GraduationCapIcon } from '@site/src/components/Icons';
 
 Your AI Voice Receptionist helps answer your calls 24/7, captures new-lead info, gives callers fast and accurate answers, and helps get questions to the right person when they don't have an answer. 
 
@@ -443,3 +443,10 @@ AI Voice Receptionist is currently available for businesses located in the **Uni
 For the most up-to-date region availability, see the [AI Workforce Overview](./index.mdx).
 
 </details>
+
+<div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '12px', background: 'rgba(60, 154, 99, 0.08)', border: '1px solid rgba(60, 154, 99, 0.35)', borderRadius: '8px', padding: '14px 18px', margin: '16px auto', width: 'fit-content', maxWidth: '100%', textAlign: 'center'}}>
+  <span style={{flexShrink: 0}}><GraduationCapIcon size={26} /></span>
+  <span style={{fontSize: '14px', color: 'var(--ifm-font-color-base)', textAlign: 'center'}}>
+    New to hiring and running an AI Employee? Take the <a href="/learn/ai-workforce" style={{color: '#3C9A63', fontWeight: 600}}>Hire your first AI Employee</a> course in Vendasta Learn — Beginner to Intermediate, 7 lessons.
+  </span>
+</div>

--- a/docusaurus/docs/ai/ai-workforce/custom-ai-employees.md
+++ b/docusaurus/docs/ai/ai-workforce/custom-ai-employees.md
@@ -6,6 +6,8 @@ description: Learn how to create specialized AI employees tailored to specific b
 tags: [ai-workforce, custom-capabilities, ai-employees]
 keywords: [custom AI employees, AI workforce, capabilities, tools, deployment, web chat]
 ---
+
+import { GraduationCapIcon } from '@site/src/components/Icons';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
@@ -313,3 +315,10 @@ While you can assign an AI Employee to multiple web chat widgets, you can't assi
 Yes! You can add Custom AI Employees to automation workflows using the "Send a prompt to an AI Employee" step. This allows you to use AI-powered decision-making in your automated processes. For more details, see [Reusable workflows](../../automations/my-automations/reusable-workflows.mdx).
 
 </details>
+
+<div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '12px', background: 'rgba(60, 154, 99, 0.08)', border: '1px solid rgba(60, 154, 99, 0.35)', borderRadius: '8px', padding: '14px 18px', margin: '16px auto', width: 'fit-content', maxWidth: '100%', textAlign: 'center'}}>
+  <span style={{flexShrink: 0}}><GraduationCapIcon size={26} /></span>
+  <span style={{fontSize: '14px', color: 'var(--ifm-font-color-base)', textAlign: 'center'}}>
+    New to hiring and running an AI Employee? Take the <a href="/learn/ai-workforce" style={{color: '#3C9A63', fontWeight: 600}}>Hire your first AI Employee</a> course in Vendasta Learn — Beginner to Intermediate, 7 lessons.
+  </span>
+</div>

--- a/docusaurus/docs/ai/knowledge-base/index.md
+++ b/docusaurus/docs/ai/knowledge-base/index.md
@@ -6,6 +6,8 @@ tags: [knowledge-base, ai-employees, knowledge-sources, conversations-ai]
 keywords: [knowledge base, knowledge sources, business profile, ai employees, conversations ai]
 ---
 
+import { GraduationCapIcon } from '@site/src/components/Icons';
+
 ## What is the Knowledge Base?
 
 The **Knowledge Base** is where AI employees access factual information about a business. It ensures that answers are accurate and grounded in real data.  
@@ -207,3 +209,10 @@ Use **text** for short, specific information not on the site. Use **website** fo
 No. You'll need to upload a new version of the file to refresh its content.
 
 </details>
+
+<div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '12px', background: 'rgba(60, 154, 99, 0.08)', border: '1px solid rgba(60, 154, 99, 0.35)', borderRadius: '8px', padding: '14px 18px', margin: '16px auto', width: 'fit-content', maxWidth: '100%', textAlign: 'center'}}>
+  <span style={{flexShrink: 0}}><GraduationCapIcon size={26} /></span>
+  <span style={{fontSize: '14px', color: 'var(--ifm-font-color-base)', textAlign: 'center'}}>
+    New to hiring and running an AI Employee? Take the <a href="/learn/ai-workforce" style={{color: '#3C9A63', fontWeight: 600}}>Hire your first AI Employee</a> course in Vendasta Learn — Beginner to Intermediate, 7 lessons.
+  </span>
+</div>

--- a/docusaurus/docs/automations/automation-history/managing-your-automations.mdx
+++ b/docusaurus/docs/automations/automation-history/managing-your-automations.mdx
@@ -71,6 +71,10 @@ When the Activity tab shows **Did not run**, the reason tells you why:
 | **Trigger choices failed** | The trigger's choice logic (conditional branching on the trigger) didn't match. |
 | **Task definition choices failed** | A step's pre-condition check failed before the workflow could start. |
 
+:::info Go deeper
+A **Did not run** entry isn't always a problem — often it's an entry setting doing its job. [Put your workforce on autopilot](/learn/ai-workforce/autopilot) walks through reading a run like this correctly before assuming something broke.
+:::
+
 ## Error handling
 
 ### View errors

--- a/docusaurus/docs/automations/my-automations/creating-and-configuring-automations.mdx
+++ b/docusaurus/docs/automations/my-automations/creating-and-configuring-automations.mdx
@@ -18,6 +18,10 @@ import { Cards, Card } from '@site/src/components/Cards';
 6. Add **actions** — the steps that run when the trigger fires.
 7. Toggle the automation **On** when you're ready.
 
+:::info Go deeper
+Want to see this built end to end? [Put your workforce on autopilot](/learn/ai-workforce/autopilot) pairs a CRM smart list with this exact trigger to run a real automation on its own.
+:::
+
 ## Settings
 
 Open an automation and click **Settings** in the left menu. Settings are organized into five tabs.

--- a/docusaurus/docs/crm/lists/index.mdx
+++ b/docusaurus/docs/crm/lists/index.mdx
@@ -115,6 +115,10 @@ You can set up automations to trigger specific actions when a contact or company
 
 These triggers allow you to automate workflows, such as sending follow-up emails, notifying a sales team, or moving a contact to another CRM stage when they join or leave a list. Simply set up the automation with the appropriate trigger, and the system will handle the rest based on your criteria.
 
+:::info Go deeper
+Want to see this trigger built end to end? [Put your workforce on autopilot](/learn/ai-workforce/autopilot) pairs a smart list with the "contact is added to a list" trigger to start a real nurture campaign on its own.
+:::
+
 ## How do I delete a list?
 
 **1. Locate the List:**

--- a/docusaurus/docs/vendasta-services/ai-workforce/index.mdx
+++ b/docusaurus/docs/vendasta-services/ai-workforce/index.mdx
@@ -8,6 +8,8 @@ tags: [vendasta-services, ai-workforce, setup, optimization]
 keywords: [AI Receptionist, AI Reputation Specialist, AI Inside Sales Representative, AI Support Agent, AI Data Analyst, AI Human Resources Coordinator, setup, optimization, AI Workforce Optimization Plan]
 ---
 
+import { GraduationCapIcon } from '@site/src/components/Icons';
+
 # AI Workforce
 
 Vendasta Services configures and runs **AI employees** for you. For each AI employee, you choose one of two options: a one-time **Setup**, or the monthly **AI Workforce Optimization Plan**.
@@ -70,3 +72,10 @@ One. Each Setup and each Optimization Plan covers a single AI employee. To add a
 
 All AI employees require Conversations AI to be active. The AI Reputation Specialist additionally requires Reputation AI Premium, and the AI Data Analyst requires at least one data source (CRM AI, Reputation AI, Social AI, or Local SEO). See each guide for details.
 </details>
+
+<div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '12px', background: 'rgba(60, 154, 99, 0.08)', border: '1px solid rgba(60, 154, 99, 0.35)', borderRadius: '8px', padding: '14px 18px', margin: '16px auto', width: 'fit-content', maxWidth: '100%', textAlign: 'center'}}>
+  <span style={{flexShrink: 0}}><GraduationCapIcon size={26} /></span>
+  <span style={{fontSize: '14px', color: 'var(--ifm-font-color-base)', textAlign: 'center'}}>
+    New to hiring and running an AI Employee? Take the <a href="/learn/ai-workforce" style={{color: '#3C9A63', fontWeight: 600}}>Hire your first AI Employee</a> course in Vendasta Learn — Beginner to Intermediate, 7 lessons.
+  </span>
+</div>

--- a/docusaurus/training/ai-workforce/autopilot.mdx
+++ b/docusaurus/training/ai-workforce/autopilot.mdx
@@ -91,6 +91,10 @@ The other two follow the same shape, one trigger and one or two steps: a new-lea
 
 An automation's activity log is where you go to confirm a run actually happened, not just to check for problems. A line reading "entity already exists" usually means the safety net worked exactly as intended, most often when an entry-setting choice like *Only once per account* correctly blocked a second run, not that anything failed. Read the log first; it usually already answers the question.
 
+:::info Go deeper
+[The Lists guide](/crm/lists) covers every filter type and list option, [Creating and configuring automations](/automations/my-automations/creating-and-configuring-automations) covers every trigger and step, and [Managing your automations](/automations/automation-history/managing-your-automations) walks through what each activity-log status means.
+:::
+
 ## Where autopilot grows into
 
 One smart list and one automation cover a single business well. A multi-location business eventually asks for more: branching a review request by zip code to the right satellite location, with a webhook per location and a safety-net fallback to the hub when nothing matches. Worth knowing the shape exists; this step is not where it gets built.

--- a/docusaurus/training/ai-workforce/sell-and-manage.mdx
+++ b/docusaurus/training/ai-workforce/sell-and-manage.mdx
@@ -61,6 +61,10 @@ Name one real prospect and decide, in one sentence, which employee and which cha
 
 Three building blocks combine into a client price: a Conversations AI tier, a one-time AI Employee Setup, and an ongoing AI Workforce Optimization Plan for ongoing management, which folds a full setup into its first month. Check current Marketplace pricing for each before you quote a number; treat this step as the structure to price with, not a fixed price list.
 
+:::info Go deeper
+[The AI Workforce services guide](/vendasta-services/ai-workforce) breaks down what Setup and the Optimization Plan each include, employee by employee, and [the Marketplace products guide](/marketplace/products) covers retail pricing in full.
+:::
+
 Two real end-to-end packages from the field show what a finished bundle looks like: a fuller voice-plus-lead-generation package running $1,500 to $2,000 a month at retail, and a lighter SMS-and-email-only automation package running $600 to $750 a month at retail. Elite Web Professionals ran this exact playbook for a client buried in missed calls: an AI Receptionist deployed, and within four months it had handled 1,017 calls and captured 778 qualified leads, a 76 percent conversion rate. Missed calls became a pipeline the business could work.
 
 Price the bundle, not the seat: a per-employee fee structure throttles a client who wants to add more employees later.


### PR DESCRIPTION
## Summary
- Link the two lessons with no outbound doc links (`autopilot`, `sell-and-manage`) to the docs they cover, using a "Go deeper" callout that groups related links together (matching the pattern from the AI foundations cross-linking work) rather than scattering individual inline links
- Add the "take the course" callout to six pillar docs pages the course is directly about: chat receptionist, voice receptionist, custom AI employees, knowledge base, tools overview, and the AI Workforce services guide
- Add a contextual "Go deeper" callout to three more general docs pages (CRM Lists, creating automations, managing automations) pointing at the specific `autopilot` lesson that shows them used end to end

Deliberately not exhaustive — several docs linked from the course (plan comparison table, SMS registration, lead capture notifications, calendar/booking links, Marketplace pricing) don't get a reciprocal callout since they're too niche to warrant one.

## Test plan
- [x] `npm run build` passes with no new broken links or anchors
- [x] Verified locally in dev server that all new callouts and links render and resolve correctly