### PR TITLE
LEARN: accuracy fixes across Vendasta Services training articles

### DIFF
--- a/docusaurus/training/vendasta-services/choose-how-the-work-gets-done.mdx
+++ b/docusaurus/training/vendasta-services/choose-how-the-work-gets-done.mdx
@@ -46,7 +46,7 @@ A setup engagement is not a subscription. The team does the hard configuration o
 A large share of this work is available to you directly, with no service order at all. Before you hand a function over, check whether a product you already resell covers it.
 
 - **An AI Receptionist you configure yourself** answers web chat, captures leads, and books meetings. Conversations AI is the activation; the configuration is yours to do.
-- **Reputation AI** drafts and sends review responses, and **Social AI** schedules posts across connected networks.
+- **Reputation AI** drafts and sends review responses, and **Social AI** drafts, schedules, and publishes posts across connected networks.
 - **Automations** carry work between products on their own: a new lead creates a task, a completed form triggers a follow-up, a won opportunity starts onboarding.
 - **Local SEO** keeps listings synced without a person editing them one directory at a time.
 - **Vibe** builds the small custom things a client asks for, in plain English, without a development engagement.
@@ -104,15 +104,15 @@ All three models run side by side. A single client can have an AI Receptionist y
   questions={[
     {
       type: 'mcq',
-      question: 'A client needs twelve social posts a month, indefinitely. Which delivery model fits best?',
+      question: 'A client needs twelve social posts a month, indefinitely. You have never designed a graphic or written social copy yourself. Which delivery model fits best?',
       options: [
-        'Do it for you, because the value is in monthly output',
+        'Do it for you, because the craft is not on your team',
         'Do it with you, because the calendar is built once',
-        'Do it yourself, because Social AI schedules posts',
+        'Do it yourself, because Social AI drafts and schedules for free',
         'Do it with you, then switch to do it yourself after launch'
       ],
       correctIndex: 0,
-      explanation: 'Recurring craft work that produces fresh output every month is what a managed service is for. Social AI schedules posts, but someone still has to create twelve of them each month.'
+      explanation: 'Social AI can draft and publish content on its own, but getting good output still takes someone shaping prompts, tone, and revisions. Where that craft is not on your team, Social Media Management supplies a human strategist, custom images, and Facebook boosting instead.'
     },
     {
       type: 'mcq',

--- a/docusaurus/training/vendasta-services/implement-your-ai-workforce.mdx
+++ b/docusaurus/training/vendasta-services/implement-your-ai-workforce.mdx
@@ -132,7 +132,7 @@ Two boundaries are worth knowing before you sell it. The plan covers AI employee
     },
     {
       type: 'mcq',
-      question: 'What does the team need from you before they can install the chat widget and lead form?',
+      question: 'What does the Vendasta Services team need from you before they can install the chat widget and lead form?',
       options: [
         'Access to the back end of the website',
         'A completed Snapshot Report for the account',
@@ -144,7 +144,7 @@ Two boundaries are worth knowing before you sell it. The plan covers AI employee
     },
     {
       type: 'mcq',
-      question: 'You configured an AI Receptionist yourself six months ago and now want the team to maintain it. What is the path?',
+      question: 'You configured an AI Receptionist yourself six months ago and now want the Vendasta Services team to maintain it. What is the path?',
       options: [
         'Add it to an existing Optimization Plan at no charge',
         'Bring it into coverage through a setup engagement',
@@ -152,7 +152,7 @@ Two boundaries are worth knowing before you sell it. The plan covers AI employee
         'Reconfigure it from scratch in the client Business App'
       ],
       correctIndex: 1,
-      explanation: 'Ongoing coverage applies to AI employees the team configured. A self-configured employee comes into scope through a setup engagement first.'
+      explanation: 'Ongoing coverage applies to AI employees the Vendasta Services team configured. A self-configured employee comes into scope through a setup engagement first.'
     },
     {
       type: 'mcq',

--- a/docusaurus/training/vendasta-services/order-and-launch-a-service.mdx
+++ b/docusaurus/training/vendasta-services/order-and-launch-a-service.mdx
@@ -35,7 +35,7 @@ import LessonFooter from "@site/src/components/LessonFooter";
 
 *You are here: Partner Center. Everything in this section happens in your workspace.*
 
-Vendasta Services products do not always carry "Vendasta Services" in the title, so searching by name misses some of them. Filter by vendor instead.
+Vendasta Services products do not carry "Vendasta Services" in the title, so searching by name misses some of them. Filter by vendor instead.
 
 Go to **Marketplace** → **Discover Products**, select **Add filter**, choose **Vendor** → **Vendasta Services**, then **Apply**. The full catalog comes back in one list. You can also recognize these products on sight by their grey circular logo with a colored ring.
 
@@ -106,7 +106,7 @@ You control whether they see it. The Projects tab can be turned off in **Partner
         'Ask Support on Demand for the product list'
       ],
       correctIndex: 1,
-      explanation: 'These products do not always carry Vendasta Services in the title. The Vendor filter on Discover Products returns all of them at once.'
+      explanation: 'These products do not carry Vendasta Services in the title. The Vendor filter on Discover Products returns all of them at once.'
     },
     {
       type: 'mcq',

--- a/docusaurus/training/vendasta-services/order-and-launch-a-service.mdx
+++ b/docusaurus/training/vendasta-services/order-and-launch-a-service.mdx
@@ -37,7 +37,7 @@ import LessonFooter from "@site/src/components/LessonFooter";
 
 Vendasta Services products do not carry "Vendasta Services" in the title, so searching by name misses some of them. Filter by vendor instead.
 
-Go to **Marketplace** → **Discover Products**, select **Add filter**, choose **Vendor** → **Vendasta Services**, then **Apply**. The full catalog comes back in one list. You can also recognize these products on sight by their grey circular logo with a colored ring.
+Go to **Marketplace** → **Discover Products**, select **Add filter**, choose **Vendor** → **Vendasta Services**, then **Apply**. The full catalog comes back in one list.
 
 :::tip Try it now
 Run that vendor filter and scan the results against the six service lines. Seeing the actual catalog is the fastest way to learn what is available to sell.

--- a/docusaurus/training/vendasta-services/what-vendasta-services-does.mdx
+++ b/docusaurus/training/vendasta-services/what-vendasta-services-does.mdx
@@ -44,7 +44,7 @@ Six service lines cover what we deliver today:
 | **AI Workforce** | Configures and launches an AI employee, then keeps it tuned: eight roles, from AI Receptionist to AI Blogger |
 | **Websites** | Express, Templated, and Accelerated Templated builds, plus hosting, imports, and Website Support+ |
 | **Social Media Management** | Standard and Plus tiers: monthly posts and stories, custom images, Facebook post boosting, and SEO blogs |
-| **Digital Advertising** | Express Ads and Managed Ads Campaign on MatchCraft, with creatives, tracking, and reporting |
+| **Digital Advertising** | Express Ads and Managed Ads Campaign on Vendasta Ads, with creatives, tracking, and reporting |
 | **Listings, claims, and optimization** | Listing Claim, Google Business Profile Optimization, and Local Listings Management across Google, Apple, and Bing |
 | **Blog Posts** | Long-form SEO blogs, one time or monthly, published to WordPress Hosting or Accelerated Templated sites |
 

--- a/docusaurus/training/vendasta-services/what-vendasta-services-does.mdx
+++ b/docusaurus/training/vendasta-services/what-vendasta-services-does.mdx
@@ -86,7 +86,7 @@ There is one exception worth preparing your client for. Several services need ac
       type: 'mcq',
       question: 'You would rather the fulfillment team never contacts your client directly on a social posting order. How do you arrange that?',
       options: [
-        'Ask Support on Demand to restrict the account',
+        'Ask Vendasta Services to restrict the account',
         'Put your own contact information on the order and fulfillment forms',
         'Order the service without completing the fulfillment form',
         'Turn off the Projects tab in Business App'
@@ -101,7 +101,7 @@ There is one exception worth preparing your client for. Several services need ac
         'To decline it and wait for a branded request instead',
         'That it is a phishing attempt they can ignore safely',
         'To expect and approve it, because that name cannot be white labeled',
-        'To forward it to Support on Demand for verification'
+        'To forward it to Vendasta Services for verification'
       ],
       correctIndex: 2,
       explanation: 'Access granted under the Digital Agency name is required for listing claims, Facebook access, and registrar delegation. The name cannot be changed, so preparing the client in advance is the move.'


### PR DESCRIPTION
## Summary
A handful of small accuracy fixes to LEARN articles under the Work with Vendasta Services path, found while reviewing knowledge check content:

- **what-vendasta-services-does**: renamed MatchCraft to Vendasta Ads in the service line table, and Support on Demand to Vendasta Services in two knowledge check distractors (both stale product/team names).
- **choose-how-the-work-gets-done**: fixed a stale claim that Social AI only schedules posts — the Social Media Manager AI employee actually drafts and publishes content on its own. Reworked the related knowledge check question so it no longer hinges on that outdated capability gap, framing the "do it for you" answer around in-house craft instead of recurring output.
- **implement-your-ai-workforce**: clarified "the team" to "the Vendasta Services team" in two knowledge check questions for consistency with the rest of the path.
- **order-and-launch-a-service**: removed "always" from the claim that Vendasta Services products don't carry "Vendasta Services" in the title (none of them do, not just some), and removed the "grey circular logo with a colored ring" visual cue, since logos are no longer consistent across these products.

## Test plan
- [ ] Visual/content review, since these are learning path edits
- [ ] Confirm Social AI capability framing in choose-how-the-work-gets-done matches current product behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)